### PR TITLE
lint: add caseOrder checker

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -123,6 +123,12 @@ This page describes checks supported by [go-critic](https://github.com/go-critic
 </td>
       </tr>
       <tr>
+        <td><a href="#caseOrder-ref">caseOrder</a></td>
+        <td>Detects erroneous case order inside switch statements.
+
+</td>
+      </tr>
+      <tr>
         <td><a href="#commentedOutCode-ref">commentedOutCode</a></td>
         <td>Detects commented-out code inside function bodies.
 
@@ -342,7 +348,35 @@ func f(in int, out *int) (err error) {}
 ```
 
 
-`captLocal` is syntax-only checker (fast).<a name="commentedOutCode-ref"></a>
+`captLocal` is syntax-only checker (fast).<a name="caseOrder-ref"></a>
+## caseOrder
+Detects erroneous case order inside switch statements.
+
+
+
+**Before:**
+```go
+switch x.(type) {
+case ast.Expr:
+	fmt.Println("expr")
+case *ast.BasicLit:
+	fmt.Println("basic lit") // Never executed
+}
+```
+
+**After:**
+```go
+switch x.(type) {
+case *ast.BasicLit:
+	fmt.Println("basic lit") // Now reachable
+case ast.Expr:
+	fmt.Println("expr")
+}
+
+```
+
+
+<a name="commentedOutCode-ref"></a>
 ## commentedOutCode
 Detects commented-out code inside function bodies.
 

--- a/lint/caseOrder_checker.go
+++ b/lint/caseOrder_checker.go
@@ -1,0 +1,84 @@
+package lint
+
+//! Detects erroneous case order inside switch statements.
+//
+// @Before:
+// switch x.(type) {
+// case ast.Expr:
+// 	fmt.Println("expr")
+// case *ast.BasicLit:
+// 	fmt.Println("basic lit") // Never executed
+// }
+//
+// @After:
+// switch x.(type) {
+// case *ast.BasicLit:
+// 	fmt.Println("basic lit") // Now reachable
+// case ast.Expr:
+// 	fmt.Println("expr")
+// }
+
+import (
+	"go/ast"
+	"go/types"
+)
+
+func init() {
+	addChecker(&caseOrderChecker{}, attrExperimental)
+}
+
+type caseOrderChecker struct {
+	checkerBase
+}
+
+func (c *caseOrderChecker) VisitStmt(stmt ast.Stmt) {
+	switch stmt := stmt.(type) {
+	case *ast.TypeSwitchStmt:
+		c.checkTypeSwitch(stmt)
+	case *ast.SwitchStmt:
+		c.checkSwitch(stmt)
+	}
+}
+
+func (c *caseOrderChecker) checkTypeSwitch(s *ast.TypeSwitchStmt) {
+	type ifaceType struct {
+		name string
+		typ  *types.Interface
+	}
+	var ifaces []ifaceType // Interfaces seen so far
+	for _, cc := range s.Body.List {
+		cc := cc.(*ast.CaseClause)
+		for _, x := range cc.List {
+			typ := c.ctx.typesInfo.TypeOf(x)
+			for _, iface := range ifaces {
+				if types.Implements(typ, iface.typ) {
+					c.warnTypeSwitch(cc, typ, iface.name)
+					break
+				}
+			}
+			if iface, ok := typ.Underlying().(*types.Interface); ok {
+				// Need to retrive object to get proper interface name.
+				name := "interface{}"
+				if obj := c.ctx.typesInfo.ObjectOf(identOf(x)); obj != nil {
+					name = obj.Name()
+				}
+				ifaces = append(ifaces, ifaceType{name: name, typ: iface})
+			}
+		}
+	}
+}
+
+func (c *caseOrderChecker) warnTypeSwitch(cause ast.Node, typ types.Type, iface string) {
+	concrete := types.TypeString(typ, func(p *types.Package) string {
+		if p == nil || p == c.ctx.pkg {
+			return ""
+		}
+		return p.Name()
+	})
+	c.ctx.Warn(cause, "case %s must go before the %s case", concrete, iface)
+}
+
+func (c *caseOrderChecker) checkSwitch(s *ast.SwitchStmt) {
+	// TODO(quasilyte): can handle expression cases that overlap.
+	// Cases that have narrower value range should go before wider ones.
+}

--- a/lint/testdata/caseOrder/negative_tests.go
+++ b/lint/testdata/caseOrder/negative_tests.go
@@ -1,0 +1,31 @@
+package checker_test
+
+type unimplemented interface {
+	dontImplementMe()
+}
+
+func goodTypeSwitches(x interface{}) {
+	// OK: good order.
+	switch x.(type) {
+	case myReader:
+	case *myReader:
+	case reader:
+	default:
+	}
+
+	// OK: good order.
+	switch x.(type) {
+	case *myReader:
+	case myReader:
+	case reader:
+	default:
+	}
+
+	// OK: interface is not implemented by latter cases.
+	switch x.(type) {
+	case unimplemented:
+	case myReader:
+	case *myReader:
+	case reader:
+	}
+}

--- a/lint/testdata/caseOrder/positive_tests.go
+++ b/lint/testdata/caseOrder/positive_tests.go
@@ -1,0 +1,41 @@
+package checker_test
+
+type reader interface {
+	Read([]byte) (int, error)
+}
+
+type myReader struct{}
+
+func (myReader) Read(_ []byte) (int, error) { return 0, nil }
+
+func typeSwitches(x interface{}) {
+	switch x.(type) {
+	case reader:
+	/// case myReader must go before the reader case
+	case myReader:
+	/// case *myReader must go before the reader case
+	case *myReader:
+	default:
+	}
+
+	switch x.(type) {
+	case interface{}:
+	/// case reader must go before the interface{} case
+	case reader:
+	/// case myReader must go before the interface{} case
+	case myReader:
+	/// case *myReader must go before the interface{} case
+	case *myReader:
+	default:
+	}
+
+	switch x.(type) {
+	case reader:
+	case interface{}:
+	/// case myReader must go before the reader case
+	case myReader:
+	/// case *myReader must go before the reader case
+	case *myReader:
+	default:
+	}
+}

--- a/lint/util.go
+++ b/lint/util.go
@@ -57,3 +57,29 @@ func findNode(root ast.Node, pred func(ast.Node) bool) ast.Node {
 	})
 	return found
 }
+
+// identOf returns identifier for x that can be used to obtain associated types.Object.
+// Returns nil for expressions that yield temporary results, like `f().field`.
+func identOf(x ast.Node) *ast.Ident {
+	switch x := x.(type) {
+	case *ast.Ident:
+		// Found ident.
+		return x
+	case *ast.TypeAssertExpr:
+		// x.(type) - x may contain ident.
+		return identOf(x.X)
+	case *ast.IndexExpr:
+		// x[i] - x may contain ident.
+		return identOf(x.X)
+	case *ast.SelectorExpr:
+		// x.y - x may contain ident.
+		return identOf(x.X)
+	case *ast.StarExpr:
+		// *x - x may contain ident.
+		return identOf(x.X)
+
+	default:
+		// Note that this function is not comprehensive.
+		return nil
+	}
+}


### PR DESCRIPTION
Detects potential issues in switch statement case clauses order.

Fixes #362