### PR TITLE
cmd/lintwalk: fix exec error

### DIFF
--- a/cmd/lintwalk/main.go
+++ b/cmd/lintwalk/main.go
@@ -11,21 +11,21 @@ import (
 
 // Main implements gocritic sub-command entry point.
 func Main() {
-	srcRoot := flag.String("src-root", "",
-		`path to directory that should be linted recursively`)
 	enable := flag.String("enable", "all",
 		`forwarded to linter "as is"`)
-	linter := flag.String("linter", "kfulint",
-		`linter command name used for it's execution`)
 	exclude := flag.String("exclude", "testdata/|vendor/|builtin/",
 		`regexp used to skip package names`)
 
 	flag.Parse()
 
-	if *srcRoot == "" {
+	if flag.NArg() != 1 {
+		log.Fatalf("expected exactly one project root argument")
+	}
+	srcRoot := flag.Arg(0)
+	if srcRoot == "" {
 		log.Fatal("empty -src-root")
 	}
-	*srcRoot = filepath.Clean(*srcRoot)
+	srcRoot = filepath.Clean(srcRoot)
 
 	excludeRE, err := regexp.Compile(*exclude)
 	if err != nil {
@@ -33,11 +33,15 @@ func Main() {
 	}
 
 	packages := make(map[string]bool)
-	err = filepath.Walk(*srcRoot, func(path string, info os.FileInfo, err error) error {
+	err = filepath.Walk(srcRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			log.Printf("walk error: %v", err)
+			return nil
+		}
 		if info.IsDir() {
 			return nil
 		}
-		path = path[len(*srcRoot)+len("/"):]
+		path = path[len(srcRoot)+len("/"):]
 		if filepath.Ext(path) != ".go" {
 			return nil
 		}
@@ -52,12 +56,12 @@ func Main() {
 	}
 
 	var args []string
-	args = append(args, "-enable", *enable)
+	args = append(args, "check-package", "-enable", *enable)
 	for pkg := range packages {
 		args = append(args, pkg)
 	}
 	/* #nosec */
-	cmd := exec.Command(*linter, args...)
+	cmd := exec.Command("gocritic", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
Also changed usage from:
	lintwalk -src-root=XYZ/src
to:
	lintwalk XYZ/src

Since we only expect one project root, this is more convenient.

README already describes new usage.

Fixes #187