### PR TITLE
cmd/makedocs: fix duplicated note sections

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -161,7 +161,6 @@ Go source code linter that brings checks that are currently not implemented in o
 </table>
 
 
-
 <a name="appendCombine-ref"></a>
 ## appendCombine
 Detects `append` chains to the same slice that can be done in a single `append` call.
@@ -182,8 +181,26 @@ xs = append(xs, 1, 2)
 ```
 
 
+<a name="boolFuncPrefix-ref"></a>
+## boolFuncPrefix
+Detects function returning only bool and suggests to add Is/Has/Contains prefix to it's name.
 
-<a name="builtinShadow-ref"></a>
+
+
+**Before:**
+```go
+func Enabled() bool
+
+```
+
+**After:**
+```go
+func IsEnabled() bool
+
+```
+
+
+`boolFuncPrefix` is very opinionated.<a name="builtinShadow-ref"></a>
 ## builtinShadow
 Detects when predeclared identifiers shadowed in assignments.
 
@@ -210,8 +227,7 @@ func main() {
 ```
 
 
-`builtinShadow` is syntax-only checker (fast).
-<a name="captLocal-ref"></a>
+`builtinShadow` is syntax-only checker (fast).<a name="captLocal-ref"></a>
 ## captLocal
 Detects capitalized names for local variables.
 
@@ -230,8 +246,7 @@ func f(in int, out *int) (err error) {}
 ```
 
 
-`captLocal` is syntax-only checker (fast).
-<a name="docStub-ref"></a>
+`captLocal` is syntax-only checker (fast).<a name="docStub-ref"></a>
 ## docStub
 Detects comments that silence go lint complaints about doc-comment.
 
@@ -257,8 +272,7 @@ func Foo() {
 > You can either remove a comment to let go lint find it or change stub to useful comment.
 > This checker makes it easier to detect stubs, the action is up to you.
 
-`docStub` is syntax-only checker (fast).
-<a name="elseif-ref"></a>
+`docStub` is syntax-only checker (fast).<a name="elseif-ref"></a>
 ## elseif
 Detects repeated if-else statements and suggests to replace them with switch statement.
 
@@ -292,8 +306,7 @@ default:
 ```
 
 
-`elseif` is syntax-only checker (fast).
-<a name="flagDeref-ref"></a>
+`elseif` is syntax-only checker (fast).<a name="flagDeref-ref"></a>
 ## flagDeref
 Detects immediate dereferencing of `flag` package pointers.
 
@@ -315,359 +328,7 @@ flag.BoolVar(&b, "b", false, "b docs")
 > Dereferencing returned pointers will lead to hard to find errors
 > where flag values are not updated after flag.Parse().
 
-`flagDeref` is syntax-only checker (fast).
-<a name="paramTypeCombine-ref"></a>
-## paramTypeCombine
-Detects if function parameters could be combined by type and suggest the way to do it.
-
-
-
-**Before:**
-```go
-func foo(a, b int, c, d int, e, f int, g int) {}
-
-```
-
-**After:**
-```go
-func foo(a, b, c, d, e, f, g int) {}
-
-```
-
-
-`paramTypeCombine` is syntax-only checker (fast).
-<a name="ptrToRefParam-ref"></a>
-## ptrToRefParam
-Detects input and output parameters that have a type of pointer to referential type.
-
-
-
-**Before:**
-```go
-func f(m *map[string]int) (ch *chan *int)
-
-```
-
-**After:**
-```go
-func f(m map[string]int) (ch chan *int)
-
-```
-
-> Slices are not as referential as maps or channels, but it's usually
-> better to return them by value rather than modyfing them by pointer.
-
-
-<a name="rangeExprCopy-ref"></a>
-## rangeExprCopy
-Detects expensive copies of `for` loop range expressions.
-
-Suggests to use pointer to array to avoid the copy using `&` on range expression.
-
-
-**Before:**
-```go
-var xs [256]byte
-for _, x := range xs {
-	// Loop body.
-}
-
-```
-
-**After:**
-```go
-var xs [256]byte
-for _, x := range &xs {
-	// Loop body.
-}
-
-```
-
-
-
-<a name="rangeValCopy-ref"></a>
-## rangeValCopy
-Detects loops that copy big objects during each iteration.
-
-
-
-**Before:**
-```go
-xs := make([][1024]byte, length)
-for _, x := range xs {
-	// Loop body.
-}
-
-```
-
-**After:**
-```go
-xs := make([][1024]byte, length)
-for i := range xs {
-	x := &xs[i]
-	// Loop body.
-}
-
-```
-
-
-
-<a name="singleCaseSwitch-ref"></a>
-## singleCaseSwitch
-Detects switch statements that could be better written as if statements.
-
-
-
-**Before:**
-```go
-switch x := x.(type) {
-case int:
-     ...
-}
-
-```
-
-**After:**
-```go
-if x, ok := x.(int); ok {
-   ...
-}
-
-```
-
-
-`singleCaseSwitch` is syntax-only checker (fast).
-<a name="stdExpr-ref"></a>
-## stdExpr
-Detects constant expressions that can be replaced by a named constant
-
-
-
-**Before:**
-```go
-intBytes := make([]byte, unsafe.Sizeof(0))
-maxVal := 1<<7 - 1
-
-```
-
-**After:**
-```go
-intBytes := make([]byte, bits.IntSize)
-maxVal := math.MaxInt8
-
-```
-
-
-
-<a name="switchTrue-ref"></a>
-## switchTrue
-Detects switch-over-bool statements that use explicit `true` tag value.
-
-
-
-**Before:**
-```go
-switch true {
-case x > y:
-	// ...
-}
-
-```
-
-**After:**
-```go
-switch {
-case x > y:
-	// ...
-}
-
-```
-
-
-`switchTrue` is syntax-only checker (fast).
-<a name="typeSwitchVar-ref"></a>
-## typeSwitchVar
-Detects type switches that can benefit from type guard clause with variable.
-
-
-
-**Before:**
-```go
-switch v.(type) {
-case int:
-	return v.(int)
-case point:
-	return v.(point).x + v.(point).y
-default:
-	return 0
-}
-
-```
-
-**After:**
-```go
-switch v := v.(type) {
-case int:
-	return v
-case point:
-	return v.x + v.y
-default:
-	return 0
-}
-
-```
-
-
-
-<a name="typeUnparen-ref"></a>
-## typeUnparen
-Detects unneded parenthesis inside type expressions and suggests to remove them.
-
-
-
-**Before:**
-```go
-func foo() [](func([](func()))) {
-     ...
-}
-
-```
-
-**After:**
-```go
-func foo() []func([]func()) {
-     ...
-}
-
-```
-
-
-`typeUnparen` is syntax-only checker (fast).
-<a name="underef-ref"></a>
-## underef
-Detects dereference expressions that can be omitted.
-
-
-
-**Before:**
-```go
-(*k).field = 5
-_ := (*a)[5] // only if a is array
-
-```
-
-**After:**
-```go
-k.field = 5
-_ := a[5]
-
-```
-
-
-
-<a name="unexportedCall-ref"></a>
-## unexportedCall
-Detects calls of unexported method from unexported type outside that type.
-
-
-
-**Before:**
-```go
-type foo struct{}
-func (f foo) bar() int { return 1 }
-func baz() {
-	var fo foo
-	fo.bar()
-}
-
-```
-
-**After:**
-```go
-type foo struct{}
-func (f foo) Bar() int { return 1 } // now Bar is exported
-func baz() {
-	var fo foo
-	fo.Bar()
-}
-
-```
-
-
-`unexportedCall` is very opinionated.
-<a name="unnamedResult-ref"></a>
-## unnamedResult
-For functions with multiple return values, detects unnamed results
-
-
-
-**Before:**
-```go
-func f() (float64, float64)
-
-```
-
-**After:**
-```go
-func f() (x, y float64)
-
-```
-
-
-
-<a name="unslice-ref"></a>
-## unslice
-Detects slice expressions that can be simplified to sliced expression itself.
-
-
-
-**Before:**
-```go
-f(s[:]) // s is string
-copy(b[:], values...) // b is []byte
-
-```
-
-**After:**
-```go
-f(s)
-copy(b, values...)
-
-```
-
-
-
-
-<a name="boolFuncPrefix-ref"></a>
-## boolFuncPrefix
-Detects function returning only bool and suggests to add Is/Has/Contains prefix to it's name.
-
-
-
-**Before:**
-```go
-func Enabled() bool
-
-```
-
-**After:**
-```go
-func IsEnabled() bool
-
-```
-
-`boolFuncPrefix` is very opinionated.
-
-
-> You can either remove a comment to let go lint find it or change stub to useful comment.
-> This checker makes it easier to detect stubs, the action is up to you.
-
-
-> Dereferencing returned pointers will lead to hard to find errors
-> where flag values are not updated after flag.Parse().
-
-
-<a name="importShadow-ref"></a>
+`flagDeref` is syntax-only checker (fast).<a name="importShadow-ref"></a>
 ## importShadow
 Detects when imported package names shadowed in assignments.
 
@@ -704,7 +365,6 @@ func main() {
 ```
 
 
-
 <a name="longChain-ref"></a>
 ## longChain
 Detects repeated expression chains and suggest to refactor them.
@@ -732,20 +392,312 @@ v := (a+x) + (b+x) + (c+x)
 ```
 
 
+<a name="paramTypeCombine-ref"></a>
+## paramTypeCombine
+Detects if function parameters could be combined by type and suggest the way to do it.
+
+
+
+**Before:**
+```go
+func foo(a, b int, c, d int, e, f int, g int) {}
+
+```
+
+**After:**
+```go
+func foo(a, b, c, d, e, f, g int) {}
+
+```
+
+
+`paramTypeCombine` is syntax-only checker (fast).<a name="ptrToRefParam-ref"></a>
+## ptrToRefParam
+Detects input and output parameters that have a type of pointer to referential type.
+
+
+
+**Before:**
+```go
+func f(m *map[string]int) (ch *chan *int)
+
+```
+
+**After:**
+```go
+func f(m map[string]int) (ch chan *int)
+
+```
 
 > Slices are not as referential as maps or channels, but it's usually
 > better to return them by value rather than modyfing them by pointer.
 
+<a name="rangeExprCopy-ref"></a>
+## rangeExprCopy
+Detects expensive copies of `for` loop range expressions.
+
+Suggests to use pointer to array to avoid the copy using `&` on range expression.
+
+
+**Before:**
+```go
+var xs [256]byte
+for _, x := range xs {
+	// Loop body.
+}
+
+```
+
+**After:**
+```go
+var xs [256]byte
+for _, x := range &xs {
+	// Loop body.
+}
+
+```
+
+
+<a name="rangeValCopy-ref"></a>
+## rangeValCopy
+Detects loops that copy big objects during each iteration.
 
 
 
+**Before:**
+```go
+xs := make([][1024]byte, length)
+for _, x := range xs {
+	// Loop body.
+}
+
+```
+
+**After:**
+```go
+xs := make([][1024]byte, length)
+for i := range xs {
+	x := &xs[i]
+	// Loop body.
+}
+
+```
+
+
+<a name="singleCaseSwitch-ref"></a>
+## singleCaseSwitch
+Detects switch statements that could be better written as if statements.
 
 
 
+**Before:**
+```go
+switch x := x.(type) {
+case int:
+     ...
+}
+
+```
+
+**After:**
+```go
+if x, ok := x.(int); ok {
+   ...
+}
+
+```
+
+
+`singleCaseSwitch` is syntax-only checker (fast).<a name="stdExpr-ref"></a>
+## stdExpr
+Detects constant expressions that can be replaced by a named constant
 
 
 
+**Before:**
+```go
+intBytes := make([]byte, unsafe.Sizeof(0))
+maxVal := 1<<7 - 1
 
+```
+
+**After:**
+```go
+intBytes := make([]byte, bits.IntSize)
+maxVal := math.MaxInt8
+
+```
+
+
+<a name="switchTrue-ref"></a>
+## switchTrue
+Detects switch-over-bool statements that use explicit `true` tag value.
+
+
+
+**Before:**
+```go
+switch true {
+case x > y:
+	// ...
+}
+
+```
+
+**After:**
+```go
+switch {
+case x > y:
+	// ...
+}
+
+```
+
+
+`switchTrue` is syntax-only checker (fast).<a name="typeSwitchVar-ref"></a>
+## typeSwitchVar
+Detects type switches that can benefit from type guard clause with variable.
+
+
+
+**Before:**
+```go
+switch v.(type) {
+case int:
+	return v.(int)
+case point:
+	return v.(point).x + v.(point).y
+default:
+	return 0
+}
+
+```
+
+**After:**
+```go
+switch v := v.(type) {
+case int:
+	return v
+case point:
+	return v.x + v.y
+default:
+	return 0
+}
+
+```
+
+
+<a name="typeUnparen-ref"></a>
+## typeUnparen
+Detects unneded parenthesis inside type expressions and suggests to remove them.
+
+
+
+**Before:**
+```go
+func foo() [](func([](func()))) {
+     ...
+}
+
+```
+
+**After:**
+```go
+func foo() []func([]func()) {
+     ...
+}
+
+```
+
+
+`typeUnparen` is syntax-only checker (fast).<a name="underef-ref"></a>
+## underef
+Detects dereference expressions that can be omitted.
+
+
+
+**Before:**
+```go
+(*k).field = 5
+_ := (*a)[5] // only if a is array
+
+```
+
+**After:**
+```go
+k.field = 5
+_ := a[5]
+
+```
+
+
+<a name="unexportedCall-ref"></a>
+## unexportedCall
+Detects calls of unexported method from unexported type outside that type.
+
+
+
+**Before:**
+```go
+type foo struct{}
+func (f foo) bar() int { return 1 }
+func baz() {
+	var fo foo
+	fo.bar()
+}
+
+```
+
+**After:**
+```go
+type foo struct{}
+func (f foo) Bar() int { return 1 } // now Bar is exported
+func baz() {
+	var fo foo
+	fo.Bar()
+}
+
+```
+
+
+`unexportedCall` is very opinionated.<a name="unnamedResult-ref"></a>
+## unnamedResult
+For functions with multiple return values, detects unnamed results
+
+
+
+**Before:**
+```go
+func f() (float64, float64)
+
+```
+
+**After:**
+```go
+func f() (x, y float64)
+
+```
+
+
+<a name="unslice-ref"></a>
+## unslice
+Detects slice expressions that can be simplified to sliced expression itself.
+
+
+
+**Before:**
+```go
+f(s[:]) // s is string
+copy(b[:], values...) // b is []byte
+
+```
+
+**After:**
+```go
+f(s)
+copy(b, values...)
+
+```
 
 
 <a name="unusedParam-ref"></a>

--- a/docs/templates/overview.md.tmpl
+++ b/docs/templates/overview.md.tmpl
@@ -40,7 +40,6 @@ Go source code linter that brings checks that are currently not implemented in o
 
 
 {{ range .Checkers -}}
-{{- if not .Experimental }}
 <a name=" {{- .Name -}} -ref"></a>
 ## {{ .Name }}
 {{ .ShortDescription -}}
@@ -64,34 +63,4 @@ Go source code linter that brings checks that are currently not implemented in o
 {{ if .VeryOpinionated -}}
   `{{.Name}}` is very opinionated.
 {{- end -}}
-{{ end -}}
-
-{{ end -}}
-
-{{ range .Checkers -}}
-{{- if .Experimental }}
-<a name=" {{- .Name -}} -ref"></a>
-## {{ .Name }}
-{{ .ShortDescription -}}
-
-{{ .Description }}
-
-**Before:**
-```go
-{{ .Before }}
-```
-
-**After:**
-```go
-{{ .After }}
-```
-
-{{ if .SyntaxOnly -}}
-  `{{.Name}}` is syntax-only checker (fast).
-{{- end -}}
-{{ if .VeryOpinionated -}}
-  `{{.Name}}` is very opinionated.
-{{- end -}}
-{{ end -}}
-{{ .Note }}
 {{ end -}}


### PR DESCRIPTION
Merged experimental+stable checkers into single
template loop. It's a good thing to split table
into 2 parts, but there is no such need for the
document body. Removes code duplication and fixes
issue with duplicated notes (at least it seems that way).

Not "Fixes" because I'm not 100% sure issue is defeated.
Updates #295