### PR TITLE
lint/switchif: handle switch statements with multiple "case" values properly

### DIFF
--- a/cmd/gocritic/testdata/switchif/negative_tests.go
+++ b/cmd/gocritic/testdata/switchif/negative_tests.go
@@ -23,3 +23,9 @@ func switchWithTwoCases(x int) {
 	case 2:
 	}
 }
+
+func caseWithTwoValues(x int) {
+	switch x {
+	case 1, 2:
+	}
+}

--- a/lint/switchif_checker.go
+++ b/lint/switchif_checker.go
@@ -32,7 +32,7 @@ func (c *switchifChecker) checkSwitchStmt(stmt ast.Stmt, body *ast.BlockStmt) {
 		if body.List[0].(*ast.CaseClause).List == nil {
 			// default case.
 			c.warnDefault(stmt)
-		} else {
+		} else if len(body.List[0].(*ast.CaseClause).List) == 1 {
 			c.warn(stmt)
 		}
 	}


### PR DESCRIPTION
#180 