### PR TITLE
cmd/makedocs: check for doc comments formatting

### DIFF
--- a/cmd/makedocs/main.go
+++ b/cmd/makedocs/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"go/format"
 	"go/parser"
 	"go/token"
 	"io/ioutil"
@@ -102,6 +103,26 @@ func parseComment(text string, c *checker) {
 			log.Println(err)
 		}
 	}
+	validateSnippets(c)
+}
+
+func validateSnippets(c *checker) {
+	if want := gofmt(c.Before); want != c.Before {
+		log.Printf("%s @Before formatting mismatch:\nhave: %s\nwant: %s",
+			c.Name, c.Before, want)
+	}
+	if want := gofmt(c.After); want != c.After {
+		log.Printf("%s @After formatting mismatch:\nhave: %s\nwant: %s",
+			c.Name, c.After, want)
+	}
+}
+
+func gofmt(code string) string {
+	out, err := format.Source([]byte(code))
+	if err != nil {
+		return err.Error()
+	}
+	return string(out)
 }
 
 func parseShortDesc(lines []string, index *int, c *checker) error {

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -315,18 +315,18 @@ Detects when predeclared identifiers shadowed in assignments.
 **Before:**
 ```go
 func main() {
-    // shadowing len function
-    len := 10
-    println(len)
+	// shadowing len function
+	len := 10
+	println(len)
 }
 ```
 
 **After:**
 ```go
 func main() {
-    // change identificator name
-    length := 10
-    println(length)
+	// change identificator name
+	length := 10
+	println(length)
 }
 ```
 
@@ -426,14 +426,12 @@ Detects comments that silence go lint complaints about doc-comment.
 ```go
 // Foo ...
 func Foo() {
-     // ...
 }
 ```
 
 **After:**
 ```go
 func Foo() {
-     // ...
 }
 ```
 
@@ -562,29 +560,14 @@ Detects when imported package names shadowed in assignments.
 
 **Before:**
 ```go
-import (
-    "fmt"
-    "math"
-)
-func main() {
-    fmt.Println(math.Pi)
-    // shadowing math package
-    math := 10
-    fmt.Println(len)
+// "path/filepath" is imported.
+func myFunc(filepath string) {
 }
 ```
 
 **After:**
 ```go
-import (
-    "fmt"
-    "math"
-)
-func main() {
-    fmt.Println(math.Pi)
-    // change identificator name
-    value := 10
-    fmt.Println(value)
+func myFunc(filename string) {
 }
 ```
 
@@ -600,7 +583,7 @@ Detects repeated expression chains and suggest to refactor them.
 a := q.w.e.r.t + 1
 b := q.w.e.r.t + 2
 c := q.w.e.r.t + 3
-v := (a+xs[i+1]) + (b+xs[i+1]) + (c+xs[i+1])
+v := (a + xs[i+1]) + (b + xs[i+1]) + (c + xs[i+1])
 ```
 
 **After:**
@@ -610,7 +593,7 @@ qwert := q.w.e.r.t
 a := qwert + 1
 b := qwert + 2
 c := qwert + 3
-v := (a+x) + (b+x) + (c+x)
+v := (a + x) + (b + x) + (c + x)
 ```
 
 
@@ -623,12 +606,12 @@ Detects literals that can be replaced with defined named const.
 **Before:**
 ```go
 // pos has type of token.Pos.
-if pos != 0 {}
+return pos != 0
 ```
 
 **After:**
 ```go
-if pos != token.NoPos {}
+return pos != token.NoPos
 ```
 
 
@@ -641,19 +624,19 @@ Finds where nesting level could be reduced.
 **Before:**
 ```go
 for _, v := range a {
-   if v.Bool {
-       ...
-   }
+	if v.Bool {
+		body()
+	}
 }
 ```
 
 **After:**
 ```go
 for _, v := range a {
-   if ! v.Bool {
-       continue
-   }
-   ...
+	if !v.Bool {
+		continue
+	}
+	body()
 }
 ```
 
@@ -769,14 +752,14 @@ Detects switch statements that could be better written as if statements.
 ```go
 switch x := x.(type) {
 case int:
-     ...
+	body()
 }
 ```
 
 **After:**
 ```go
 if x, ok := x.(int); ok {
-   ...
+	body()
 }
 ```
 
@@ -862,16 +845,12 @@ Detects unneded parenthesis inside type expressions and suggests to remove them.
 
 **Before:**
 ```go
-func foo() [](func([](func()))) {
-     ...
-}
+type foo [](func([](func())))
 ```
 
 **After:**
 ```go
-func foo() []func([]func()) {
-     ...
-}
+type foo []func([]func())
 ```
 
 
@@ -902,21 +881,15 @@ Detects calls of unexported method from unexported type outside that type.
 
 **Before:**
 ```go
-type foo struct{}
-func (f foo) bar() int { return 1 }
-func baz() {
-	var fo foo
+func baz(f foo) {
 	fo.bar()
 }
 ```
 
 **After:**
 ```go
-type foo struct{}
-func (f foo) Bar() int { return 1 } // now Bar is exported
-func baz() {
-	var fo foo
-	fo.Bar()
+func baz(f foo) {
+	fo.Bar() // Made method exported
 }
 ```
 
@@ -946,7 +919,7 @@ Detects slice expressions that can be simplified to sliced expression itself.
 
 **Before:**
 ```go
-f(s[:]) // s is string
+f(s[:])               // s is string
 copy(b[:], values...) // b is []byte
 ```
 
@@ -982,12 +955,12 @@ Detects Yoda style expressions that suggest to replace them.
 
 **Before:**
 ```go
-if nil != ptr {}
+return nil != ptr
 ```
 
 **After:**
 ```go
-if ptr != nil {}
+return ptr != nil
 ```
 
 

--- a/lint/builtinShadow_checker.go
+++ b/lint/builtinShadow_checker.go
@@ -4,16 +4,16 @@ package lint
 //
 // @Before:
 // func main() {
-//     // shadowing len function
-//     len := 10
-//     println(len)
+// 	// shadowing len function
+// 	len := 10
+// 	println(len)
 // }
 //
 // @After:
 // func main() {
-//     // change identificator name
-//     length := 10
-//     println(length)
+// 	// change identificator name
+// 	length := 10
+// 	println(length)
 // }
 
 import (

--- a/lint/docStub_checker.go
+++ b/lint/docStub_checker.go
@@ -5,12 +5,10 @@ package lint
 // @Before:
 // // Foo ...
 // func Foo() {
-//      // ...
 // }
 //
 // @After:
 // func Foo() {
-//      // ...
 // }
 //
 // @Note:

--- a/lint/importShadow_checker.go
+++ b/lint/importShadow_checker.go
@@ -3,27 +3,12 @@ package lint
 //! Detects when imported package names shadowed in assignments.
 //
 // @Before:
-// import (
-//     "fmt"
-//     "math"
-// )
-// func main() {
-//     fmt.Println(math.Pi)
-//     // shadowing math package
-//     math := 10
-//     fmt.Println(len)
+// // "path/filepath" is imported.
+// func myFunc(filepath string) {
 // }
 //
 // @After:
-// import (
-//     "fmt"
-//     "math"
-// )
-// func main() {
-//     fmt.Println(math.Pi)
-//     // change identificator name
-//     value := 10
-//     fmt.Println(value)
+// func myFunc(filename string) {
 // }
 
 import (

--- a/lint/longChain_checker.go
+++ b/lint/longChain_checker.go
@@ -6,7 +6,7 @@ package lint
 // a := q.w.e.r.t + 1
 // b := q.w.e.r.t + 2
 // c := q.w.e.r.t + 3
-// v := (a+xs[i+1]) + (b+xs[i+1]) + (c+xs[i+1])
+// v := (a + xs[i+1]) + (b + xs[i+1]) + (c + xs[i+1])
 //
 // @After:
 // x := xs[i+1]
@@ -14,7 +14,7 @@ package lint
 // a := qwert + 1
 // b := qwert + 2
 // c := qwert + 3
-// v := (a+x) + (b+x) + (c+x)
+// v := (a + x) + (b + x) + (c + x)
 
 import (
 	"go/ast"

--- a/lint/namedConst_checker.go
+++ b/lint/namedConst_checker.go
@@ -4,10 +4,10 @@ package lint
 //
 // @Before:
 // // pos has type of token.Pos.
-// if pos != 0 {}
+// return pos != 0
 //
 // @After:
-// if pos != token.NoPos {}
+// return pos != token.NoPos
 
 import (
 	"go/ast"

--- a/lint/nestingReduce_checker.go
+++ b/lint/nestingReduce_checker.go
@@ -6,17 +6,17 @@ import "go/ast"
 //
 // @Before:
 // for _, v := range a {
-//    if v.Bool {
-//        ...
-//    }
+// 	if v.Bool {
+// 		body()
+// 	}
 // }
 //
 // @After:
 // for _, v := range a {
-//    if ! v.Bool {
-//        continue
-//    }
-//    ...
+// 	if !v.Bool {
+// 		continue
+// 	}
+// 	body()
 // }
 
 func init() {

--- a/lint/singleCaseSwitch_checker.go
+++ b/lint/singleCaseSwitch_checker.go
@@ -5,12 +5,12 @@ package lint
 // @Before:
 // switch x := x.(type) {
 // case int:
-//      ...
+// 	body()
 // }
 //
 // @After:
 // if x, ok := x.(int); ok {
-//    ...
+// 	body()
 // }
 
 import (

--- a/lint/typeUnparen_checker.go
+++ b/lint/typeUnparen_checker.go
@@ -3,14 +3,10 @@ package lint
 //! Detects unneded parenthesis inside type expressions and suggests to remove them.
 //
 // @Before:
-// func foo() [](func([](func()))) {
-//      ...
-// }
+// type foo [](func([](func())))
 //
 // @After:
-// func foo() []func([]func()) {
-//      ...
-// }
+// type foo []func([]func())
 
 import (
 	"go/ast"

--- a/lint/unexportedCall_checker.go
+++ b/lint/unexportedCall_checker.go
@@ -3,19 +3,13 @@ package lint
 //! Detects calls of unexported method from unexported type outside that type.
 //
 // @Before:
-// type foo struct{}
-// func (f foo) bar() int { return 1 }
-// func baz() {
-// 	var fo foo
+// func baz(f foo) {
 // 	fo.bar()
 // }
 //
 // @After:
-// type foo struct{}
-// func (f foo) Bar() int { return 1 } // now Bar is exported
-// func baz() {
-// 	var fo foo
-// 	fo.Bar()
+// func baz(f foo) {
+// 	fo.Bar() // Made method exported
 // }
 
 import (

--- a/lint/unslice_checker.go
+++ b/lint/unslice_checker.go
@@ -3,7 +3,7 @@ package lint
 //! Detects slice expressions that can be simplified to sliced expression itself.
 //
 // @Before:
-// f(s[:]) // s is string
+// f(s[:])               // s is string
 // copy(b[:], values...) // b is []byte
 //
 // @After:

--- a/lint/yodaStyleExpr_checker.go
+++ b/lint/yodaStyleExpr_checker.go
@@ -3,10 +3,10 @@ package lint
 //! Detects Yoda style expressions that suggest to replace them.
 //
 // @Before:
-// if nil != ptr {}
+// return nil != ptr
 //
 // @After:
-// if ptr != nil {}
+// return ptr != nil
 
 import (
 	"go/ast"


### PR DESCRIPTION
Using gofmt to validate code snippets formatting.

Fixes #378