### PR TITLE
lint: traverse params properly in wrapLocalNameChecker

### DIFF
--- a/cmd/gocritic/testdata/captLocal/negative_tests.go
+++ b/cmd/gocritic/testdata/captLocal/negative_tests.go
@@ -12,6 +12,12 @@ type emptyStruct struct{}
 
 func (in emptyStruct) method1(out *int) {}
 
+type ExportedType int
+
+func (x ExportedType) capitalizedType(y ExportedType) ExportedType {
+	return 0
+}
+
 func noWarnings() {
 	type LocalCapitalizedType int
 	type (

--- a/lint/checker_base.go
+++ b/lint/checker_base.go
@@ -189,17 +189,23 @@ func wrapLocalNameChecker(c localNameChecker) func(*ast.File) {
 				continue
 			}
 			// First, function params.
-			ast.Inspect(decl.Type, func(x ast.Node) bool {
-				if id, ok := x.(*ast.Ident); ok {
+			for _, p := range decl.Type.Params.List {
+				for _, id := range p.Names {
 					c.CheckLocalName(id)
 				}
-				return true
-			})
+			}
+			if decl.Type.Results != nil {
+				for _, p := range decl.Type.Results.List {
+					for _, id := range p.Names {
+						c.CheckLocalName(id)
+					}
+				}
+			}
 			if decl.Recv != nil {
 				c.CheckLocalName(decl.Recv.List[0].Names[0])
 			}
-			if decl.Body == nil { // Skip external functions
-				return
+			if !c.VisitFunc(decl) {
+				continue
 			}
 			// Now every assignment and var/const decl.
 			ast.Inspect(decl.Body, func(x ast.Node) bool {


### PR DESCRIPTION
ast.Inspect caused to pass type expressions as names into
checker, leading to false positives for capitalized (exported) types.