### PR TITLE
add imported package names shadowing linter

### DIFF
--- a/cmd/gocritic/testdata/importShadow/negative_tests.go
+++ b/cmd/gocritic/testdata/importShadow/negative_tests.go
@@ -1,0 +1,12 @@
+package checker_test
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/go-critic/go-critic/lint"
+)
+
+func noWarnings() {
+	fmt.Printf("Hello PI=%v, Rule=%v", math.Pi, lint.Rule{})
+}

--- a/cmd/gocritic/testdata/importShadow/positive_tests.go
+++ b/cmd/gocritic/testdata/importShadow/positive_tests.go
@@ -1,0 +1,19 @@
+package checker_test
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/go-critic/go-critic/lint"
+)
+
+func shadowImportedPackages() {
+	fmt.Printf("Hello PI=%v, Rule=%v", math.Pi, lint.Rule{})
+
+	/// shadow of imported package 'math'
+	math := "some math"
+	/// shadow of imported from 'github.com/go-critic/go-critic/lint' package 'lint'
+	lint := "some lint"
+
+	fmt.Printf("Hello math=%v, lint=%v", math, lint)
+}

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -48,12 +48,6 @@ Go source code linter that brings checks that are currently not implemented in o
 </td>
       </tr>
       <tr>
-        <td><a href="#importShadow-ref">importShadow</a></td>
-        <td>Detects when imported package names shadowed in assignments.
-
-</td>
-      </tr>
-      <tr>
         <td><a href="#paramTypeCombine-ref">paramTypeCombine</a></td>
         <td>Detects if function parameters could be combined by type and suggest the way to do it.
 
@@ -143,6 +137,12 @@ Go source code linter that brings checks that are currently not implemented in o
       <tr>
         <td><a href="#boolFuncPrefix-ref">boolFuncPrefix</a></td>
         <td>Detects function returning only bool and suggests to add Is/Has/Contains prefix to it's name.
+
+</td>
+      </tr>
+      <tr>
+        <td><a href="#importShadow-ref">importShadow</a></td>
+        <td>Detects when imported package names shadowed in assignments.
 
 </td>
       </tr>
@@ -317,43 +317,6 @@ flag.BoolVar(&b, "b", false, "b docs")
 > where flag values are not updated after flag.Parse().
 
 
-<a name="importShadow-ref"></a>
-## importShadow
-Detects when imported package names shadowed in assignments.
-
-
-
-**Before:**
-```go
-import (
-	   "fmt"
-    "math"
-)
-func main() {
-    fmt.Println(math.Pi)
-    // shadowing math package
-    math := 10
-    fmt.Println(len)
-}
-
-```
-
-**After:**
-```go
-import (
-    "fmt"
-    "math"
-)
-func main() {
-    fmt.Println(math.Pi)
-    // change identificator name
-    value := 10
-    fmt.Println(value)
-}
-
-```
-
-`importShadow` is syntax-only checker (fast).
 
 
 <a name="paramTypeCombine-ref"></a>
@@ -706,6 +669,43 @@ func IsEnabled() bool
 
 > Dereferencing returned pointers will lead to hard to find errors
 > where flag values are not updated after flag.Parse().
+
+
+<a name="importShadow-ref"></a>
+## importShadow
+Detects when imported package names shadowed in assignments.
+
+
+
+**Before:**
+```go
+import (
+	   "fmt"
+    "math"
+)
+func main() {
+    fmt.Println(math.Pi)
+    // shadowing math package
+    math := 10
+    fmt.Println(len)
+}
+
+```
+
+**After:**
+```go
+import (
+    "fmt"
+    "math"
+)
+func main() {
+    fmt.Println(math.Pi)
+    // change identificator name
+    value := 10
+    fmt.Println(value)
+}
+
+```
 
 
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -319,19 +319,21 @@ flag.BoolVar(&b, "b", false, "b docs")
 
 <a name="importShadow-ref"></a>
 ## importShadow
+Detects when imported package names shadowed in assignments.
+
 
 
 **Before:**
 ```go
 import (
-"fmt"
-"math"
+	   "fmt"
+    "math"
 )
 func main() {
-fmt.Println(math.Pi)
-// shadowing math package
-math := 10
-fmt.Println(len)
+    fmt.Println(math.Pi)
+    // shadowing math package
+    math := 10
+    fmt.Println(len)
 }
 
 ```
@@ -339,14 +341,14 @@ fmt.Println(len)
 **After:**
 ```go
 import (
-"fmt"
-"math"
+    "fmt"
+    "math"
 )
 func main() {
-fmt.Println(math.Pi)
-// change identificator name
-value := 10
-fmt.Println(value)
+    fmt.Println(math.Pi)
+    // change identificator name
+    value := 10
+    fmt.Println(value)
 }
 
 ```

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -48,6 +48,12 @@ Go source code linter that brings checks that are currently not implemented in o
 </td>
       </tr>
       <tr>
+        <td><a href="#importShadow-ref">importShadow</a></td>
+        <td>Detects when imported package names shadowed in assignments.
+
+</td>
+      </tr>
+      <tr>
         <td><a href="#paramTypeCombine-ref">paramTypeCombine</a></td>
         <td>Detects if function parameters could be combined by type and suggest the way to do it.
 
@@ -298,6 +304,42 @@ flag.BoolVar(&b, "b", false, "b docs")
 `flagDeref` is syntax-only checker (fast).> Dereferencing returned pointers will lead to hard to find errors
 > where flag values are not updated after flag.Parse().
 
+
+<a name="importShadow-ref"></a>
+## importShadow
+
+
+**Before:**
+```go
+import (
+"fmt"
+"math"
+)
+func main() {
+fmt.Println(math.Pi)
+// shadowing math package
+math := 10
+fmt.Println(len)
+}
+
+```
+
+**After:**
+```go
+import (
+"fmt"
+"math"
+)
+func main() {
+fmt.Println(math.Pi)
+// change identificator name
+value := 10
+fmt.Println(value)
+}
+
+```
+
+`importShadow` is syntax-only checker (fast).
 
 
 <a name="paramTypeCombine-ref"></a>
@@ -622,6 +664,7 @@ func IsEnabled() bool
 
 > Dereferencing returned pointers will lead to hard to find errors
 > where flag values are not updated after flag.Parse().
+
 
 
 <a name="longChain-ref"></a>

--- a/lint/importShadow_checker.go
+++ b/lint/importShadow_checker.go
@@ -34,7 +34,7 @@ import (
 )
 
 func init() {
-	addChecker(&importShadowChecker{}, attrSyntaxOnly)
+	addChecker(&importShadowChecker{}, attrExperimental, attrSyntaxOnly)
 }
 
 type importShadowChecker struct {

--- a/lint/importShadow_checker.go
+++ b/lint/importShadow_checker.go
@@ -1,0 +1,61 @@
+package lint
+
+//! Detects when imported package names shadowed in assignments.
+//
+// @Before:
+// import (
+// 	   "fmt"
+//     "math"
+// )
+// func main() {
+//     fmt.Println(math.Pi)
+//     // shadowing math package
+//     math := 10
+//     fmt.Println(len)
+// }
+//
+// @After:
+// import (
+//     "fmt"
+//     "math"
+// )
+// func main() {
+//     fmt.Println(math.Pi)
+//     // change identificator name
+//     value := 10
+//     fmt.Println(value)
+// }
+
+import (
+	"go/ast"
+	"go/types"
+
+	"github.com/go-critic/go-critic/lint/internal/astwalk"
+)
+
+func init() {
+	addChecker(&importShadowChecker{}, attrSyntaxOnly)
+}
+
+type importShadowChecker struct {
+	checkerBase
+}
+
+func (c *importShadowChecker) Init() {}
+
+func (c *importShadowChecker) VisitLocalDef(def astwalk.Name, _ ast.Expr) {
+	for _, imp := range c.ctx.Context.pkg.Imports() {
+		if imp.Name() == def.ID.Name {
+			c.warnImportShadowed(def.ID, imp)
+		}
+	}
+}
+
+func (c *importShadowChecker) warnImportShadowed(id ast.Node, pkg *types.Package) {
+	if pkg.Path() == pkg.Name() {
+		// check for standart library packages
+		c.ctx.Warn(id, "shadow of imported package '%s'", pkg.Name())
+	} else {
+		c.ctx.Warn(id, "shadow of imported from '%s' package '%s'", pkg.Path(), pkg.Name())
+	}
+}

--- a/lint/importShadow_checker.go
+++ b/lint/importShadow_checker.go
@@ -34,14 +34,12 @@ import (
 )
 
 func init() {
-	addChecker(&importShadowChecker{}, attrExperimental, attrSyntaxOnly)
+	addChecker(&importShadowChecker{}, attrExperimental)
 }
 
 type importShadowChecker struct {
 	checkerBase
 }
-
-func (c *importShadowChecker) Init() {}
 
 func (c *importShadowChecker) VisitLocalDef(def astwalk.Name, _ ast.Expr) {
 	for _, imp := range c.ctx.Context.pkg.Imports() {


### PR DESCRIPTION
Sometimes developers use the same name for the variables as imported packages, more often I see something like importing "log" package and having "log" variable in the code.

This linter checks what imports the package has and what variables got created and compares one to another.