### PR TITLE
lint/ptrToRefParam add interface

### DIFF
--- a/lint/ptrToRefParam_checker.go
+++ b/lint/ptrToRefParam_checker.go
@@ -52,12 +52,15 @@ func (c *ptrToRefParamChecker) checkParams(params []*ast.Field) {
 }
 
 func (c *ptrToRefParamChecker) isRefType(x types.Type) bool {
-	switch x.(type) {
-	case *types.Map, *types.Chan, *types.Slice:
+	switch typ := x.(type) {
+	case *types.Map, *types.Chan, *types.Slice, *types.Interface:
 		return true
-	default:
-		return false
+	case *types.Named:
+		if _, ok := typ.Underlying().(*types.Interface); ok {
+			return true
+		}
 	}
+	return false
 }
 
 func (c *ptrToRefParamChecker) warn(id *ast.Ident) {

--- a/lint/testdata/ptrToRefParam/positive_tests.go
+++ b/lint/testdata/ptrToRefParam/positive_tests.go
@@ -34,3 +34,27 @@ func f6(c int, a, b *chan string) {}
 func f7() (a, b *chan string) {
 	return nil, nil
 }
+
+/// consider `a' to be of non-pointer type
+/// consider `b' to be of non-pointer type
+func f8(a, b *interface{}) {}
+
+/// consider `a' to be of non-pointer type
+/// consider `b' to be of non-pointer type
+func f9() (a, b *interface{}) {
+	return nil, nil
+}
+
+type myInterface interface {
+	f()
+}
+
+/// consider `a' to be of non-pointer type
+/// consider `b' to be of non-pointer type
+func f10(a, b *myInterface) {}
+
+/// consider `a' to be of non-pointer type
+/// consider `b' to be of non-pointer type
+func f11() (a, b *myInterface) {
+	return nil, nil
+}


### PR DESCRIPTION
interface{} and named interfaces like chan, map, slice are referential
type.

Interface are implemented as struct containing a pointer to the itab
and a pointer to the underlying struct or ptr to struct implementing 
the interface.

This PR is linked to #380 in a sense, but could be view independently.