### PR TITLE
lint: mark 4 checkers as experimental

### DIFF
--- a/lint/docStub_checker.go
+++ b/lint/docStub_checker.go
@@ -23,7 +23,7 @@ import (
 )
 
 func init() {
-	addChecker(&docStubChecker{}, attrSyntaxOnly)
+	addChecker(&docStubChecker{}, attrSyntaxOnly, attrExperimental)
 }
 
 type docStubChecker struct {

--- a/lint/ptrToRefParam_checker.go
+++ b/lint/ptrToRefParam_checker.go
@@ -18,7 +18,7 @@ import (
 )
 
 func init() {
-	addChecker(&ptrToRefParamChecker{})
+	addChecker(&ptrToRefParamChecker{}, attrExperimental)
 }
 
 type ptrToRefParamChecker struct {

--- a/lint/stdExpr_checker.go
+++ b/lint/stdExpr_checker.go
@@ -39,7 +39,7 @@ import (
 // For example: func(http.ResponseWriter, *http.Request) => http.HandlerFunc.
 
 func init() {
-	addChecker(&stdExprChecker{})
+	addChecker(&stdExprChecker{}, attrExperimental)
 }
 
 // mathConstant describes named constant value defined in "math" package.

--- a/lint/unexportedCall_checker.go
+++ b/lint/unexportedCall_checker.go
@@ -24,7 +24,7 @@ import (
 )
 
 func init() {
-	addChecker(&unexportedCallChecker{}, attrVeryOpinionated)
+	addChecker(&unexportedCallChecker{}, attrVeryOpinionated, attrExperimental)
 }
 
 type unexportedCallChecker struct {

--- a/lint/unnamedResult_checker.go
+++ b/lint/unnamedResult_checker.go
@@ -15,7 +15,7 @@ import (
 )
 
 func init() {
-	addChecker(&unnamedResultChecker{})
+	addChecker(&unnamedResultChecker{}, attrExperimental)
 }
 
 type unnamedResultChecker struct {


### PR DESCRIPTION
docStub, stdExpr, unexportedCall and unnamedResult
are marked with experimental attirbute until they
are better tested and their bugs are fixed.

Updates #300