### PR TITLE
lint: add namedConst checker

### DIFF
--- a/cmd/gocritic/testdata/namedConst/negative_tests.go
+++ b/cmd/gocritic/testdata/namedConst/negative_tests.go
@@ -1,0 +1,25 @@
+package checker_tests
+
+import (
+	"time"
+)
+
+func returnExpr() {
+	// The value is 2 (colorGreen), but it's an expression,
+	// not a raw value, so the programmer intention can be
+	// more intricate. To avoid false positives, leave these alone.
+	var _ color = 1 + 1
+	var _ color = colRed + colRed
+}
+
+func nonExistingValues() {
+	var _ color = 423
+	var _ color = 10 + 132
+}
+
+func constexpr() {
+	// This kind of usage is idiomatic.
+	// We should not suggest writing `time.Nanosecond * time.Second` here.
+	var x time.Duration = 1 * time.Second
+	var _ time.Duration = x / 100
+}

--- a/cmd/gocritic/testdata/namedConst/negative_tests.go
+++ b/cmd/gocritic/testdata/namedConst/negative_tests.go
@@ -4,7 +4,33 @@ import (
 	"time"
 )
 
-func returnExpr() {
+const (
+	untyped1 = "one"
+	untyped2 = "two"
+)
+
+type globalType int32
+
+func localConsts() {
+	// May consider checking for local const defs,
+	// but without proper index, it's going to be notoriously slow.
+
+	type localType int
+	const (
+		l1 localType  = 10
+		l2 globalType = 20
+	)
+	var _ localType = 10
+	var _ globalType = 20
+}
+
+func untypedConsts() {
+	_ = "one"
+	_ = "two"
+	_ = 0
+}
+
+func expression() {
 	// The value is 2 (colorGreen), but it's an expression,
 	// not a raw value, so the programmer intention can be
 	// more intricate. To avoid false positives, leave these alone.

--- a/cmd/gocritic/testdata/namedConst/positive_tests.go
+++ b/cmd/gocritic/testdata/namedConst/positive_tests.go
@@ -1,0 +1,63 @@
+package checker_tests
+
+import (
+	"time"
+)
+
+type color int
+
+const (
+	colDefault color = iota
+	colRed
+	colGreen
+	colBlue
+)
+
+func returnRaw1() color {
+	/// use colDefault instead of 0
+	return 0
+}
+
+func returnRaw2() time.Duration {
+	/// use time.Nanosecond instead of 1
+	return 1
+}
+
+func returnRaw4() color {
+	/// use colRed instead of 1
+	return 1
+}
+
+func conversions() {
+	// TODO: may want to include whole conversion to warning message.
+	// So, instead of 0, report color(0).
+
+	/// use colDefault instead of 0
+	_ = color(0)
+	/// use colRed instead of 1
+	_ = color(1)
+	/// use colGreen instead of 2
+	_ = color(2)
+	/// use colBlue instead of 3
+	_ = color(3)
+}
+
+func comparisons(x color) {
+	/// use colDefault instead of 0
+	if x == 0 {
+		panic("default?")
+	}
+
+	/// use colDefault instead of 0
+	if true || x == 0 {
+	}
+
+	switch x {
+	/// use colRed instead of 1
+	case 1:
+		panic("red?")
+	/// use colGreen instead of 2
+	case 2:
+		panic("green?")
+	}
+}

--- a/cmd/gocritic/testdata/namedConst/positive_tests.go
+++ b/cmd/gocritic/testdata/namedConst/positive_tests.go
@@ -13,19 +13,39 @@ const (
 	colBlue
 )
 
-func returnRaw1() color {
-	/// use colDefault instead of 0
-	return 0
-}
+type typename string
 
-func returnRaw2() time.Duration {
-	/// use time.Nanosecond instead of 1
-	return 1
-}
+const (
+	tnInt    typename = "int"
+	tnString typename = "string"
+)
 
-func returnRaw4() color {
-	/// use colRed instead of 1
-	return 1
+func rawReturn() {
+	_ = func() color {
+		/// use colDefault instead of 0
+		return 0
+	}
+
+	_ = func() time.Duration {
+		/// use time.Nanosecond instead of 1
+		return 1
+	}
+
+	_ = func() color {
+		/// use colRed instead of 1
+		return 1
+	}
+
+	_ = func() typename {
+		/// use tnInt instead of "int"
+		return "int"
+	}
+
+	_ = func() typename {
+		/// use tnInt instead of "int"
+		/// use tnString instead of "string"
+		return "int" + typename("/") + "string"
+	}
 }
 
 func conversions() {

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -159,6 +159,12 @@ Go source code linter that brings checks that are currently not implemented in o
 </td>
       </tr>
       <tr>
+        <td><a href="#namedConst-ref">namedConst</a></td>
+        <td>Detects literals that can be replaced with defined named const.
+
+</td>
+      </tr>
+      <tr>
         <td><a href="#ptrToRefParam-ref">ptrToRefParam</a></td>
         <td>Detects input and output parameters that have a type of pointer to referential type.
 
@@ -540,6 +546,26 @@ a := qwert + 1
 b := qwert + 2
 c := qwert + 3
 v := (a+x) + (b+x) + (c+x)
+
+```
+
+
+<a name="namedConst-ref"></a>
+## namedConst
+Detects literals that can be replaced with defined named const.
+
+
+
+**Before:**
+```go
+// pos has type of token.Pos.
+if pos != 0 {}
+
+```
+
+**After:**
+```go
+if pos != token.NoPos {}
 
 ```
 

--- a/lint/namedConst_checker.go
+++ b/lint/namedConst_checker.go
@@ -1,0 +1,93 @@
+package lint
+
+//! Detects literals that can be replaced with defined named const.
+//
+// @Before:
+// // pos has type of token.Pos.
+// if pos != 0 {}
+//
+// @After:
+// if pos != token.NoPos {}
+
+import (
+	"go/ast"
+	"go/constant"
+	"go/token"
+	"go/types"
+
+	"github.com/go-toolsmith/astp"
+)
+
+func init() {
+	addChecker(&namedConstChecker{}, attrExperimental)
+}
+
+type namedConstChecker struct {
+	checkerBase
+}
+
+func (c *namedConstChecker) EnterChilds(x ast.Node) bool {
+	if x, ok := x.(*ast.BinaryExpr); ok {
+		// TODO(quasilyte): figure out how to handle
+		// things like 1*time.Second without false
+		// positives without adhoc check and without
+		// introducing too much of false negatives.
+		return !c.isTimeExpr(x)
+	}
+	return true
+}
+
+func (c *namedConstChecker) isTimeExpr(x *ast.BinaryExpr) bool {
+	// The most sensible operations are:
+	//	N * time.X
+	//	timeExpr / N
+	if x.Op != token.MUL && x.Op != token.QUO {
+		return false
+	}
+	typ := c.ctx.typesInfo.TypeOf(x)
+	if typ == nil || typ.String() != "time.Duration" {
+		return false
+	}
+	return astp.IsBasicLit(x.X) || astp.IsBasicLit(x.Y)
+}
+
+func (c *namedConstChecker) VisitExpr(x ast.Expr) {
+	if !astp.IsBasicLit(x) {
+		return
+	}
+
+	tv, ok := c.ctx.typesInfo.Types[x]
+	if !ok {
+		return
+	}
+	named, ok := tv.Type.(*types.Named)
+	if !ok {
+		return
+	}
+	// This linear search is not efficient, but does not
+	// bite hard since only few expressions make it up to
+	// this point. May consider building an index though.
+	typObj := named.Obj()
+	top := typObj.Pkg().Scope()
+	for _, name := range top.Names() {
+		cv, ok := top.Lookup(name).(*types.Const)
+		if !ok {
+			continue
+		}
+		typ2, ok := cv.Type().(*types.Named)
+		if !ok || typ2.Obj() != typObj {
+			continue
+		}
+		if constant.Compare(tv.Value, token.EQL, cv.Val()) {
+			c.warn(x, tv.Value, cv)
+		}
+	}
+}
+
+func (c *namedConstChecker) warn(cause ast.Node, v constant.Value, named *types.Const) {
+	suggestion := named.Name()
+	if named.Pkg() != c.ctx.pkg {
+		suggestion = named.Pkg().Name() + "." + suggestion
+	}
+	c.ctx.Warn(cause, "use %s instead of %s", suggestion, v)
+}


### PR DESCRIPTION
Detects raw literal values that can be replaced
by already defined (and imported) named constant.

Fixes #215