### PR TITLE
lint: use astp from go-toolsmith

### DIFF
--- a/lint/parenthesis_checker.go
+++ b/lint/parenthesis_checker.go
@@ -3,8 +3,8 @@ package lint
 import (
 	"go/ast"
 
-	"github.com/cristaloleg/astp"
 	"github.com/go-toolsmith/astcopy"
+	"github.com/go-toolsmith/astp"
 	"golang.org/x/tools/go/ast/astutil"
 )
 

--- a/lint/typeGuard_checker.go
+++ b/lint/typeGuard_checker.go
@@ -3,8 +3,8 @@ package lint
 import (
 	"go/ast"
 
-	"github.com/cristaloleg/astp"
 	"github.com/go-toolsmith/astequal"
+	"github.com/go-toolsmith/astp"
 )
 
 func init() {


### PR DESCRIPTION
I think this is how it supposed to be, right?
@cristaloleg 