### PR TITLE
lint: annotate yodaStylExpr with attrs + fix import

### DIFF
--- a/lint/yodaStyleExpr_checker.go
+++ b/lint/yodaStyleExpr_checker.go
@@ -12,12 +12,12 @@ import (
 	"go/ast"
 	"go/token"
 
-	"github.com/cristaloleg/astp"
 	"github.com/go-toolsmith/astcopy"
+	"github.com/go-toolsmith/astp"
 )
 
 func init() {
-	addChecker(&yodaStyleExprChecker{})
+	addChecker(&yodaStyleExprChecker{}, attrExperimental, attrVeryOpinionated)
 }
 
 type yodaStyleExprChecker struct {


### PR DESCRIPTION
- Use go-toolsmith version of astp.
- Add experimental + opinionated attrs.