### PR TITLE
cmd: apply sub-command design to gocritic

### DIFF
--- a/cmd/criticize/main.go
+++ b/cmd/criticize/main.go
@@ -1,0 +1,185 @@
+package criticize
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/types"
+	"log"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/go-critic/go-critic/lint"
+	"golang.org/x/tools/go/loader"
+)
+
+type linter struct {
+	ctx *lint.Context
+
+	prog *loader.Program
+
+	checkers []*lint.Checker
+
+	// Command line flags:
+
+	packages        []string
+	enabledCheckers []string
+}
+
+// Main implements gocritic sub-command entry point.
+func Main() {
+	var l linter
+	parseArgv(&l)
+	l.LoadProgram()
+	l.InitCheckers()
+
+	for _, pkgPath := range l.packages {
+		l.CheckPackage(pkgPath)
+	}
+}
+
+func blame(format string, args ...interface{}) {
+	log.Printf(format, args...)
+	flag.Usage()
+	os.Exit(1)
+}
+
+// parseArgv processes command-line arguments and fills ctx argument with them.
+// Terminates program on error.
+func parseArgv(l *linter) {
+	flag.Usage = func() {
+		fmt.Fprintln(os.Stderr, "usage: gocritic [flags] [package]")
+		flag.PrintDefaults()
+	}
+
+	enable := flag.String("enable", "all", "comma-separated list of enabled checkers")
+
+	flag.Parse()
+
+	l.packages = flag.Args()
+	if len(l.packages) == 0 {
+		blame("no packages specified\n")
+	}
+
+	switch *enable {
+	case "all":
+		// Special case. l.enabledCheckers remains nil.
+	case "":
+		// Empty slice. Semantically "disable-all".
+		// Can be used to run all pipelines without actual checkers.
+		l.enabledCheckers = []string{}
+	default:
+		// Comma-separated list of names.
+		l.enabledCheckers = strings.Split(*enable, ",")
+	}
+}
+
+func (l *linter) LoadProgram() {
+	sizes := types.SizesFor("gc", runtime.GOARCH)
+	if sizes == nil {
+		log.Fatalf("can't find sizes info for %s", runtime.GOARCH)
+	}
+
+	conf := loader.Config{
+		ParserMode: parser.ParseComments,
+		TypeChecker: types.Config{
+			Sizes: sizes,
+		},
+	}
+
+	if _, err := conf.FromArgs(l.packages, true); err != nil {
+		log.Fatalf("resolve packages: %v", err)
+	}
+	prog, err := conf.Load()
+	if err != nil {
+		log.Fatalf("load program: %v", err)
+	}
+
+	l.prog = prog
+
+	l.ctx = &lint.Context{
+		FileSet:   prog.Fset,
+		SizesInfo: sizes,
+	}
+}
+
+func (l *linter) InitCheckers() {
+	requested := make(map[string]bool)
+	available := lint.RuleList()
+
+	if l.enabledCheckers == nil {
+		for _, rule := range available {
+			// Exclude experimental checkers from default list.
+			if !rule.Experimental() {
+				requested[rule.Name()] = true
+			}
+		}
+	} else {
+		for _, name := range l.enabledCheckers {
+			requested[name] = true
+		}
+	}
+
+	for _, rule := range available {
+		if !requested[rule.Name()] {
+			continue
+		}
+		l.checkers = append(l.checkers, lint.NewChecker(rule, l.ctx))
+		delete(requested, rule.Name())
+	}
+
+	if len(requested) != 0 {
+		for name := range requested {
+			log.Printf("%s: checker not found", name)
+		}
+		log.Fatalf("exiting due to initialization failure")
+	}
+}
+
+func (l *linter) CheckPackage(pkgPath string) {
+	pkgInfo := l.prog.Imported[pkgPath]
+	if pkgInfo == nil || !pkgInfo.TransitivelyErrorFree {
+		log.Fatalf("%s package is not properly loaded", pkgPath)
+	}
+
+	l.ctx.TypesInfo = &pkgInfo.Info
+	for _, f := range pkgInfo.Files {
+		l.checkFile(f)
+	}
+}
+
+func (l *linter) checkFile(f *ast.File) {
+	var wg sync.WaitGroup
+	wg.Add(len(l.checkers))
+	for _, c := range l.checkers {
+		// All checkers are expected to use *lint.Context
+		// as read-only structure, so no copying is required.
+		go func(c *lint.Checker) {
+			defer func() {
+				wg.Done()
+				// Checker signals unexpected error with panic(error).
+				r := recover()
+				if r == nil {
+					return // There were no panic
+				}
+				if err, ok := r.(error); ok {
+					log.Printf("%s: error: %v\n", c.Rule, err)
+					panic(err)
+				} else {
+					// Some other kind of run-time panic.
+					// Undo the recover and resume panic.
+					panic(r)
+				}
+			}()
+
+			for _, warn := range c.Check(f) {
+				pos := l.ctx.FileSet.Position(warn.Node.Pos())
+				log.Printf("%s: %s: %v\n", pos, c.Rule, warn.Text)
+			}
+		}(c)
+	}
+	wg.Wait()
+}

--- a/cmd/gocritic/check-package_test.go
+++ b/cmd/gocritic/check-package_test.go
@@ -52,7 +52,8 @@ func init() {
 }
 
 func runChecker(name, pkgPath string) (output []byte, err error) {
-	return exec.Command("./"+binary, "-enable", name, pkgPath).CombinedOutput()
+	cmd := exec.Command("./"+binary, "check-package", "-enable", name, pkgPath)
+	return cmd.CombinedOutput()
 }
 
 func TestSanity(t *testing.T) {

--- a/cmd/gocritic/main.go
+++ b/cmd/gocritic/main.go
@@ -1,186 +1,93 @@
 package main
 
 import (
-	"flag"
 	"fmt"
-	"go/ast"
-	"go/parser"
-	"go/types"
 	"log"
 	"os"
-	"runtime"
-	"strings"
-	"sync"
 
-	"github.com/go-critic/go-critic/lint"
-	"golang.org/x/tools/go/loader"
+	"github.com/go-critic/go-critic/cmd/criticize"
+	"github.com/go-critic/go-critic/cmd/lintwalk"
 )
 
-type linter struct {
-	ctx *lint.Context
+// subCommand is an implementation of a gocritic sub-command.
+type subCommand struct {
+	// main is command entry point.
+	main func()
 
-	prog *loader.Program
+	// name is sub-command name used to execute it.
+	name string
 
-	checkers []*lint.Checker
+	// short describes command in one line of text.
+	short string
+}
 
-	// Command line flags:
-
-	packages        []string
-	enabledCheckers []string
+// subCommands describes all supported sub-commands as well
+// as their metadata required to run them and print useful help messages.
+var subCommands = []*subCommand{
+	{
+		main:  criticize.Main,
+		name:  "check-package",
+		short: "run gocritic over specified package list",
+	},
+	{
+		main:  lintwalk.Main,
+		name:  "check-project",
+		short: "run gocritic over specified source tree, recursively",
+	},
 }
 
 func main() {
 	log.SetFlags(0)
 
-	var l linter
-	parseArgv(&l)
-	l.LoadProgram()
-	l.InitCheckers()
-
-	for _, pkgPath := range l.packages {
-		l.CheckPackage(pkgPath)
+	argv := os.Args
+	if len(argv) < 2 {
+		terminate("not enough arguments, expected sub-command name", printUsage)
 	}
+
+	subIdx := 1 // [0] is program name
+	sub := os.Args[subIdx]
+	// Erase sub-command argument (index=1) to make it invisible for
+	// sub commands themselves.
+	os.Args = append(os.Args[:subIdx], os.Args[subIdx+1:]...)
+
+	// Choose and run sub-command main.
+	cmd := findSubCommand(sub)
+	if cmd == nil {
+		terminate("unknown sub-command: "+sub, printSupportedSubs)
+	}
+	cmd.main()
 }
 
-func blame(format string, args ...interface{}) {
-	log.Printf(format, args...)
-	flag.Usage()
+// findSubCommand looks up subCommand by it's name.
+// Returns nil if requested command not found.
+func findSubCommand(name string) *subCommand {
+	for _, cmd := range subCommands {
+		if cmd.name == name {
+			return cmd
+		}
+	}
+	return nil
+}
+
+// terminate prints error specified by reason, runs optional printHelp
+// function and then exists with non-zero status.
+func terminate(reason string, printHelp func()) {
+	fmt.Fprintf(os.Stderr, "error: %s\n", reason)
+	if printHelp != nil {
+		os.Stderr.WriteString("\n")
+		printHelp()
+	}
 	os.Exit(1)
 }
 
-// parseArgv processes command-line arguments and fills ctx argument with them.
-// Terminates program on error.
-func parseArgv(l *linter) {
-	flag.Usage = func() {
-		fmt.Fprintln(os.Stderr, "usage: gocritic [flags] [package]")
-		flag.PrintDefaults()
-	}
-
-	enable := flag.String("enable", "all", "comma-separated list of enabled checkers")
-
-	flag.Parse()
-
-	l.packages = flag.Args()
-	if len(l.packages) == 0 {
-		blame("no packages specified\n")
-	}
-
-	switch *enable {
-	case "all":
-		// Special case. l.enabledCheckers remains nil.
-	case "":
-		// Empty slice. Semantically "disable-all".
-		// Can be used to run all pipelines without actual checkers.
-		l.enabledCheckers = []string{}
-	default:
-		// Comma-separated list of names.
-		l.enabledCheckers = strings.Split(*enable, ",")
-	}
+func printUsage() {
+	// TODO: implement me. For now, print supported commands.
+	printSupportedSubs()
 }
 
-func (l *linter) LoadProgram() {
-	sizes := types.SizesFor("gc", runtime.GOARCH)
-	if sizes == nil {
-		log.Fatalf("can't find sizes info for %s", runtime.GOARCH)
+func printSupportedSubs() {
+	os.Stderr.WriteString("Supported sub-commands:\n")
+	for _, cmd := range subCommands {
+		fmt.Fprintf(os.Stderr, "\t%s - %s\n", cmd.name, cmd.short)
 	}
-
-	conf := loader.Config{
-		ParserMode: parser.ParseComments,
-		TypeChecker: types.Config{
-			Sizes: sizes,
-		},
-	}
-
-	if _, err := conf.FromArgs(l.packages, true); err != nil {
-		log.Fatalf("resolve packages: %v", err)
-	}
-	prog, err := conf.Load()
-	if err != nil {
-		log.Fatalf("load program: %v", err)
-	}
-
-	l.prog = prog
-
-	l.ctx = &lint.Context{
-		FileSet:   prog.Fset,
-		SizesInfo: sizes,
-	}
-}
-
-func (l *linter) InitCheckers() {
-	requested := make(map[string]bool)
-	available := lint.RuleList()
-
-	if l.enabledCheckers == nil {
-		for _, rule := range available {
-			// Exclude experimental checkers from default list.
-			if !rule.Experimental() {
-				requested[rule.Name()] = true
-			}
-		}
-	} else {
-		for _, name := range l.enabledCheckers {
-			requested[name] = true
-		}
-	}
-
-	for _, rule := range available {
-		if !requested[rule.Name()] {
-			continue
-		}
-		l.checkers = append(l.checkers, lint.NewChecker(rule, l.ctx))
-		delete(requested, rule.Name())
-	}
-
-	if len(requested) != 0 {
-		for name := range requested {
-			log.Printf("%s: checker not found", name)
-		}
-		log.Fatalf("exiting due to initialization failure")
-	}
-}
-
-func (l *linter) CheckPackage(pkgPath string) {
-	pkgInfo := l.prog.Imported[pkgPath]
-	if pkgInfo == nil || !pkgInfo.TransitivelyErrorFree {
-		log.Fatalf("%s package is not properly loaded", pkgPath)
-	}
-
-	l.ctx.TypesInfo = &pkgInfo.Info
-	for _, f := range pkgInfo.Files {
-		l.checkFile(f)
-	}
-}
-
-func (l *linter) checkFile(f *ast.File) {
-	var wg sync.WaitGroup
-	wg.Add(len(l.checkers))
-	for _, c := range l.checkers {
-		// All checkers are expected to use *lint.Context
-		// as read-only structure, so no copying is required.
-		go func(c *lint.Checker) {
-			defer func() {
-				wg.Done()
-				// Checker signals unexpected error with panic(error).
-				r := recover()
-				if r == nil {
-					return // There were no panic
-				}
-				if err, ok := r.(error); ok {
-					log.Printf("%s: error: %v\n", c.Rule, err)
-					panic(err)
-				} else {
-					// Some other kind of run-time panic.
-					// Undo the recover and resume panic.
-					panic(r)
-				}
-			}()
-
-			for _, warn := range c.Check(f) {
-				pos := l.ctx.FileSet.Position(warn.Node.Pos())
-				log.Printf("%s: %s: %v\n", pos, c.Rule, warn.Text)
-			}
-		}(c)
-	}
-	wg.Wait()
 }

--- a/cmd/gocritic/main.go
+++ b/cmd/gocritic/main.go
@@ -72,9 +72,9 @@ func findSubCommand(name string) *subCommand {
 // terminate prints error specified by reason, runs optional printHelp
 // function and then exists with non-zero status.
 func terminate(reason string, printHelp func()) {
-	fmt.Fprintf(os.Stderr, "error: %s\n", reason)
+	stderrPrintf("error: %s\n", reason)
 	if printHelp != nil {
-		os.Stderr.WriteString("\n")
+		stderrPrintf("\n")
 		printHelp()
 	}
 	os.Exit(1)
@@ -86,8 +86,17 @@ func printUsage() {
 }
 
 func printSupportedSubs() {
-	os.Stderr.WriteString("Supported sub-commands:\n")
+	stderrPrintf("Supported sub-commands:\n")
 	for _, cmd := range subCommands {
-		fmt.Fprintf(os.Stderr, "\t%s - %s\n", cmd.name, cmd.short)
+		stderrPrintf("\t%s - %s\n", cmd.name, cmd.short)
+	}
+}
+
+// stderrPrintf writes formatted message to stderr and checks for error
+// making "not annoying at all" linters happy.
+func stderrPrintf(format string, args ...interface{}) {
+	_, err := fmt.Fprintf(os.Stderr, format, args...)
+	if err != nil {
+		panic(fmt.Sprintf("stderr write error: %v", err))
 	}
 }

--- a/cmd/lintwalk/main.go
+++ b/cmd/lintwalk/main.go
@@ -1,4 +1,4 @@
-package main
+package lintwalk
 
 import (
 	"flag"
@@ -9,7 +9,8 @@ import (
 	"regexp"
 )
 
-func main() {
+// Main implements gocritic sub-command entry point.
+func Main() {
 	srcRoot := flag.String("src-root", "",
 		`path to directory that should be linted recursively`)
 	enable := flag.String("enable", "all",


### PR DESCRIPTION
gocritic is user API for the linter.
It has several sub-commands that should be stable,
but implementation can change in any way we want.

Currently there are only 2 sub commands:
- check-package (previously gocritic)
- check-project (previously lintwalk)

Example:
```
# New command:
	gocritic check-package a b
# Old command:
	gorcitic a b
```