### PR TITLE
lint/unusedParam: skip external functions

### DIFF
--- a/cmd/gocritic/testdata/unusedParam/negative_tests.go
+++ b/cmd/gocritic/testdata/unusedParam/negative_tests.go
@@ -10,3 +10,5 @@ func (f *foo) g2(_ int, _ float64) {
 func g3() (_ int, _ float64) {
 	return 0, 0
 }
+
+func external(x int)

--- a/lint/unusedParam_checker.go
+++ b/lint/unusedParam_checker.go
@@ -14,7 +14,7 @@ type unusedParamChecker struct {
 
 func (c *unusedParamChecker) CheckFuncDecl(decl *ast.FuncDecl) {
 	params := decl.Type.Params
-	if params == nil || params.NumFields() == 0 {
+	if decl.Body == nil || params == nil || params.NumFields() == 0 {
 		return
 	}
 


### PR DESCRIPTION
Fixes #264 