### PR TITLE
lint: teach stddef to avoid pkgs that define suggested consts

### DIFF
--- a/cmd/criticize/main.go
+++ b/cmd/criticize/main.go
@@ -146,6 +146,7 @@ func (l *linter) CheckPackage(pkgPath string) {
 	}
 
 	l.ctx.TypesInfo = &pkgInfo.Info
+	l.ctx.Package = pkgInfo.Pkg
 	for _, f := range pkgInfo.Files {
 		l.checkFile(f)
 	}

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -108,6 +108,9 @@ type Context struct {
 	// TypesInfo carries parsed packages types information.
 	TypesInfo *types.Info
 
+	// Package describes package that is being checked.
+	Package *types.Package
+
 	// SizesInfo carries alignment and type size information.
 	// Arch-dependent.
 	SizesInfo types.Sizes


### PR DESCRIPTION
Fixes #181