### PR TITLE
lint: add appendAssign checker

### DIFF
--- a/cmd/gocritic/testdata/appendAssign/negative_tests.go
+++ b/cmd/gocritic/testdata/appendAssign/negative_tests.go
@@ -1,0 +1,85 @@
+package checker_tests
+
+func normalAppends() {
+	var xs, ys []int
+
+	xs = append(xs, 1)
+	ys = append(ys, 1, 2)
+	xs = append(xs, ys[0], xs[0])
+}
+
+func permittedAppends() {
+	var xs, ys []int
+
+	// We're trying to detect `x = append(y, ...)` patterns
+	// where y is used instead of x by mistake, so lines below
+	// do not trigger a warning.
+
+	xs0 := append(xs, 1)
+	xs1 := append(xs, 1)
+	ys0 := append(ys, 1)
+
+	// Also permit to assign to "_".
+	_ = append(xs, xs0[0], xs1[1], ys0[0])
+
+	{
+		var m map[int][]int
+		xs := m[0]
+		m[0] = append(xs, 1)
+	}
+
+	// Sliced xs is still xs.
+	xs = append(xs[:0], 1)
+	xs = append(xs[:], 2)
+
+	// OK to use slice literals.
+	xs = append([]int{}, 1)
+	xs = append([]int{1, 2}, 1)
+
+	// Also OK to use slices returned by a function calls.
+	xs = append(*new([]int), 1)
+	*(new([]int)) = append(*(new([]int)), 1)
+
+	// This prepends ys to the xs. Common idiom.
+	xs = append(ys, xs...)
+	xs = append(ys, xs[1:]...)
+
+	// Scratch array idiom.
+	var scratch [10]int
+	xs = append(scratch[:], 1)
+	xs = append(scratch[1:5])
+
+	{
+		xs := &xs
+		*xs = append((*xs)[:], 1, 2)
+	}
+
+	var withSlices struct {
+		a []int
+		b []int
+	}
+	withSlices.a = append(withSlices.a, 1)
+	withSlices.b = append(withSlices.b, 1)
+
+	var xsMap map[string][]int
+	xsMap["10"] = append(xsMap["10"], 1, 2)
+}
+
+func appendNotInAssignment() {
+	var xs, ys []int
+
+	// These are somewhat weird, but has nothing
+	// to do with diagnostic this checker wants to perform.
+
+	var v1 = append(xs, 1)
+	var (
+		_  = 1
+		v2 = append(xs, v1[0])
+		v3 = append(v2[:], ys[0])
+	)
+	v4 := append(v3, xs[0])
+	{
+		v3 := append(v4, 1)
+		_ = v3
+	}
+}

--- a/cmd/gocritic/testdata/appendAssign/negative_tests.go
+++ b/cmd/gocritic/testdata/appendAssign/negative_tests.go
@@ -73,7 +73,6 @@ func appendNotInAssignment() {
 
 	var v1 = append(xs, 1)
 	var (
-		_  = 1
 		v2 = append(xs, v1[0])
 		v3 = append(v2[:], ys[0])
 	)

--- a/cmd/gocritic/testdata/appendAssign/positive_tests.go
+++ b/cmd/gocritic/testdata/appendAssign/positive_tests.go
@@ -1,0 +1,37 @@
+package checker_tests
+
+func suspeciousAppends() {
+	var xs []int
+	var ys []int
+
+	/// append result not assigned to the same slice
+	xs = append(ys, 1)
+	/// append result not assigned to the same slice
+	ys = append(xs, 1)
+
+	/// append result not assigned to the same slice
+	xs, xs[0] = append(ys, 1), ys[9]
+	/// append result not assigned to the same slice
+	ys, xs = append(ys, 1), append(ys[:])
+
+	var withSlices struct {
+		a []int
+		b []int
+	}
+	/// append result not assigned to the same slice
+	withSlices.a = append(withSlices.b, 1)
+	/// append result not assigned to the same slice
+	withSlices.b = append(withSlices.a, 1)
+
+	var xsMap map[string][]int
+	/// append result not assigned to the same slice
+	xsMap["10"] = append(xsMap["100"], 1, 2)
+
+	{
+		xs2 := xs
+		/// append result not assigned to the same slice
+		xs = append(xs2, 1)
+		/// append result not assigned to the same slice
+		xs2 = append(xs, 1)
+	}
+}

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -105,6 +105,12 @@ Go source code linter that brings checks that are currently not implemented in o
     <th>Short description</th>
   </tr>
       <tr>
+        <td><a href="#appendAssign-ref">appendAssign</a></td>
+        <td>Detects suspicious append result assignments.
+
+</td>
+      </tr>
+      <tr>
         <td><a href="#boolFuncPrefix-ref">boolFuncPrefix</a></td>
         <td>Detects function returning only bool and suggests to add Is/Has/Contains prefix to it's name.
 
@@ -195,6 +201,27 @@ Go source code linter that brings checks that are currently not implemented in o
 </td>
       </tr>
 </table>
+
+
+<a name="appendAssign-ref"></a>
+## appendAssign
+Detects suspicious append result assignments.
+
+
+
+**Before:**
+```go
+p.positives = append(p.negatives, x)
+p.negatives = append(p.negatives, y)
+
+```
+
+**After:**
+```go
+p.positives = append(p.positives, x)
+p.negatives = append(p.negatives, y)
+
+```
 
 
 <a name="appendCombine-ref"></a>
@@ -395,14 +422,14 @@ Detects usages of formatting functions without formatting arguments.
 **Before:**
 ```go
 fmt.Sprintf("whatever")
-fmt.Errorf("whereever")
+fmt.Errorf("wherever")
 
 ```
 
 **After:**
 ```go
 fmt.Sprint("whatever")
-errors.New("whereever")
+errors.New("wherever")
 
 ```
 

--- a/lint/appendAssign_checker.go
+++ b/lint/appendAssign_checker.go
@@ -1,0 +1,108 @@
+package lint
+
+//! Detects suspicious append result assignments.
+//
+// @Before:
+// p.positives = append(p.negatives, x)
+// p.negatives = append(p.negatives, y)
+//
+// @After:
+// p.positives = append(p.positives, x)
+// p.negatives = append(p.negatives, y)
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+
+	"github.com/go-toolsmith/astequal"
+	"github.com/go-toolsmith/astp"
+	"golang.org/x/tools/go/ast/astutil"
+)
+
+func init() {
+	addChecker(&appendAssignChecker{}, attrExperimental)
+}
+
+type appendAssignChecker struct {
+	checkerBase
+}
+
+func (c *appendAssignChecker) checkAssign(lhs, rhs ast.Expr) {
+	call, ok := rhs.(*ast.CallExpr)
+	if !ok || qualifiedName(call.Fun) != "append" {
+		return
+	}
+	c.checkAppend(lhs, call)
+}
+
+func (c *appendAssignChecker) VisitStmt(stmt ast.Stmt) {
+	assign, ok := stmt.(*ast.AssignStmt)
+	if !ok || assign.Tok != token.ASSIGN || len(assign.Lhs) != len(assign.Rhs) {
+		return
+	}
+	for i, rhs := range assign.Rhs {
+		call, ok := rhs.(*ast.CallExpr)
+		if !ok || qualifiedName(call.Fun) != "append" {
+			continue
+		}
+		c.checkAppend(assign.Lhs[i], call)
+	}
+}
+
+func (c *appendAssignChecker) matchSlices(cause ast.Node, x, y ast.Expr) {
+	if !astequal.Expr(x, astutil.Unparen(y)) {
+		c.warn(cause)
+	}
+}
+
+func (c *appendAssignChecker) checkAppend(x ast.Expr, call *ast.CallExpr) {
+	if call.Ellipsis != token.NoPos {
+		// Try to detect `xs = append(ys, xs...)` idiom.
+		for _, arg := range call.Args[1:] {
+			y := arg
+			if arg, ok := arg.(*ast.SliceExpr); ok {
+				y = arg.X
+			}
+			if astequal.Expr(x, y) {
+				return
+			}
+		}
+	}
+
+	switch x := x.(type) {
+	case *ast.Ident:
+		if x.Name == "_" {
+			return // Don't check assignments to blank ident
+		}
+	case *ast.IndexExpr:
+		if !astp.IsIndexExpr(call.Args[0]) {
+			// Most likely `m[k] = append(x, ...)`
+			// pattern, where x was retrieved by m[k] before.
+			//
+			// TODO: it's possible to record such map/slice reads
+			// and check whether it was done before this call.
+			// But for now, treat it like x belongs to m[k].
+			return
+		}
+	}
+
+	if id, ok := x.(*ast.Ident); ok && id.Name == "_" {
+		return // Don't check assignments to blank ident
+	}
+	switch y := call.Args[0].(type) {
+	case *ast.SliceExpr:
+		if _, ok := c.ctx.typesInfo.TypeOf(y.X).(*types.Array); ok {
+			// Arrays are frequently used as scratch storages.
+			return
+		}
+		c.matchSlices(call, x, y.X)
+	case *ast.IndexExpr, *ast.Ident, *ast.SelectorExpr:
+		c.matchSlices(call, x, y)
+	}
+
+}
+
+func (c *appendAssignChecker) warn(cause ast.Node) {
+	c.ctx.Warn(cause, "append result not assigned to the same slice")
+}

--- a/lint/appendAssign_checker.go
+++ b/lint/appendAssign_checker.go
@@ -28,14 +28,6 @@ type appendAssignChecker struct {
 	checkerBase
 }
 
-func (c *appendAssignChecker) checkAssign(lhs, rhs ast.Expr) {
-	call, ok := rhs.(*ast.CallExpr)
-	if !ok || qualifiedName(call.Fun) != "append" {
-		return
-	}
-	c.checkAppend(lhs, call)
-}
-
 func (c *appendAssignChecker) VisitStmt(stmt ast.Stmt) {
 	assign, ok := stmt.(*ast.AssignStmt)
 	if !ok || assign.Tok != token.ASSIGN || len(assign.Lhs) != len(assign.Rhs) {

--- a/lint/appendAssign_checker.go
+++ b/lint/appendAssign_checker.go
@@ -42,12 +42,6 @@ func (c *appendAssignChecker) VisitStmt(stmt ast.Stmt) {
 	}
 }
 
-func (c *appendAssignChecker) matchSlices(cause ast.Node, x, y ast.Expr) {
-	if !astequal.Expr(x, astutil.Unparen(y)) {
-		c.warn(cause)
-	}
-}
-
 func (c *appendAssignChecker) checkAppend(x ast.Expr, call *ast.CallExpr) {
 	if call.Ellipsis != token.NoPos {
 		// Try to detect `xs = append(ys, xs...)` idiom.
@@ -92,7 +86,12 @@ func (c *appendAssignChecker) checkAppend(x ast.Expr, call *ast.CallExpr) {
 	case *ast.IndexExpr, *ast.Ident, *ast.SelectorExpr:
 		c.matchSlices(call, x, y)
 	}
+}
 
+func (c *appendAssignChecker) matchSlices(cause ast.Node, x, y ast.Expr) {
+	if !astequal.Expr(x, astutil.Unparen(y)) {
+		c.warn(cause)
+	}
 }
 
 func (c *appendAssignChecker) warn(cause ast.Node) {


### PR DESCRIPTION
Detects suspicious assignments of append results.
Does recognize several popular slice/append idioms
to reduce the amount of false positives.

This kind of error may occur when append assignment being copy/pasted.