### PR TITLE
lint/underef ignore pointer on interface

### DIFF
--- a/lint/testdata/underef/negative_tests.go
+++ b/lint/testdata/underef/negative_tests.go
@@ -28,3 +28,13 @@ type myString string
 func convertPtr(x string) *myString {
 	return (*myString)(&x)
 }
+
+type myInterface interface {
+	f()
+}
+
+func interfacePtr() {
+	var val myInterface
+	ptrInterface := &val
+	(*(ptrInterface)).f()
+}

--- a/lint/underef_checker.go
+++ b/lint/underef_checker.go
@@ -74,8 +74,13 @@ func (c *underefChecker) checkStarExpr(expr *ast.StarExpr) bool {
 		return false
 	}
 
+	el := typ.Elem()
 	// Checks if dereference of typ is pointer.
-	if _, ok := typ.Elem().(*types.Pointer); ok {
+	if _, ok := el.(*types.Pointer); ok {
+		return false
+	}
+	// Check if dereference of typ is interface.
+	if _, ok := el.Underlying().(*types.Interface); ok {
 		return false
 	}
 


### PR DESCRIPTION
    Pointer on interface show a warning from underef linter, but following
    the advice doesn't produce valid code.