### PR TITLE
lint: use types.Object in indexOnlyLoop

### DIFF
--- a/lint/testdata/indexOnlyLoop/negative_tests.go
+++ b/lint/testdata/indexOnlyLoop/negative_tests.go
@@ -54,3 +54,11 @@ func rangeOverString() {
 		f(ch)
 	}
 }
+
+func shadowed() {
+	var xs []*string
+	for k := range xs {
+		var xs []int
+		println(xs[k] + xs[k])
+	}
+}

--- a/lint/testdata/indexOnlyLoop/positive_tests.go
+++ b/lint/testdata/indexOnlyLoop/positive_tests.go
@@ -1,23 +1,36 @@
 package checker_test
 
-func closeFiles(files []*string) {
-	f := func(s *string) {}
+func closeFile(f *string) {}
 
-	/// key variable occurs more then once in the loop; consider using for _, value := range files
+func closeFiles(files []*string) {
+	/// i occurs more than once in the loop; consider using for _, value := range files
 	for i := range files {
 		if files[i] != nil {
-			f(files[i])
+			closeFile(files[i])
 		}
 	}
 }
 
 func sliceLoop(files []*string) {
-	f := func(s *string) {}
-
-	/// key variable occurs more then once in the loop; consider using for _, value := range files
+	/// k occurs more than once in the loop; consider using for _, value := range files
 	for k := range files[:] {
 		if files[k] != nil {
-			f(files[k])
+			closeFile(files[k])
+		}
+	}
+}
+
+func nestedLoop(files []*string) {
+	/// k occurs more than once in the loop; consider using for _, value := range files
+	for k := range files[:] {
+		if files[k] != nil {
+			closeFile(files[k])
+		}
+
+		var xs []*int
+		/// j occurs more than once in the loop; consider using for _, value := range xs
+		for j := range xs {
+			println(*xs[j] + *xs[j])
 		}
 	}
 }

--- a/lint/util.go
+++ b/lint/util.go
@@ -77,9 +77,18 @@ func identOf(x ast.Node) *ast.Ident {
 	case *ast.StarExpr:
 		// *x - x may contain ident.
 		return identOf(x.X)
+	case *ast.SliceExpr:
+		// x[:] - x may contain ident.
+		return identOf(x.X)
 
 	default:
 		// Note that this function is not comprehensive.
 		return nil
 	}
+}
+
+// typeIsPointer reports whether typ has type of *types.Pointer.
+func typeIsPointer(typ types.Type) bool {
+	_, ok := typ.(*types.Pointer)
+	return ok
 }


### PR DESCRIPTION
Replaces usages of ast.Object with types.Object.