### PR TITLE
docs/templates: move "notes" above "attrs" in overview tmpl

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -183,7 +183,6 @@ xs = append(xs, 1, 2)
 
 
 
-
 <a name="builtinShadow-ref"></a>
 ## builtinShadow
 Detects when predeclared identifiers shadowed in assignments.
@@ -210,8 +209,8 @@ func main() {
 
 ```
 
-`builtinShadow` is syntax-only checker (fast).
 
+`builtinShadow` is syntax-only checker (fast).
 <a name="captLocal-ref"></a>
 ## captLocal
 Detects capitalized names for local variables.
@@ -230,8 +229,8 @@ func f(in int, out *int) (err error) {}
 
 ```
 
-`captLocal` is syntax-only checker (fast).
 
+`captLocal` is syntax-only checker (fast).
 <a name="docStub-ref"></a>
 ## docStub
 Detects comments that silence go lint complaints about doc-comment.
@@ -255,10 +254,10 @@ func Foo() {
 
 ```
 
-`docStub` is syntax-only checker (fast).> You can either remove a comment to let go lint find it or change stub to useful comment.
+> You can either remove a comment to let go lint find it or change stub to useful comment.
 > This checker makes it easier to detect stubs, the action is up to you.
 
-
+`docStub` is syntax-only checker (fast).
 <a name="elseif-ref"></a>
 ## elseif
 Detects repeated if-else statements and suggests to replace them with switch statement.
@@ -292,8 +291,8 @@ default:
 
 ```
 
-`elseif` is syntax-only checker (fast).
 
+`elseif` is syntax-only checker (fast).
 <a name="flagDeref-ref"></a>
 ## flagDeref
 Detects immediate dereferencing of `flag` package pointers.
@@ -313,12 +312,10 @@ flag.BoolVar(&b, "b", false, "b docs")
 
 ```
 
-`flagDeref` is syntax-only checker (fast).> Dereferencing returned pointers will lead to hard to find errors
+> Dereferencing returned pointers will lead to hard to find errors
 > where flag values are not updated after flag.Parse().
 
-
-
-
+`flagDeref` is syntax-only checker (fast).
 <a name="paramTypeCombine-ref"></a>
 ## paramTypeCombine
 Detects if function parameters could be combined by type and suggest the way to do it.
@@ -337,8 +334,8 @@ func foo(a, b, c, d, e, f, g int) {}
 
 ```
 
-`paramTypeCombine` is syntax-only checker (fast).
 
+`paramTypeCombine` is syntax-only checker (fast).
 <a name="ptrToRefParam-ref"></a>
 ## ptrToRefParam
 Detects input and output parameters that have a type of pointer to referential type.
@@ -438,8 +435,8 @@ if x, ok := x.(int); ok {
 
 ```
 
-`singleCaseSwitch` is syntax-only checker (fast).
 
+`singleCaseSwitch` is syntax-only checker (fast).
 <a name="stdExpr-ref"></a>
 ## stdExpr
 Detects constant expressions that can be replaced by a named constant
@@ -486,8 +483,8 @@ case x > y:
 
 ```
 
-`switchTrue` is syntax-only checker (fast).
 
+`switchTrue` is syntax-only checker (fast).
 <a name="typeSwitchVar-ref"></a>
 ## typeSwitchVar
 Detects type switches that can benefit from type guard clause with variable.
@@ -544,8 +541,8 @@ func foo() []func([]func()) {
 
 ```
 
-`typeUnparen` is syntax-only checker (fast).
 
+`typeUnparen` is syntax-only checker (fast).
 <a name="underef-ref"></a>
 ## underef
 Detects dereference expressions that can be omitted.
@@ -596,8 +593,8 @@ func baz() {
 
 ```
 
-`unexportedCall` is very opinionated.
 
+`unexportedCall` is very opinionated.
 <a name="unnamedResult-ref"></a>
 ## unnamedResult
 For functions with multiple return values, detects unnamed results
@@ -637,7 +634,6 @@ f(s)
 copy(b, values...)
 
 ```
-
 
 
 

--- a/docs/templates/overview.md.tmpl
+++ b/docs/templates/overview.md.tmpl
@@ -57,6 +57,7 @@ Go source code linter that brings checks that are currently not implemented in o
 {{ .After }}
 ```
 
+{{ .Note }}
 {{ if .SyntaxOnly -}}
   `{{.Name}}` is syntax-only checker (fast).
 {{- end -}}
@@ -64,7 +65,7 @@ Go source code linter that brings checks that are currently not implemented in o
   `{{.Name}}` is very opinionated.
 {{- end -}}
 {{ end -}}
-{{ .Note }}
+
 {{ end -}}
 
 {{ range .Checkers -}}


### PR DESCRIPTION
This fixes issue with note section rendering.