### PR TITLE
lint/docStub: do not check unexported funcs, warn about XXX

### DIFF
--- a/cmd/gocritic/testdata/docStub/negative_tests.go
+++ b/cmd/gocritic/testdata/docStub/negative_tests.go
@@ -1,6 +1,6 @@
 package checker_test
 
 // Bar returns string.
-func Bar() {
+func Bar() {}
 
-}
+func foo() {}

--- a/cmd/gocritic/testdata/docStub/positive_tests.go
+++ b/cmd/gocritic/testdata/docStub/positive_tests.go
@@ -2,6 +2,12 @@ package checker_test
 
 // Foo ...
 /// silencing go lint doc-comment warnings is unadvised
-func Foo() {
+func Foo() {}
 
-}
+// Baz XXX.
+/// silencing go lint doc-comment warnings is unadvised
+func Baz() {}
+
+// Barr XXX
+/// silencing go lint doc-comment warnings is unadvised
+func Barr() {}

--- a/lint/docStub_checker.go
+++ b/lint/docStub_checker.go
@@ -33,12 +33,12 @@ type docStubChecker struct {
 }
 
 func (c *docStubChecker) Init() {
-	re := `//\s?\w+[^a-zA-Z]+$`
+	re := `//\s?\w+([^a-zA-Z]+|( XXX.?))$`
 	c.badCommentRE = regexp.MustCompile(re)
 }
 
 func (c *docStubChecker) VisitFuncDecl(decl *ast.FuncDecl) {
-	if decl.Doc != nil && c.badCommentRE.MatchString(decl.Doc.List[0].Text) {
+	if decl.Name.IsExported() && decl.Doc != nil && c.badCommentRE.MatchString(decl.Doc.List[0].Text) {
 		c.warn(decl)
 	}
 }


### PR DESCRIPTION
Fixes #261 