### PR TITLE
lint: handle any slices in unslice

### DIFF
--- a/cmd/gocritic/testdata/unslice/negative_tests.go
+++ b/cmd/gocritic/testdata/unslice/negative_tests.go
@@ -1,9 +1,42 @@
 package checker_test
 
+func sliceArray() {
+	var xs [3]int
+	_ = xs[:]
+}
+
 func noWarning() {
 	var s string
 
 	_ = s[1:]
 	_ = s[:1]
 	_ = s
+}
+
+func slicing() {
+	{
+		var xs []byte
+		var ys []byte
+		copy(xs[1:], ys[:2])
+	}
+	{
+		var xs []int
+		_ = xs[:len(xs)-1]
+	}
+	{
+		var xs [][]int
+		_ = xs[0][1:]
+	}
+	{
+		var xs []string
+		_ = xs[:0]
+	}
+	{
+		var xs []struct{}
+		_ = xs[0:]
+	}
+	{
+		var xs map[string][][]int
+		_ = xs["0"][0][:10]
+	}
 }

--- a/cmd/gocritic/testdata/unslice/positive_tests.go
+++ b/cmd/gocritic/testdata/unslice/positive_tests.go
@@ -1,8 +1,43 @@
 package checker_test
 
-func withWarning() {
+func dullStringSlicing() {
 	var s string
 
 	/// could simplify s[:] to s
 	_ = s[:]
+}
+
+func dullSlicing() {
+	{
+		var xs []byte
+		var ys []byte
+		/// could simplify xs[:] to xs
+		/// could simplify ys[:] to ys
+		copy(xs[:], ys[:])
+	}
+	{
+		var xs []int
+		/// could simplify xs[:] to xs
+		_ = xs[:]
+	}
+	{
+		var xs [][]int
+		/// could simplify xs[0][:] to xs[0]
+		_ = xs[0][:]
+	}
+	{
+		var xs []string
+		/// could simplify xs[:] to xs
+		_ = xs[:]
+	}
+	{
+		var xs []struct{}
+		/// could simplify xs[:] to xs
+		_ = xs[:]
+	}
+	{
+		var xs map[string][][]int
+		/// could simplify xs["0"][0][:] to xs["0"][0]
+		_ = xs["0"][0][:]
+	}
 }

--- a/lint/unslice_checker.go
+++ b/lint/unslice_checker.go
@@ -25,14 +25,15 @@ type unsliceChecker struct {
 
 func (c *unsliceChecker) VisitLocalExpr(expr ast.Expr) {
 	if expr, ok := expr.(*ast.SliceExpr); ok {
-		if expr.Low == nil && expr.High == nil {
-			typ := c.ctx.typesInfo.TypeOf(expr)
-			switch typ := typ.(type) {
-			case *types.Basic:
-				if typ.Kind() == types.String {
-					c.warn(expr)
-				}
-			}
+		// No need to worry about 3-index slicing,
+		// because it's only permitted if expr.High is not nil.
+		if expr.Low != nil || expr.High != nil {
+			return
+		}
+		switch c.ctx.typesInfo.TypeOf(expr.X).(type) {
+		case *types.Slice, *types.Basic:
+			// Basic kind catches strings, Slice cathes everything else.
+			c.warn(expr)
 		}
 	}
 }


### PR DESCRIPTION
Previously handled only string slicing.
Now works for arbitrary slice types.