### PR TITLE
lint: re-organize wrappers.go

### DIFF
--- a/lint/appendCombine_checker.go
+++ b/lint/appendCombine_checker.go
@@ -16,7 +16,7 @@ type appendCombineChecker struct {
 }
 
 func (c appendCombineChecker) New(ctx *context) func(*ast.File) {
-	return wrapBlockChecker(&appendCombineChecker{
+	return wrapStmtListChecker(&appendCombineChecker{
 		baseStmtListChecker: baseStmtListChecker{ctx: ctx},
 	})
 }


### PR DESCRIPTION
Also fixed incorrect wrapper name: s/wrapBlockChecker/wrapStmtListChecker/.

Fixes #249.