### PR TITLE
cmd/criticize: replace GOPATH and GOROOT err loc prefix

### DIFF
--- a/cmd/criticize/main.go
+++ b/cmd/criticize/main.go
@@ -245,11 +245,12 @@ func (l *linter) checkFile(f *ast.File) {
 }
 
 func shortenLocation(loc string) string {
-	if strings.HasPrefix(loc, build.Default.GOPATH) {
+	switch {
+	case strings.HasPrefix(loc, build.Default.GOPATH):
 		return strings.Replace(loc, build.Default.GOPATH, "$GOPATH", 1)
-	}
-	if strings.HasPrefix(loc, build.Default.GOROOT) {
+	case strings.HasPrefix(loc, build.Default.GOROOT):
 		return strings.Replace(loc, build.Default.GOROOT, "$GOROOT", 1)
+	default:
+		return loc
 	}
-	return loc
 }

--- a/cmd/criticize/main.go
+++ b/cmd/criticize/main.go
@@ -3,6 +3,7 @@ package criticize
 import (
 	"flag"
 	"go/ast"
+	"go/build"
 	"go/parser"
 	"go/types"
 	"log"
@@ -30,9 +31,10 @@ type linter struct {
 
 	// Command line flags:
 
-	withOpinionated  bool
-	withExperimental bool
-	checkGenerated   bool
+	withOpinionated    bool
+	withExperimental   bool
+	checkGenerated     bool
+	shorterErrLocation bool
 
 	packages        []string
 	enabledCheckers []string
@@ -79,6 +81,8 @@ func parseArgv(l *linter) {
 		`exit code to be used when lint issues are found`)
 	flag.BoolVar(&l.checkGenerated, "checkGenerated", false,
 		`whether to check machine-generated files`)
+	flag.BoolVar(&l.shorterErrLocation, "shorterErrLocation", true,
+		`whether to replace error location prefix with $GOROOT and $GOPATH`)
 
 	flag.Parse()
 
@@ -229,10 +233,23 @@ func (l *linter) checkFile(f *ast.File) {
 
 			for _, warn := range c.Check(f) {
 				l.foundIssues = true
-				pos := l.ctx.FileSet().Position(warn.Node.Pos())
-				log.Printf("%s: %s: %v\n", pos, c.Rule, warn.Text)
+				loc := l.ctx.FileSet().Position(warn.Node.Pos()).String()
+				if l.shorterErrLocation {
+					loc = shortenLocation(loc)
+				}
+				log.Printf("%s: %s: %v\n", loc, c.Rule, warn.Text)
 			}
 		}(c)
 	}
 	wg.Wait()
+}
+
+func shortenLocation(loc string) string {
+	if strings.HasPrefix(loc, build.Default.GOPATH) {
+		return strings.Replace(loc, build.Default.GOPATH, "$GOPATH", 1)
+	}
+	if strings.HasPrefix(loc, build.Default.GOROOT) {
+		return strings.Replace(loc, build.Default.GOROOT, "$GOROOT", 1)
+	}
+	return loc
 }

--- a/cmd/lintwalk/main.go
+++ b/cmd/lintwalk/main.go
@@ -2,6 +2,7 @@ package lintwalk
 
 import (
 	"flag"
+	"fmt"
 	"go/build"
 	"log"
 	"os"
@@ -34,6 +35,7 @@ func Main() {
 	exclude := flag.String("exclude", "testdata/|vendor/|builtin/",
 		`regexp used to skip package names`)
 	checkGenerated := flag.Bool("checkGenerated", false, `forwarded to linter "as is"`)
+	shorterErrLocation := flag.Bool("shorterErrLocation", true, `forwarded to linter "as is"`)
 
 	flag.Parse()
 
@@ -83,12 +85,12 @@ func Main() {
 		log.Fatalf("walk src-root: %v", err)
 	}
 
-	var args []string
-	args = append(args, "check-package", "-enable", *enable)
-	if *checkGenerated {
-		args = append(args, "-checkGenerated")
+	args := []string{
+		"check-package",
+		"-enable", *enable,
+		"-checkGenerated=" + fmt.Sprint(*checkGenerated),
+		"-shorterErrLocation=" + fmt.Sprint(*shorterErrLocation),
 	}
-
 	for p := range packages {
 		args = append(args, p)
 	}


### PR DESCRIPTION
```
/blah/path/to/goroot/src/pkg/file.go:1:2
=>
$GOROOT/src/pkg/file.go:1:1

Same for $GOPATH.
This behavior can be surpressed with `-shorterErrLocation=false` flag.
```