### PR TITLE
lint: add global expr checker base

### DIFF
--- a/cmd/gocritic/testdata/flagDeref/positive_tests.go
+++ b/cmd/gocritic/testdata/flagDeref/positive_tests.go
@@ -2,6 +2,14 @@ package checker_test
 
 import "flag"
 
+var (
+	/// immediate deref in *flag.Bool("global1", false, "") is most likely an error; consider using flag.BoolVar
+	_ = *flag.Bool("global1", false, "")
+
+	/// immediate deref in *flag.Float64("global2", 0, "") is most likely an error; consider using flag.Float64Var
+	_ = *flag.Float64("global2", 0, "")
+)
+
 func shouldWarn() {
 	/// immediate deref in *flag.Bool("b", false, "") is most likely an error; consider using flag.BoolVar
 	_ = *flag.Bool("b", false, "")

--- a/cmd/gocritic/testdata/underef/positive_tests.go
+++ b/cmd/gocritic/testdata/underef/positive_tests.go
@@ -11,6 +11,19 @@ type sampleInterface interface {
 	method()
 }
 
+var (
+	globalStruct = &sampleStruct{}
+	globalArray  = &[5]int{}
+)
+
+var (
+	/// could simplify (*globalStruct).field to globalStruct.field
+	_ = (*globalStruct).field
+
+	/// could simplify (*globalArray)[0] to globalArray[0]
+	_ = (*globalArray)[0]
+)
+
 func sampleCase() {
 	var k *sampleStruct
 	/// could simplify (*k).field to k.field

--- a/lint/flagDeref_checker.go
+++ b/lint/flagDeref_checker.go
@@ -9,15 +9,14 @@ func init() {
 }
 
 type flagDerefChecker struct {
-	// TODO(quasilyte): should be global expr checker. Refs #124.
-	baseLocalExprChecker
+	baseExprChecker
 
 	flagPtrFuncs map[string]bool
 }
 
 func (c flagDerefChecker) New(ctx *context) func(*ast.File) {
-	return wrapLocalExprChecker(&flagDerefChecker{
-		baseLocalExprChecker: baseLocalExprChecker{ctx: ctx},
+	return wrapExprChecker(&flagDerefChecker{
+		baseExprChecker: baseExprChecker{ctx: ctx},
 
 		flagPtrFuncs: map[string]bool{
 			"flag.Bool":     true,
@@ -32,7 +31,7 @@ func (c flagDerefChecker) New(ctx *context) func(*ast.File) {
 	})
 }
 
-func (c *flagDerefChecker) CheckLocalExpr(expr ast.Expr) {
+func (c *flagDerefChecker) CheckExpr(expr ast.Expr) {
 	if expr, ok := expr.(*ast.StarExpr); ok {
 		call, ok := expr.X.(*ast.CallExpr)
 		if !ok {

--- a/lint/stddef_checker.go
+++ b/lint/stddef_checker.go
@@ -43,8 +43,7 @@ type mathConstant struct {
 }
 
 type stddefChecker struct {
-	// TODO(quasilyte): should be global expr checker. Refs #124.
-	baseLocalExprChecker
+	baseExprChecker
 
 	mathConsts []mathConstant
 
@@ -62,8 +61,8 @@ func (c stddefChecker) New(ctx *context) func(*ast.File) {
 		return x
 	}
 
-	return wrapLocalExprChecker(&stddefChecker{
-		baseLocalExprChecker: baseLocalExprChecker{ctx: ctx},
+	return wrapExprChecker(&stddefChecker{
+		baseExprChecker: baseExprChecker{ctx: ctx},
 
 		suggestionToExpression: map[string]ast.Expr{
 			"math.MaxInt8":   expr(`1<<7 - 1`),
@@ -125,7 +124,7 @@ func (c stddefChecker) New(ctx *context) func(*ast.File) {
 	})
 }
 
-func (c *stddefChecker) CheckLocalExpr(expr ast.Expr) {
+func (c *stddefChecker) CheckExpr(expr ast.Expr) {
 	val := c.ctx.TypesInfo.Types[expr].Value
 	if val == nil {
 		// Not a compile-time constant.

--- a/lint/underef_checker.go
+++ b/lint/underef_checker.go
@@ -10,17 +10,16 @@ func init() {
 }
 
 type underefChecker struct {
-	baseLocalExprChecker
+	baseExprChecker
 }
 
 func (c underefChecker) New(ctx *context) func(*ast.File) {
-	// TODO: should be global expr checker, but we don't have such right now.
-	return wrapLocalExprChecker(&underefChecker{
-		baseLocalExprChecker: baseLocalExprChecker{ctx: ctx},
+	return wrapExprChecker(&underefChecker{
+		baseExprChecker: baseExprChecker{ctx: ctx},
 	})
 }
 
-func (c *underefChecker) CheckLocalExpr(expr ast.Expr) {
+func (c *underefChecker) CheckExpr(expr ast.Expr) {
 	switch n := expr.(type) {
 	case *ast.SelectorExpr:
 		expr, ok := n.X.(*ast.ParenExpr)

--- a/lint/wrappers.go
+++ b/lint/wrappers.go
@@ -65,6 +65,26 @@ func wrapFuncDeclChecker(c funcDeclChecker) func(*ast.File) {
 	}
 }
 
+type exprChecker interface {
+	CheckExpr(ast.Expr)
+}
+
+type baseExprChecker struct {
+	ctx *context
+}
+
+// wrapExprChecker returns a check function that visits every expression.
+func wrapExprChecker(c exprChecker) func(*ast.File) {
+	return func(f *ast.File) {
+		ast.Inspect(f, func(x ast.Node) bool {
+			if expr, ok := x.(ast.Expr); ok {
+				c.CheckExpr(expr)
+			}
+			return true
+		})
+	}
+}
+
 type localExprChecker interface {
 	PerFuncInit(*ast.FuncDecl) bool
 	CheckLocalExpr(ast.Expr)


### PR DESCRIPTION
Also added tests for updated checkers to make sure
they do check global expressions now.

Fixes #124