### PR TITLE
lint/ptrToRefParam: fix underlying types

### DIFF
--- a/cmd/gocritic/testdata/ptrToRefParam/negative_tests.go
+++ b/cmd/gocritic/testdata/ptrToRefParam/negative_tests.go
@@ -18,3 +18,19 @@ func ok4(ch chan *string) chan *int {
 
 /// OK: just a func
 func ok5() {}
+
+type kek map[int]int
+type kek2 chan string
+type kek3 []string
+
+func (k *kek) ok(kk *kek)   {}
+func (k *kek2) ok(kk *kek2) {}
+func (k *kek3) ok(kk *kek3) {}
+
+type wow *map[int]int
+type wow2 *chan string
+type wow3 *[]string
+
+func wowok(kk wow)   {}
+func wowok2(kk wow2) {}
+func wowok3(kk wow3) {}

--- a/lint/ptrToRefParam_checker.go
+++ b/lint/ptrToRefParam_checker.go
@@ -27,7 +27,7 @@ func (c *ptrToRefParamChecker) checkParams(params []*ast.Field) {
 			continue
 		}
 
-		if c.isRefType(ptr.Elem().Underlying()) {
+		if c.isRefType(ptr.Elem()) {
 			if len(param.Names) == 0 {
 				c.ctx.Warn(param, "consider to make non-pointer type for `%s`", ptr.String())
 			} else {


### PR DESCRIPTION
Fixes #262 