### PR TITLE
cmd/criticize: add withOpinionated and withExperimental flags

### DIFF
--- a/cmd/criticize/main.go
+++ b/cmd/criticize/main.go
@@ -58,12 +58,14 @@ func blame(format string, args ...interface{}) {
 // parseArgv processes command-line arguments and fills ctx argument with them.
 // Terminates program on error.
 func parseArgv(l *linter) {
+	const enableAll = "all"
+
 	flag.Usage = func() {
 		log.Printf("usage: [flags] package...")
 		flag.PrintDefaults()
 	}
 
-	enable := flag.String("enable", "all", "comma-separated list of enabled checkers")
+	enable := flag.String("enable", enableAll, "comma-separated list of enabled checkers")
 	flag.BoolVar(&l.withExperimental, `withExperimental`, false,
 		`only for -enable=all, include experimental checks`)
 	flag.BoolVar(&l.withOpinionated, `withOpinionated`, false,
@@ -77,15 +79,15 @@ func parseArgv(l *linter) {
 	if len(l.packages) == 0 {
 		blame("no packages specified\n")
 	}
-	if *enable != "all" && l.withExperimental {
+	if *enable != enableAll && l.withExperimental {
 		blame("-withExperimental used with -enable=%q", *enable)
 	}
-	if *enable != "all" && l.withOpinionated {
+	if *enable != enableAll && l.withOpinionated {
 		blame("-withOpinionated used with -enable=%q", *enable)
 	}
 
 	switch *enable {
-	case "all":
+	case enableAll:
 		// Special case. l.enabledCheckers remains nil.
 	case "":
 		// Empty slice. Semantically "disable-all".


### PR DESCRIPTION
Also skip VeryOpinionated checks for "all" (default) set.

Now we have this:
	- Just "all" to include all stable checkers
	- "all"+withOpinionated
	- "all"+withExperimental
	- "all"+withOpinionated+withExperimental

Should be enough for any sensible case, given that we
have explicit whitelist that permits any kind of checker.

Fixes #273