### PR TITLE
lint: improve type-expr walker and visitor

### DIFF
--- a/cmd/gocritic/testdata/typeUnparen/negative_tests.go
+++ b/cmd/gocritic/testdata/typeUnparen/negative_tests.go
@@ -54,3 +54,23 @@ type structWithEmbedding struct {
 	structToEmbed
 	Field int
 }
+
+var _ interface{} = (*int)(nil)
+
+type myWriter interface {
+	myWrite()
+}
+
+type noopWriter struct{}
+
+func (*noopWriter) myWrite() {}
+
+var _ myWriter = (*noopWriter)(nil)
+
+func ptrCast() {
+	_ = (*int)(nil)
+
+	_ = (*int)((*int)(nil))
+
+	_ = (***int)(nil)
+}

--- a/cmd/gocritic/testdata/typeUnparen/positive_tests.go
+++ b/cmd/gocritic/testdata/typeUnparen/positive_tests.go
@@ -122,3 +122,43 @@ var _ = []interface{}{
 		)
 	},
 }
+
+/// could simplify *(noopWriter) to *noopWriter
+var _ myWriter = (*(noopWriter))(nil)
+
+func typeAssert(x interface{}) {
+	/// could simplify (int) to int
+	_ = x.((int))
+
+	/// could simplify (*(int)) to *int
+	_ = x.((*(int)))
+
+	/// could simplify *(int) to *int
+	_ = x.(*(int))
+}
+
+func newCall() {
+	/// could simplify (int) to int
+	_ = new((int))
+
+	/// could simplify *(*(*(int))) to ***int
+	_ = new(*(*(*(int))))
+}
+
+func conversions() {
+	/// could simplify (int) to int
+	/// could simplify (int32) to int32
+	_ = int((int)((int32)(0)))
+
+	/// could simplify (int) to int
+	_ = (int)(1)
+
+	/// could simplify *(int) to *int
+	_ = (*(int))(nil)
+
+	/// could simplify *(*(int)) to **int
+	_ = (*(*(int)))(nil)
+
+	/// could simplify ***(*(int)) to ****int
+	_ = (***(*(int)))(nil)
+}

--- a/lint/internal/astwalk/type_expr_walker.go
+++ b/lint/internal/astwalk/type_expr_walker.go
@@ -49,7 +49,7 @@ func (w *typeExprWalker) walk(x ast.Node) bool {
 		}
 		return true
 	case *ast.CallExpr:
-		// Pointer convensions require parenthesis around pointer type.
+		// Pointer conversions require parenthesis around pointer type.
 		// These casts are represented as call expressions.
 		// Because it's impossible for the visitor to distinguish such
 		// "required" parenthesis, walker skips outmost parenthesis in such cases.

--- a/lint/typeUnparen_checker.go
+++ b/lint/typeUnparen_checker.go
@@ -57,10 +57,10 @@ func (c *typeUnparenChecker) checkTypeExpr(x ast.Expr) {
 func (c *typeUnparenChecker) VisitTypeExpr(x ast.Expr) {
 	switch x := x.(type) {
 	case *ast.ParenExpr:
-		switch {
-		case astp.IsStructType(x.X):
+		switch x.X.(type) {
+		case *ast.StructType:
 			c.ctx.Warn(x, "could simplify (struct{...}) to struct{...}")
-		case astp.IsInterfaceType(x.X):
+		case *ast.InterfaceType:
 			c.ctx.Warn(x, "could simplify (interface{...}) to interface{...}")
 		default:
 			c.warn(x, c.unparenExpr(astcopy.Expr(x)))


### PR DESCRIPTION
Handle (*T)(...) properly.

Added tests to make sure that #258 is resolved.

Updates #258