### PR TITLE
lint: re-design attribute passing to addChecker function

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -468,7 +468,7 @@ func baz() {
 }
 ```
 
-
+`unexportedCall` is very opinionated.
 <a name="unnamedResult-ref"></a>
 ## unnamedResult
 For functions with multiple return values, detects unnamed results

--- a/lint/appendCombine_checker.go
+++ b/lint/appendCombine_checker.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	addChecker(appendCombineChecker{}, &ruleInfo{})
+	addChecker(appendCombineChecker{})
 }
 
 type appendCombineChecker struct {

--- a/lint/attributes.go
+++ b/lint/attributes.go
@@ -5,9 +5,8 @@ package lint
 
 type checkerAttribute int
 
-// All valid attributes.
-var (
-	attrExperimental    = new(checkerAttribute)
-	attrSyntaxOnly      = new(checkerAttribute)
-	attrVeryOpinionated = new(checkerAttribute)
+const (
+	attrExperimental checkerAttribute = iota
+	attrSyntaxOnly
+	attrVeryOpinionated
 )

--- a/lint/attributes.go
+++ b/lint/attributes.go
@@ -1,0 +1,13 @@
+package lint
+
+// TODO(quasilyte): move attribute-related things here
+// when this refactoring is complete.
+
+type checkerAttribute int
+
+// All valid attributes.
+var (
+	attrExperimental    = new(checkerAttribute)
+	attrSyntaxOnly      = new(checkerAttribute)
+	attrVeryOpinionated = new(checkerAttribute)
+)

--- a/lint/builtinShadow_checker.go
+++ b/lint/builtinShadow_checker.go
@@ -5,9 +5,7 @@ import (
 )
 
 func init() {
-	addChecker(builtinShadowChecker{}, &ruleInfo{
-		SyntaxOnly: true,
-	})
+	addChecker(builtinShadowChecker{}, attrSyntaxOnly)
 }
 
 type builtinShadowChecker struct {

--- a/lint/captLocal_checker.go
+++ b/lint/captLocal_checker.go
@@ -6,9 +6,7 @@ import (
 )
 
 func init() {
-	addChecker(captLocalChecker{}, &ruleInfo{
-		SyntaxOnly: true,
-	})
+	addChecker(captLocalChecker{}, attrSyntaxOnly)
 }
 
 type captLocalChecker struct {

--- a/lint/docStub_checker.go
+++ b/lint/docStub_checker.go
@@ -6,9 +6,7 @@ import (
 )
 
 func init() {
-	addChecker(docStubChecker{}, &ruleInfo{
-		SyntaxOnly: true,
-	})
+	addChecker(docStubChecker{}, attrSyntaxOnly)
 }
 
 type docStubChecker struct {

--- a/lint/elseif_checker.go
+++ b/lint/elseif_checker.go
@@ -5,9 +5,7 @@ import (
 )
 
 func init() {
-	addChecker(elseifChecker{}, &ruleInfo{
-		SyntaxOnly: true,
-	})
+	addChecker(elseifChecker{}, attrSyntaxOnly)
 }
 
 type elseifChecker struct {

--- a/lint/flagDeref_checker.go
+++ b/lint/flagDeref_checker.go
@@ -5,9 +5,7 @@ import (
 )
 
 func init() {
-	addChecker(flagDerefChecker{}, &ruleInfo{
-		SyntaxOnly: true,
-	})
+	addChecker(flagDerefChecker{}, attrSyntaxOnly)
 }
 
 type flagDerefChecker struct {

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -180,7 +180,7 @@ func (ctx *context) Warn(node ast.Node, format string, args ...interface{}) {
 	})
 }
 
-func addChecker(c checkFunction, attrs ...*checkerAttribute) {
+func addChecker(c checkFunction, attrs ...checkerAttribute) {
 	var info ruleInfo
 	for _, attr := range attrs {
 		switch attr {

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -1,6 +1,7 @@
 package lint
 
 import (
+	"fmt"
 	"go/ast"
 	"go/token"
 	"go/types"
@@ -179,9 +180,22 @@ func (ctx *context) Warn(node ast.Node, format string, args ...interface{}) {
 	})
 }
 
-func addChecker(c checkFunction, inf *ruleInfo) {
+func addChecker(c checkFunction, attrs ...*checkerAttribute) {
+	var info ruleInfo
+	for _, attr := range attrs {
+		switch attr {
+		case attrExperimental:
+			info.Experimental = true
+		case attrSyntaxOnly:
+			info.SyntaxOnly = true
+		case attrVeryOpinionated:
+			info.VeryOpinionated = true
+		default:
+			panic(fmt.Sprintf("unexpected checkerAttribute"))
+		}
+	}
 	typeName := reflect.ValueOf(c).Type().Name()
 	ruleName := typeName[:len(typeName)-len("Checker")]
-	inf.New = c.New
-	checkFunctions[ruleName] = inf
+	info.New = c.New
+	checkFunctions[ruleName] = &info
 }

--- a/lint/longChain_checker.go
+++ b/lint/longChain_checker.go
@@ -9,9 +9,7 @@ import (
 )
 
 func init() {
-	addChecker(longChainChecker{}, &ruleInfo{
-		Experimental: true,
-	})
+	addChecker(longChainChecker{}, attrExperimental)
 }
 
 type longChainChecker struct {

--- a/lint/paramTypeCombine_checker.go
+++ b/lint/paramTypeCombine_checker.go
@@ -7,9 +7,7 @@ import (
 )
 
 func init() {
-	addChecker(paramTypeCombineChecker{}, &ruleInfo{
-		SyntaxOnly: true,
-	})
+	addChecker(paramTypeCombineChecker{}, attrSyntaxOnly)
 }
 
 type paramTypeCombineChecker struct {

--- a/lint/ptrToRefParam_checker.go
+++ b/lint/ptrToRefParam_checker.go
@@ -6,7 +6,7 @@ import (
 )
 
 func init() {
-	addChecker(ptrToRefParamChecker{}, &ruleInfo{})
+	addChecker(ptrToRefParamChecker{})
 }
 
 type ptrToRefParamChecker struct {

--- a/lint/rangeExprCopy_checker.go
+++ b/lint/rangeExprCopy_checker.go
@@ -6,7 +6,7 @@ import (
 )
 
 func init() {
-	addChecker(rangeExprCopyChecker{}, &ruleInfo{})
+	addChecker(rangeExprCopyChecker{})
 }
 
 type rangeExprCopyChecker struct {

--- a/lint/rangeValCopy_checker.go
+++ b/lint/rangeValCopy_checker.go
@@ -5,7 +5,7 @@ import (
 )
 
 func init() {
-	addChecker(rangeValCopyChecker{}, &ruleInfo{})
+	addChecker(rangeValCopyChecker{})
 }
 
 type rangeValCopyChecker struct {

--- a/lint/singleCaseSwitch_checker.go
+++ b/lint/singleCaseSwitch_checker.go
@@ -5,9 +5,7 @@ import (
 )
 
 func init() {
-	addChecker(singleCaseSwitchChecker{}, &ruleInfo{
-		SyntaxOnly: true,
-	})
+	addChecker(singleCaseSwitchChecker{}, attrSyntaxOnly)
 }
 
 type singleCaseSwitchChecker struct {

--- a/lint/stdExpr_checker.go
+++ b/lint/stdExpr_checker.go
@@ -28,7 +28,7 @@ import (
 // For example: func(http.ResponseWriter, *http.Request) => http.HandlerFunc.
 
 func init() {
-	addChecker(stdExprChecker{}, &ruleInfo{})
+	addChecker(stdExprChecker{})
 }
 
 // mathConstant describes named constant value defined in "math" package.

--- a/lint/switchTrue_checker.go
+++ b/lint/switchTrue_checker.go
@@ -3,9 +3,7 @@ package lint
 import "go/ast"
 
 func init() {
-	addChecker(switchTrueChecker{}, &ruleInfo{
-		SyntaxOnly: true,
-	})
+	addChecker(switchTrueChecker{}, attrSyntaxOnly)
 }
 
 type switchTrueChecker struct {

--- a/lint/typeSwitchVar_checker.go
+++ b/lint/typeSwitchVar_checker.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	addChecker(typeSwitchVarChecker{}, &ruleInfo{})
+	addChecker(typeSwitchVarChecker{})
 }
 
 type typeSwitchVarChecker struct {

--- a/lint/typeUnparen_checker.go
+++ b/lint/typeUnparen_checker.go
@@ -9,9 +9,7 @@ import (
 )
 
 func init() {
-	addChecker(typeUnparenChecker{}, &ruleInfo{
-		SyntaxOnly: true,
-	})
+	addChecker(typeUnparenChecker{}, attrSyntaxOnly)
 }
 
 type typeUnparenChecker struct {

--- a/lint/underef_checker.go
+++ b/lint/underef_checker.go
@@ -6,7 +6,7 @@ import (
 )
 
 func init() {
-	addChecker(underefChecker{}, &ruleInfo{})
+	addChecker(underefChecker{})
 }
 
 type underefChecker struct {

--- a/lint/unexportedCall_checker.go
+++ b/lint/unexportedCall_checker.go
@@ -6,7 +6,7 @@ import (
 )
 
 func init() {
-	addChecker(unexportedCallChecker{}, &ruleInfo{})
+	addChecker(unexportedCallChecker{}, attrVeryOpinionated)
 }
 
 type unexportedCallChecker struct {

--- a/lint/unnamedResult_checker.go
+++ b/lint/unnamedResult_checker.go
@@ -6,7 +6,7 @@ import (
 )
 
 func init() {
-	addChecker(unnamedResultChecker{}, &ruleInfo{})
+	addChecker(unnamedResultChecker{})
 }
 
 type unnamedResultChecker struct {

--- a/lint/unslice_checker.go
+++ b/lint/unslice_checker.go
@@ -6,7 +6,7 @@ import (
 )
 
 func init() {
-	addChecker(unsliceChecker{}, &ruleInfo{})
+	addChecker(unsliceChecker{})
 }
 
 type unsliceChecker struct {

--- a/lint/unusedParam_checker.go
+++ b/lint/unusedParam_checker.go
@@ -5,9 +5,7 @@ import (
 )
 
 func init() {
-	addChecker(unusedParamChecker{}, &ruleInfo{
-		Experimental: true,
-	})
+	addChecker(unusedParamChecker{}, attrExperimental)
 }
 
 type unusedParamChecker struct {


### PR DESCRIPTION
This makes passing empty ruleInfo not needed.
We retain type-safety and all benefits of "false" by
default of original approach.

Also mark unexportedCall as VeryOpinionated while there.