### PR TITLE
cmd/criticize: update usage string

### DIFF
--- a/cmd/criticize/main.go
+++ b/cmd/criticize/main.go
@@ -2,7 +2,6 @@ package criticize
 
 import (
 	"flag"
-	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/types"
@@ -51,7 +50,7 @@ func blame(format string, args ...interface{}) {
 // Terminates program on error.
 func parseArgv(l *linter) {
 	flag.Usage = func() {
-		fmt.Fprintln(os.Stderr, "usage: gocritic [flags] [package]")
+		log.Printf("usage: [flags] package...")
 		flag.PrintDefaults()
 	}
 

--- a/cmd/gocritic/main.go
+++ b/cmd/gocritic/main.go
@@ -55,6 +55,7 @@ func main() {
 	if cmd == nil {
 		terminate("unknown sub-command: "+sub, printSupportedSubs)
 	}
+	log.SetPrefix(sub + ": ")
 	cmd.main()
 }
 


### PR DESCRIPTION
Now printed like:
	check-package: usage: [flags] package...

The "check-package" comes from gocritic log.SetPrefix.
This way, criticize binary does not need any knowledge
about sub-command names.

Fixes #191