### PR TITLE
lint: add regexpMust checker

### DIFF
--- a/cmd/gocritic/testdata/_sanity/tests.go
+++ b/cmd/gocritic/testdata/_sanity/tests.go
@@ -164,3 +164,19 @@ func (myString) noReceiverName1(a, b string) {}
 func (*myString) noReceiverName2() (a, b string) { return "", "" }
 
 var noInit1, noInit2 int
+
+func funcCalls() {
+	f0 := func() {}
+	f1 := func(x int) {}
+	f2 := func(x, y int) {}
+	f3 := func(x, y, z int) {}
+	fVariadic := func(xs ...int) {}
+
+	f0()
+	f1(1)
+	f2(1, 2)
+	f3(1, 2, 3)
+	fVariadic()
+	fVariadic(1, 2)
+	fVariadic([]int{1, 2}...)
+}

--- a/cmd/gocritic/testdata/regexpMust/negative_tests.go
+++ b/cmd/gocritic/testdata/regexpMust/negative_tests.go
@@ -1,0 +1,11 @@
+package checker_tests
+
+import "regexp"
+
+var anotherRE = regexp.MustCompile(`pat123`)
+
+func noWarnings() {
+	_ = regexp.MustCompile(`[0-9]+`)
+	_ = regexp.MustCompile(`go-critic linter`)
+	_ = regexp.MustCompilePOSIX(`go-critic linter`)
+}

--- a/cmd/gocritic/testdata/regexpMust/positive_tests.go
+++ b/cmd/gocritic/testdata/regexpMust/positive_tests.go
@@ -1,0 +1,20 @@
+package checker_tests
+
+import "regexp"
+
+/// for const patterns like `pat123`, use regexp.MustCompile
+var myRegexp, _ = regexp.Compile(`pat123`)
+
+func warnings() {
+	/// for const patterns like `[0-9]+`, use regexp.MustCompile
+	re, err := regexp.Compile(`[0-9]+`)
+	if err != nil {
+		panic(err)
+	}
+	_ = re
+
+	/// for const patterns like (`go-critic linter`), use regexp.MustCompile
+	_, _ = regexp.Compile((`go-critic linter`))
+	/// for const patterns like `go-critic linter`, use regexp.MustCompilePOSIX
+	_, _ = regexp.CompilePOSIX(`go-critic linter`)
+}

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -147,6 +147,12 @@ Go source code linter that brings checks that are currently not implemented in o
 </td>
       </tr>
       <tr>
+        <td><a href="#regexpMust-ref">regexpMust</a></td>
+        <td>Detects `regexp.Compile*` that can be replaced with `regexp.MustCompile*`.
+
+</td>
+      </tr>
+      <tr>
         <td><a href="#stdExpr-ref">stdExpr</a></td>
         <td>Detects constant expressions that can be replaced by a named constant
 
@@ -536,6 +542,25 @@ for i := range xs {
 	x := &xs[i]
 	// Loop body.
 }
+
+```
+
+
+<a name="regexpMust-ref"></a>
+## regexpMust
+Detects `regexp.Compile*` that can be replaced with `regexp.MustCompile*`.
+
+
+
+**Before:**
+```go
+re, _ := regexp.Compile(`const pattern`)
+
+```
+
+**After:**
+```go
+re := regexp.MustCompile(`const pattern`)
 
 ```
 

--- a/lint/regexpMust_checker.go
+++ b/lint/regexpMust_checker.go
@@ -1,0 +1,43 @@
+package lint
+
+//! Detects `regexp.Compile*` that can be replaced with `regexp.MustCompile*`.
+//
+// @Before:
+// re, _ := regexp.Compile(`const pattern`)
+//
+// @After:
+// re := regexp.MustCompile(`const pattern`)
+
+import (
+	"go/ast"
+	"strings"
+
+	"github.com/go-toolsmith/astp"
+	"golang.org/x/tools/go/ast/astutil"
+)
+
+func init() {
+	addChecker(&regexpMustChecker{}, attrExperimental)
+}
+
+type regexpMustChecker struct {
+	checkerBase
+}
+
+func (c *regexpMustChecker) VisitExpr(x ast.Expr) {
+	if x, ok := x.(*ast.CallExpr); ok {
+		switch name := qualifiedName(x.Fun); name {
+		case "regexp.Compile", "regexp.CompilePOSIX":
+			// Only check for trivial string args, permit parenthesis.
+			if !astp.IsBasicLit(astutil.Unparen(x.Args[0])) {
+				return
+			}
+			c.warn(x, strings.Replace(name, "Compile", "MustCompile", 1))
+		}
+	}
+}
+
+func (c *regexpMustChecker) warn(cause *ast.CallExpr, suggestion string) {
+	c.ctx.Warn(cause, "for const patterns like %s, use %s",
+		cause.Args[0], suggestion)
+}


### PR DESCRIPTION
At least for now, don't do same work as megacheck
and only suggest MustCompile|MustCompilePOSIX.

Fixes #209