### PR TITLE
docs/templates/overview: optimize for github pages

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,8 +1,8 @@
+## Checks overview
+
+This page describes checks supported by [go-critic](https://github.com/go-critic/go-critic) linter.
+
 [//]: # (This is generated file, please don't edit it yourself.)
-
-## Overview
-
-Go source code linter that brings checks that are currently not implemented in other linters.
 
 ## Checkers:
 

--- a/docs/templates/overview.md.tmpl
+++ b/docs/templates/overview.md.tmpl
@@ -1,8 +1,8 @@
+## Checks overview
+
+This page describes checks supported by [go-critic](https://github.com/go-critic/go-critic) linter.
+
 [//]: # (This is generated file, please don't edit it yourself.)
-
-## Overview
-
-Go source code linter that brings checks that are currently not implemented in other linters.
 
 ## Checkers:
 


### PR DESCRIPTION
Now rendered page has proper title.

It was an issue with comment that surpressed correct expected
behavior. Moved it below the title.

Fixes #164