### PR TITLE
lint: handle init stmt inside if stmt properly in elseif checker

### DIFF
--- a/cmd/gocritic/testdata/elseif/negative_tests.go
+++ b/cmd/gocritic/testdata/elseif/negative_tests.go
@@ -25,3 +25,36 @@ func noWarnings() {
 	} else {
 	}
 }
+
+func ifelseWithInit() {
+	// Don't trigger on these due to init statements.
+
+	if true {
+	} else if false {
+	} else if x := 1; x > 0 {
+	} else {
+	}
+
+	if x := 0; x == 0 {
+	} else if y := 2; y != 0 {
+	} else if true {
+	}
+
+	if x := 0; x == 0 {
+		if true {
+		} else if false {
+		} else if x := 1; x > 0 {
+		} else {
+		}
+	} else if y := 2; y != 0 {
+		if x := 0; x == 0 {
+			if x := 0; x == 0 {
+			} else if y := 2; y != 0 {
+			} else if true {
+			}
+		} else if y := 2; y != 0 {
+		} else if true {
+		}
+	} else if true {
+	}
+}

--- a/lint/elseif_checker.go
+++ b/lint/elseif_checker.go
@@ -69,6 +69,9 @@ func (c *elseifChecker) countIfelseLen(stmt *ast.IfStmt) int {
 	for {
 		switch e := stmt.Else.(type) {
 		case *ast.IfStmt:
+			if e.Init != nil {
+				return 0 // Give up
+			}
 			// Else if.
 			stmt = e
 			count++


### PR DESCRIPTION
Give up if there are any init stmt inside else-if chain.

Fixed #311