### PR TITLE
Quasilyte/gosu pro lint redesign

### DIFF
--- a/lint/appendCombine_checker.go
+++ b/lint/appendCombine_checker.go
@@ -12,13 +12,7 @@ func init() {
 }
 
 type appendCombineChecker struct {
-	baseStmtListChecker
-}
-
-func (c *appendCombineChecker) New(ctx *context) func(*ast.File) {
-	return wrapStmtListChecker(&appendCombineChecker{
-		baseStmtListChecker: baseStmtListChecker{ctx: ctx},
-	})
+	checkerBase
 }
 
 func (c *appendCombineChecker) CheckStmtList(list []ast.Stmt) {

--- a/lint/boolFuncPrefix_cheker.go
+++ b/lint/boolFuncPrefix_cheker.go
@@ -11,13 +11,7 @@ func init() {
 }
 
 type boolFuncPrefixChecker struct {
-	baseFuncDeclChecker
-}
-
-func (c *boolFuncPrefixChecker) New(ctx *context) func(*ast.File) {
-	return wrapFuncDeclChecker(&boolFuncPrefixChecker{
-		baseFuncDeclChecker: baseFuncDeclChecker{ctx: ctx},
-	})
+	checkerBase
 }
 
 func (c *boolFuncPrefixChecker) CheckFuncDecl(decl *ast.FuncDecl) {

--- a/lint/builtinShadow_checker.go
+++ b/lint/builtinShadow_checker.go
@@ -9,64 +9,60 @@ func init() {
 }
 
 type builtinShadowChecker struct {
-	baseStmtChecker
+	checkerBase
 
 	builtins map[string]bool
 }
 
-func (c *builtinShadowChecker) New(ctx *context) func(*ast.File) {
-	return wrapStmtChecker(&builtinShadowChecker{
-		baseStmtChecker: baseStmtChecker{ctx: ctx},
+func (c *builtinShadowChecker) Init() {
+	c.builtins = map[string]bool{
+		// Types
+		"bool":       true,
+		"byte":       true,
+		"complex64":  true,
+		"complex128": true,
+		"error":      true,
+		"float32":    true,
+		"float64":    true,
+		"int":        true,
+		"int8":       true,
+		"int16":      true,
+		"int32":      true,
+		"int64":      true,
+		"rune":       true,
+		"string":     true,
+		"uint":       true,
+		"uint8":      true,
+		"uint16":     true,
+		"uint32":     true,
+		"uint64":     true,
+		"uintptr":    true,
 
-		builtins: map[string]bool{
-			// Types
-			"bool":       true,
-			"byte":       true,
-			"complex64":  true,
-			"complex128": true,
-			"error":      true,
-			"float32":    true,
-			"float64":    true,
-			"int":        true,
-			"int8":       true,
-			"int16":      true,
-			"int32":      true,
-			"int64":      true,
-			"rune":       true,
-			"string":     true,
-			"uint":       true,
-			"uint8":      true,
-			"uint16":     true,
-			"uint32":     true,
-			"uint64":     true,
-			"uintptr":    true,
+		// Constants
+		"true":  true,
+		"false": true,
+		"iota":  true,
 
-			// Constants
-			"true":  true,
-			"false": true,
-			"iota":  true,
+		// Zero value
+		"nil": true,
 
-			// Zero value
-			"nil": true,
-
-			// Functions
-			"append":  true,
-			"cap":     true,
-			"close":   true,
-			"complex": true,
-			"copy":    true,
-			"delete":  true,
-			"imag":    true,
-			"len":     true,
-			"make":    true,
-			"new":     true,
-			"panic":   true,
-			"print":   true,
-			"println": true,
-			"real":    true,
-			"recover": true,
-		},
-	})
+		// Functions
+		"append":  true,
+		"cap":     true,
+		"close":   true,
+		"complex": true,
+		"copy":    true,
+		"delete":  true,
+		"imag":    true,
+		"len":     true,
+		"make":    true,
+		"new":     true,
+		"panic":   true,
+		"print":   true,
+		"println": true,
+		"real":    true,
+		"recover": true,
+	}
 }
 
 func (c *builtinShadowChecker) CheckStmt(stmt ast.Stmt) {

--- a/lint/captLocal_checker.go
+++ b/lint/captLocal_checker.go
@@ -10,23 +10,19 @@ func init() {
 }
 
 type captLocalChecker struct {
-	baseLocalNameChecker
+	checkerBase
 
 	loudNames map[string]bool
 }
 
-func (c *captLocalChecker) New(ctx *context) func(*ast.File) {
-	return wrapLocalNameChecker(&captLocalChecker{
-		baseLocalNameChecker: baseLocalNameChecker{ctx: ctx},
+func (c *captLocalChecker) Init() {
+	c.loudNames = map[string]bool{
+		"IN":    true,
+		"OUT":   true,
+		"INOUT": true,
 
-		loudNames: map[string]bool{
-			"IN":    true,
-			"OUT":   true,
-			"INOUT": true,
-
-			// TODO: add common acronyms like HTTP and URL?
-		},
-	})
+		// TODO: add common acronyms like HTTP and URL?
+	}
 }
 
 func (c *captLocalChecker) CheckLocalName(id *ast.Ident) {

--- a/lint/checker_base.go
+++ b/lint/checker_base.go
@@ -6,28 +6,34 @@ import (
 )
 
 type (
+	// walkerEventHandler describes common hooks available for every checker.
+	walkerEventHandler interface {
+		// VisitFunc is called for every function declaration that is about
+		// to be traversed. If false is returned, function is not visited.
+		VisitFunc(*ast.FuncDecl) bool
+	}
+
 	// funcDeclChecker visits every top-level function declaration.
 	//
-	// See also: baseFuncDeclChecker, wrapFuncDeclChecker.
+	// See also: wrapFuncDeclChecker.
 	funcDeclChecker interface {
+		walkerEventHandler
 		CheckFuncDecl(*ast.FuncDecl)
 	}
 
 	// exprChecker visits every expression inside AST file.
 	//
-	// See also: baseExprChecker, wrapExprChecker.
+	// See also: wrapExprChecker.
 	exprChecker interface {
+		walkerEventHandler
 		CheckExpr(ast.Expr)
 	}
 
 	// localExprChecker visits every expression inside function body.
 	//
-	// PerFuncInit is called for every function visited.
-	// If returned false, function is skipped.
-	//
-	// See also: baseLocalExprChecker, wrapLocalExprChecker.
+	// See also: wrapLocalExprChecker.
 	localExprChecker interface {
-		PerFuncInit(*ast.FuncDecl) bool
+		walkerEventHandler
 		CheckLocalExpr(ast.Expr)
 	}
 
@@ -35,19 +41,17 @@ type (
 	// This includes block statement bodies as well as implicit blocks
 	// introduced by case clauses and alike.
 	//
-	// See also: baseStmtListChecker, wrapStmtListChecker.
+	// See also: wrapStmtListChecker.
 	stmtListChecker interface {
+		walkerEventHandler
 		CheckStmtList([]ast.Stmt)
 	}
 
 	// stmtChecker visits every statement inside function body.
 	//
-	// PerFuncInit is called for every function visited.
-	// If returned false, function is skipped.
-	//
-	// See also: baseStmtChecker, wrapStmtChecker.
+	// See also: wrapStmtChecker.
 	stmtChecker interface {
-		PerFuncInit(*ast.FuncDecl) bool
+		walkerEventHandler
 		CheckStmt(ast.Stmt)
 	}
 
@@ -57,8 +61,9 @@ type (
 	//	- Every LHS of ":=" assignment
 	//	- Every local var/const declaration.
 	//
-	// See also: baseLocalNameChecker, wrapLocalNameChecker.
+	// See also: wrapLocalNameChecker.
 	localNameChecker interface {
+		walkerEventHandler
 		CheckLocalName(*ast.Ident)
 	}
 
@@ -66,14 +71,25 @@ type (
 	// It also traverses struct types and interface types to run
 	// checker over their fields/method signatures.
 	//
-	// See also: baseTypeExprChecker, wrapTypeExprChecker.
+	// See also: wrapTypeExprChecker.
 	typeExprChecker interface {
+		walkerEventHandler
 		CheckTypeExpr(ast.Expr)
 	}
 )
 
-type baseFuncDeclChecker struct {
+type checkerBase struct {
 	ctx *context
+}
+
+func (c *checkerBase) BindContext(ctx *context) {
+	c.ctx = ctx
+}
+
+func (c *checkerBase) Init() {}
+
+func (c *checkerBase) VisitFunc(fn *ast.FuncDecl) bool {
+	return fn.Body != nil
 }
 
 func wrapFuncDeclChecker(c funcDeclChecker) func(*ast.File) {
@@ -84,10 +100,6 @@ func wrapFuncDeclChecker(c funcDeclChecker) func(*ast.File) {
 			}
 		}
 	}
-}
-
-type baseExprChecker struct {
-	ctx *context
 }
 
 func wrapExprChecker(c exprChecker) func(*ast.File) {
@@ -101,15 +113,11 @@ func wrapExprChecker(c exprChecker) func(*ast.File) {
 	}
 }
 
-type baseLocalExprChecker struct {
-	ctx *context
-}
-
 func wrapLocalExprChecker(c localExprChecker) func(*ast.File) {
 	return func(f *ast.File) {
 		for _, decl := range f.Decls {
 			decl, ok := decl.(*ast.FuncDecl)
-			if !ok || !c.PerFuncInit(decl) {
+			if !ok || !c.VisitFunc(decl) {
 				continue
 			}
 			ast.Inspect(decl.Body, func(x ast.Node) bool {
@@ -120,14 +128,6 @@ func wrapLocalExprChecker(c localExprChecker) func(*ast.File) {
 			})
 		}
 	}
-}
-
-func (c baseLocalExprChecker) PerFuncInit(fn *ast.FuncDecl) bool {
-	return fn.Body != nil
-}
-
-type baseStmtListChecker struct {
-	ctx *context
 }
 
 func wrapStmtListChecker(c stmtListChecker) func(*ast.File) {
@@ -152,20 +152,12 @@ func wrapStmtListChecker(c stmtListChecker) func(*ast.File) {
 	}
 }
 
-type baseStmtChecker struct {
-	ctx *context
-}
-
-func (c baseStmtChecker) PerFuncInit(fn *ast.FuncDecl) bool {
-	return fn.Body != nil
-}
-
 func wrapStmtChecker(c stmtChecker) func(*ast.File) {
 	return func(f *ast.File) {
 		for _, decl := range f.Decls {
 			// Only functions can contain statements.
 			decl, ok := decl.(*ast.FuncDecl)
-			if !ok || !c.PerFuncInit(decl) {
+			if !ok || !c.VisitFunc(decl) {
 				continue
 			}
 			ast.Inspect(decl.Body, func(x ast.Node) bool {
@@ -176,10 +168,6 @@ func wrapStmtChecker(c stmtChecker) func(*ast.File) {
 			})
 		}
 	}
-}
-
-type baseLocalNameChecker struct {
-	ctx *context
 }
 
 func wrapLocalNameChecker(c localNameChecker) func(*ast.File) {
@@ -235,10 +223,6 @@ func wrapLocalNameChecker(c localNameChecker) func(*ast.File) {
 			})
 		}
 	}
-}
-
-type baseTypeExprChecker struct {
-	ctx *context
 }
 
 func wrapTypeExprChecker(c typeExprChecker) func(*ast.File) {

--- a/lint/checker_base.go
+++ b/lint/checker_base.go
@@ -82,10 +82,21 @@ type checkerBase struct {
 	ctx *context
 }
 
+// BindContext saves checker-local context.
+// Called once before Init.
+//
+// Generally, embedding checker needs not to define BindContext
+// as default implementation does the right thing.
 func (c *checkerBase) BindContext(ctx *context) {
 	c.ctx = ctx
 }
 
+// Init implements checker initialization.
+// It is called for zero value instance only once, inside NewChecker.
+//
+// Default initialization does nothing.
+// If embedding checker has a state that needs to be initialized, it must
+// define method with the same signature and perform initialization there.
 func (c *checkerBase) Init() {}
 
 func (c *checkerBase) VisitFunc(fn *ast.FuncDecl) bool {

--- a/lint/docStub_checker.go
+++ b/lint/docStub_checker.go
@@ -10,24 +10,19 @@ func init() {
 }
 
 type docStubChecker struct {
-	ctx          *context
+	checkerBase
+
 	badCommentRE *regexp.Regexp
 }
 
-func (c *docStubChecker) New(ctx *context) func(*ast.File) {
+func (c *docStubChecker) Init() {
 	re := `//\s?\w+[^a-zA-Z]+$`
-	c.ctx = ctx
 	c.badCommentRE = regexp.MustCompile(re)
-	return c.CheckFile
 }
 
-func (c *docStubChecker) CheckFile(f *ast.File) {
-	for _, decl := range f.Decls {
-		if decl, ok := decl.(*ast.FuncDecl); ok {
-			if decl.Doc != nil && c.badCommentRE.MatchString(decl.Doc.List[0].Text) {
-				c.warn(decl)
-			}
-		}
+func (c *docStubChecker) CheckFuncDecl(decl *ast.FuncDecl) {
+	if decl.Doc != nil && c.badCommentRE.MatchString(decl.Doc.List[0].Text) {
+		c.warn(decl)
 	}
 }
 

--- a/lint/elseif_checker.go
+++ b/lint/elseif_checker.go
@@ -9,19 +9,13 @@ func init() {
 }
 
 type elseifChecker struct {
-	baseStmtChecker
+	checkerBase
 
 	cause   *ast.IfStmt
 	visited map[*ast.IfStmt]bool
 }
 
-func (c *elseifChecker) New(ctx *context) func(*ast.File) {
-	return wrapStmtChecker(&elseifChecker{
-		baseStmtChecker: baseStmtChecker{ctx: ctx},
-	})
-}
-
-func (c *elseifChecker) PerFuncInit(fn *ast.FuncDecl) bool {
+func (c *elseifChecker) VisitFunc(fn *ast.FuncDecl) bool {
 	if fn.Body == nil {
 		return false
 	}

--- a/lint/flagDeref_checker.go
+++ b/lint/flagDeref_checker.go
@@ -9,26 +9,22 @@ func init() {
 }
 
 type flagDerefChecker struct {
-	baseExprChecker
+	checkerBase
 
 	flagPtrFuncs map[string]bool
 }
 
-func (c *flagDerefChecker) New(ctx *context) func(*ast.File) {
-	return wrapExprChecker(&flagDerefChecker{
-		baseExprChecker: baseExprChecker{ctx: ctx},
-
-		flagPtrFuncs: map[string]bool{
-			"flag.Bool":     true,
-			"flag.Duration": true,
-			"flag.Float64":  true,
-			"flag.Int":      true,
-			"flag.Int64":    true,
-			"flag.String":   true,
-			"flag.Uint":     true,
-			"flag.Uint64":   true,
-		},
-	})
+func (c *flagDerefChecker) Init() {
+	c.flagPtrFuncs = map[string]bool{
+		"flag.Bool":     true,
+		"flag.Duration": true,
+		"flag.Float64":  true,
+		"flag.Int":      true,
+		"flag.Int64":    true,
+		"flag.String":   true,
+		"flag.Uint":     true,
+		"flag.Uint64":   true,
+	}
 }
 
 func (c *flagDerefChecker) CheckExpr(expr ast.Expr) {

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -83,7 +83,6 @@ type Checker struct {
 
 	ctx context
 
-	clone func(context) *Checker
 	check func(*ast.File)
 }
 

--- a/lint/lint_private.go
+++ b/lint/lint_private.go
@@ -8,14 +8,31 @@ import (
 	"github.com/go-toolsmith/astfmt"
 )
 
-// checkerPrototypes is a table of existing checkers used
-// instantiate new checkers.
+// checkerPrototypes is a table of checker prototypes that are
+// used to instantiate new checker instances.
 //
 // Keys are rule names.
-var checkerPrototypes = map[string]Checker{}
+var checkerPrototypes = map[string]checkerProto{}
 
-type checkFunction interface {
-	New(*context) func(*ast.File)
+type checkerProto struct {
+	rule *Rule
+
+	// clone performs prototype copy and returns it as *Checker.
+	clone func(context) *Checker
+}
+
+// abstractChecker is a proxy interface to forward checkerBase
+// embedding checker into addChecker.
+//
+// It's an implementation detail that has only these guarantees:
+//	- implemented by checkerBase type
+//	- it is an argument type for addChecker
+//
+// Therefore, every checker that embeds checkerBase (normally, every checker)
+// also a valid argument to addChecker.
+type abstractChecker interface {
+	BindContext(*context)
+	Init()
 }
 
 type checkerAttribute int
@@ -45,8 +62,43 @@ func (ctx *context) Warn(node ast.Node, format string, args ...interface{}) {
 	})
 }
 
-func addChecker(c checkFunction, attrs ...checkerAttribute) {
+// addChecker adds checker c to global checkers prototype table.
+// Checker must be a pointer to zero value of concrete checker.
+//
+// Attributes used to fill AttributeSet for the rule inferred from checker.
+func addChecker(c abstractChecker, attrs ...checkerAttribute) {
+	// Clone abstractChecker underlying object.
+	cloneAbstractChecker := func(c abstractChecker) abstractChecker {
+		dynType := reflect.ValueOf(c).Elem().Type()
+		return reflect.New(dynType).Interface().(abstractChecker)
+	}
+
+	bindCheckFunction := func(c abstractChecker) func(*ast.File) {
+		// Infer proper AST traversing wrapper (walker).
+		switch c := c.(type) {
+		case funcDeclChecker:
+			return wrapFuncDeclChecker(c)
+		case exprChecker:
+			return wrapExprChecker(c)
+		case localExprChecker:
+			return wrapLocalExprChecker(c)
+		case stmtListChecker:
+			return wrapStmtListChecker(c)
+		case stmtChecker:
+			return wrapStmtChecker(c)
+		case localNameChecker:
+			return wrapLocalNameChecker(c)
+		case typeExprChecker:
+			return wrapTypeExprChecker(c)
+		default:
+			panic(fmt.Sprintf("can't bind check function for %T", c))
+		}
+	}
+
 	var rule Rule
+	typeName := reflect.ValueOf(c).Type().String()
+	rule.name = typeName[len("*lint.") : len(typeName)-len("Checker")]
+	// Fill rule attributes using provided attr list.
 	for _, attr := range attrs {
 		switch attr {
 		case attrExperimental:
@@ -59,10 +111,16 @@ func addChecker(c checkFunction, attrs ...checkerAttribute) {
 			panic(fmt.Sprintf("unexpected checkerAttribute"))
 		}
 	}
-	typeName := reflect.ValueOf(c).Type().String()
-	rule.name = typeName[len("*lint.") : len(typeName)-len("Checker")]
-	checkerPrototypes[rule.name] = Checker{
-		Rule: &rule,
-		init: c.New,
+
+	proto := checkerProto{rule: &rule}
+	proto.clone = func(ctx context) *Checker {
+		c := cloneAbstractChecker(c)
+		clone := Checker{Rule: proto.rule}
+		clone.check = bindCheckFunction(c)
+		clone.ctx = ctx
+		c.BindContext(&clone.ctx)
+		c.Init()
+		return &clone
 	}
+	checkerPrototypes[rule.name] = proto
 }

--- a/lint/lint_private.go
+++ b/lint/lint_private.go
@@ -24,12 +24,10 @@ type checkerProto struct {
 // abstractChecker is a proxy interface to forward checkerBase
 // embedding checker into addChecker.
 //
-// It's an implementation detail that has only these guarantees:
-//	- implemented by checkerBase type
-//	- it is an argument type for addChecker
+// abstarctChecher is implemented by checkerBase directly and completely,
+// making any checker that embeds it a valid argument to addChecker.
 //
-// Therefore, every checker that embeds checkerBase (normally, every checker)
-// also a valid argument to addChecker.
+// See checkerBase and its implementation of this interface for more info.
 type abstractChecker interface {
 	BindContext(*context)
 	Init()
@@ -115,9 +113,11 @@ func addChecker(c abstractChecker, attrs ...checkerAttribute) {
 	proto := checkerProto{rule: &rule}
 	proto.clone = func(ctx context) *Checker {
 		c := cloneAbstractChecker(c)
-		clone := Checker{Rule: proto.rule}
-		clone.check = bindCheckFunction(c)
-		clone.ctx = ctx
+		clone := Checker{
+			Rule:  proto.rule,
+			check: bindCheckFunction(c),
+			ctx:   ctx,
+		}
 		c.BindContext(&clone.ctx)
 		c.Init()
 		return &clone

--- a/lint/lint_private.go
+++ b/lint/lint_private.go
@@ -24,7 +24,7 @@ type checkerProto struct {
 // abstractChecker is a proxy interface to forward checkerBase
 // embedding checker into addChecker.
 //
-// abstarctChecher is implemented by checkerBase directly and completely,
+// abstractChecker is implemented by checkerBase directly and completely,
 // making any checker that embeds it a valid argument to addChecker.
 //
 // See checkerBase and its implementation of this interface for more info.

--- a/lint/longChain_checker.go
+++ b/lint/longChain_checker.go
@@ -13,7 +13,7 @@ func init() {
 }
 
 type longChainChecker struct {
-	baseLocalExprChecker
+	checkerBase
 
 	// chains is a {expr string => count} mapping.
 	chains map[string]int
@@ -23,13 +23,7 @@ type longChainChecker struct {
 	reported map[string]bool
 }
 
-func (c *longChainChecker) New(ctx *context) func(*ast.File) {
-	return wrapLocalExprChecker(&longChainChecker{
-		baseLocalExprChecker: baseLocalExprChecker{ctx: ctx},
-	})
-}
-
-func (c *longChainChecker) PerFuncInit(fn *ast.FuncDecl) bool {
+func (c *longChainChecker) VisitFunc(fn *ast.FuncDecl) bool {
 	// Avoid checking functions of 1 statement.
 	// Both performance and false-positives reasons.
 	if fn.Body == nil || len(fn.Body.List) == 1 {

--- a/lint/paramTypeCombine_checker.go
+++ b/lint/paramTypeCombine_checker.go
@@ -11,13 +11,7 @@ func init() {
 }
 
 type paramTypeCombineChecker struct {
-	baseFuncDeclChecker
-}
-
-func (c *paramTypeCombineChecker) New(ctx *context) func(*ast.File) {
-	return wrapFuncDeclChecker(&paramTypeCombineChecker{
-		baseFuncDeclChecker: baseFuncDeclChecker{ctx: ctx},
-	})
+	checkerBase
 }
 
 func (c *paramTypeCombineChecker) CheckFuncDecl(decl *ast.FuncDecl) {

--- a/lint/ptrToRefParam_checker.go
+++ b/lint/ptrToRefParam_checker.go
@@ -10,13 +10,7 @@ func init() {
 }
 
 type ptrToRefParamChecker struct {
-	baseFuncDeclChecker
-}
-
-func (c *ptrToRefParamChecker) New(ctx *context) func(*ast.File) {
-	return wrapFuncDeclChecker(&ptrToRefParamChecker{
-		baseFuncDeclChecker: baseFuncDeclChecker{ctx: ctx},
-	})
+	checkerBase
 }
 
 func (c *ptrToRefParamChecker) CheckFuncDecl(fn *ast.FuncDecl) {

--- a/lint/rangeExprCopy_checker.go
+++ b/lint/rangeExprCopy_checker.go
@@ -10,19 +10,10 @@ func init() {
 }
 
 type rangeExprCopyChecker struct {
-	baseStmtChecker
+	checkerBase
 }
 
-func (c *rangeExprCopyChecker) New(ctx *context) func(*ast.File) {
-	// TODO(quasilyte): there is some annoying code duplication with other
-	// range statement checker. We should consider refactoring if
-	// more checkers that inspect range statements will appear.
-	return wrapStmtChecker(&rangeExprCopyChecker{
-		baseStmtChecker: baseStmtChecker{ctx: ctx},
-	})
-}
-
-func (c *rangeExprCopyChecker) PerFuncInit(fn *ast.FuncDecl) bool {
+func (c *rangeExprCopyChecker) VisitFunc(fn *ast.FuncDecl) bool {
 	return fn.Body != nil && !c.ctx.IsUnitTestFuncDecl(fn)
 }
 

--- a/lint/rangeValCopy_checker.go
+++ b/lint/rangeValCopy_checker.go
@@ -9,16 +9,10 @@ func init() {
 }
 
 type rangeValCopyChecker struct {
-	baseStmtChecker
+	checkerBase
 }
 
-func (c *rangeValCopyChecker) New(ctx *context) func(*ast.File) {
-	return wrapStmtChecker(&rangeValCopyChecker{
-		baseStmtChecker: baseStmtChecker{ctx: ctx},
-	})
-}
-
-func (c *rangeValCopyChecker) PerFuncInit(fn *ast.FuncDecl) bool {
+func (c *rangeValCopyChecker) VisitFunc(fn *ast.FuncDecl) bool {
 	return fn.Body != nil && !c.ctx.IsUnitTestFuncDecl(fn)
 }
 

--- a/lint/singleCaseSwitch_checker.go
+++ b/lint/singleCaseSwitch_checker.go
@@ -9,13 +9,7 @@ func init() {
 }
 
 type singleCaseSwitchChecker struct {
-	baseStmtChecker
-}
-
-func (c *singleCaseSwitchChecker) New(ctx *context) func(*ast.File) {
-	return wrapStmtChecker(&singleCaseSwitchChecker{
-		baseStmtChecker: baseStmtChecker{ctx: ctx},
-	})
+	checkerBase
 }
 
 func (c *singleCaseSwitchChecker) CheckStmt(stmt ast.Stmt) {

--- a/lint/switchTrue_checker.go
+++ b/lint/switchTrue_checker.go
@@ -7,13 +7,7 @@ func init() {
 }
 
 type switchTrueChecker struct {
-	baseStmtChecker
-}
-
-func (c *switchTrueChecker) New(ctx *context) func(*ast.File) {
-	return wrapStmtChecker(&switchTrueChecker{
-		baseStmtChecker: baseStmtChecker{ctx: ctx},
-	})
+	checkerBase
 }
 
 func (c *switchTrueChecker) CheckStmt(stmt ast.Stmt) {

--- a/lint/typeSwitchVar_checker.go
+++ b/lint/typeSwitchVar_checker.go
@@ -12,13 +12,7 @@ func init() {
 }
 
 type typeSwitchVarChecker struct {
-	baseStmtChecker
-}
-
-func (c *typeSwitchVarChecker) New(ctx *context) func(*ast.File) {
-	return wrapStmtChecker(&typeSwitchVarChecker{
-		baseStmtChecker: baseStmtChecker{ctx: ctx},
-	})
+	checkerBase
 }
 
 func (c *typeSwitchVarChecker) CheckStmt(stmt ast.Stmt) {

--- a/lint/typeUnparen_checker.go
+++ b/lint/typeUnparen_checker.go
@@ -13,13 +13,7 @@ func init() {
 }
 
 type typeUnparenChecker struct {
-	baseTypeExprChecker
-}
-
-func (c *typeUnparenChecker) New(ctx *context) func(*ast.File) {
-	return wrapTypeExprChecker(&typeUnparenChecker{
-		baseTypeExprChecker: baseTypeExprChecker{ctx: ctx},
-	})
+	checkerBase
 }
 
 func (c *typeUnparenChecker) CheckTypeExpr(expr ast.Expr) {

--- a/lint/underef_checker.go
+++ b/lint/underef_checker.go
@@ -10,13 +10,7 @@ func init() {
 }
 
 type underefChecker struct {
-	baseExprChecker
-}
-
-func (c *underefChecker) New(ctx *context) func(*ast.File) {
-	return wrapExprChecker(&underefChecker{
-		baseExprChecker: baseExprChecker{ctx: ctx},
-	})
+	checkerBase
 }
 
 func (c *underefChecker) CheckExpr(expr ast.Expr) {

--- a/lint/unexportedCall_checker.go
+++ b/lint/unexportedCall_checker.go
@@ -10,18 +10,12 @@ func init() {
 }
 
 type unexportedCallChecker struct {
-	baseLocalExprChecker
+	checkerBase
 
 	recvName string
 }
 
-func (c *unexportedCallChecker) New(ctx *context) func(*ast.File) {
-	return wrapLocalExprChecker(&unexportedCallChecker{
-		baseLocalExprChecker: baseLocalExprChecker{ctx: ctx},
-	})
-}
-
-func (c *unexportedCallChecker) PerFuncInit(decl *ast.FuncDecl) bool {
+func (c *unexportedCallChecker) VisitFunc(decl *ast.FuncDecl) bool {
 	if decl.Body == nil {
 		return false
 	}

--- a/lint/unnamedResult_checker.go
+++ b/lint/unnamedResult_checker.go
@@ -10,13 +10,7 @@ func init() {
 }
 
 type unnamedResultChecker struct {
-	baseFuncDeclChecker
-}
-
-func (c *unnamedResultChecker) New(ctx *context) func(*ast.File) {
-	return wrapFuncDeclChecker(&unnamedResultChecker{
-		baseFuncDeclChecker: baseFuncDeclChecker{ctx: ctx},
-	})
+	checkerBase
 }
 
 func (c *unnamedResultChecker) CheckFuncDecl(decl *ast.FuncDecl) {

--- a/lint/unslice_checker.go
+++ b/lint/unslice_checker.go
@@ -10,13 +10,7 @@ func init() {
 }
 
 type unsliceChecker struct {
-	baseLocalExprChecker
-}
-
-func (c *unsliceChecker) New(ctx *context) func(*ast.File) {
-	return wrapLocalExprChecker(&unsliceChecker{
-		baseLocalExprChecker: baseLocalExprChecker{ctx: ctx},
-	})
+	checkerBase
 }
 
 func (c *unsliceChecker) CheckLocalExpr(expr ast.Expr) {

--- a/lint/unusedParam_checker.go
+++ b/lint/unusedParam_checker.go
@@ -9,13 +9,7 @@ func init() {
 }
 
 type unusedParamChecker struct {
-	baseFuncDeclChecker
-}
-
-func (c *unusedParamChecker) New(ctx *context) func(*ast.File) {
-	return wrapFuncDeclChecker(&unusedParamChecker{
-		baseFuncDeclChecker: baseFuncDeclChecker{ctx: ctx},
-	})
+	checkerBase
 }
 
 func (c *unusedParamChecker) CheckFuncDecl(decl *ast.FuncDecl) {


### PR DESCRIPTION
Main changes:
- 1 checker base `checkerBase` instead of N checker bases. There are still N interfaces and we need them both for documentation and type assertions inside `addChecker`, but having multiple bases was a mistake. It lead to some code duplication and higher overall complexity.
- No need to bind context inside checker code. Checkers that only did context assignment do not need `New` function anymore. Checkers that need initalization can define `Init()` function for that.
- `wrapXxx` call is done by `addChecker`, so checkers are not required to wrap themselves anymore.

My main objective was to simplify checkers code even if this required some complications inside `addChecker` function. Also, it's simpler now to choose base type -- there is only one correct option.
It is also simpler to add new walkers/wrappers/whether we call them, since now there is no need to add new base type that implements `VisitFunc`/`PerFuncInit`, etc.

We also can modify our implementation of this magic later as API should be enough to encapsulate that completely.