### PR TITLE
lint: teach boolExprSimplify to recognize combined comparisons

### DIFF
--- a/lint/boolExprSimplify_checker.go
+++ b/lint/boolExprSimplify_checker.go
@@ -56,6 +56,7 @@ func (c *boolExprSimplifyChecker) simplifyBool(x ast.Expr) ast.Expr {
 		return c.doubleNegation(cur) ||
 			c.negatedEquals(cur) ||
 			c.invertComparison(cur) ||
+			c.combineChecks(cur) ||
 			true
 	}).(ast.Expr)
 }
@@ -114,6 +115,38 @@ func (c *boolExprSimplifyChecker) invertComparison(cur *astutil.Cursor) bool {
 	return true
 }
 
+func (c *boolExprSimplifyChecker) combineChecks(cur *astutil.Cursor) bool {
+	or := c.logicalOr(cur.Node())
+	lhs := c.binaryExpr(astutil.Unparen(or.X))
+	rhs := c.binaryExpr(astutil.Unparen(or.Y))
+
+	if !astequal.Expr(lhs.X, rhs.X) || !astequal.Expr(lhs.Y, rhs.Y) {
+		return false
+	}
+	if !isSafeExpr(lhs.X) || !isSafeExpr(lhs.Y) {
+		return false
+	}
+
+	combTable := [...]struct {
+		x      token.Token
+		y      token.Token
+		result token.Token
+	}{
+		{token.GTR, token.EQL, token.GEQ},
+		{token.EQL, token.GTR, token.GEQ},
+		{token.LSS, token.EQL, token.LEQ},
+		{token.EQL, token.LSS, token.LEQ},
+	}
+	for _, comb := range combTable {
+		if comb.x == lhs.Op && comb.y == rhs.Op {
+			lhs.Op = comb.result
+			cur.Replace(lhs)
+			return true
+		}
+	}
+	return false
+}
+
 // binaryExpr coerces x into binary expr if possible,
 // otherwise returns c.nilBinaryExpr.
 func (c *boolExprSimplifyChecker) binaryExpr(x ast.Node) *ast.BinaryExpr {
@@ -132,6 +165,14 @@ func (c *boolExprSimplifyChecker) unaryNot(x ast.Node) *ast.UnaryExpr {
 		return c.nilUnaryExpr
 	}
 	return neg
+}
+
+func (c *boolExprSimplifyChecker) logicalOr(x ast.Node) *ast.BinaryExpr {
+	or, ok := x.(*ast.BinaryExpr)
+	if !ok || or.Op != token.LOR {
+		return c.nilBinaryExpr
+	}
+	return or
 }
 
 func (c *boolExprSimplifyChecker) warn(cause, suggestion ast.Expr) {

--- a/lint/boolExprSimplify_checker.go
+++ b/lint/boolExprSimplify_checker.go
@@ -137,7 +137,7 @@ func (c *boolExprSimplifyChecker) combineChecks(cur *astutil.Cursor) bool {
 		{token.LSS, token.EQL, token.LEQ},
 		{token.EQL, token.LSS, token.LEQ},
 	}
-	for _, comb := range combTable {
+	for _, comb := range &combTable {
 		if comb.x == lhs.Op && comb.y == rhs.Op {
 			lhs.Op = comb.result
 			cur.Replace(lhs)

--- a/lint/testdata/boolExprSimplify/negative_tests.go
+++ b/lint/testdata/boolExprSimplify/negative_tests.go
@@ -16,3 +16,27 @@ func otherBinOps() {
 	_ = true && false
 	_ = true || false
 }
+
+func cantCombine() {
+	fn := func() int { return 0 }
+
+	var x, y, z int
+
+	// OK: not safe expressions.
+	_ = fn() > y || fn() == y
+	_ = fn() == y || fn() > y
+	_ = x > fn() || x == fn()
+	_ = x == fn() || x > fn()
+	_ = fn() > fn() || fn() == fn()
+	_ = fn() == fn() || fn() > fn()
+
+	// OK: different operands.
+	_ = x > y || x == z
+	_ = x == z || x > y
+	_ = x > z || x == y
+	_ = x == y || x > z
+
+	// OK: unrelated operations.
+	_ = x < y || x > z
+	_ = x > z || x < y
+}

--- a/lint/testdata/boolExprSimplify/positive_tests.go
+++ b/lint/testdata/boolExprSimplify/positive_tests.go
@@ -4,6 +4,30 @@ var (
 	x, y, z bool
 )
 
+func combineChecks() {
+	var x, y int
+
+	/// can simplify `x > y || x == y` to `x >= y`
+	_ = x > y || x == y
+	/// can simplify `x == y || x > y` to `x >= y`
+	_ = x == y || x > y
+
+	/// can simplify `(x > y) || (x == y)` to `x >= y`
+	_ = (x > y) || (x == y)
+	/// can simplify `(x == y) || (x > y)` to `x >= y`
+	_ = (x == y) || (x > y)
+
+	/// can simplify `x < y || x == y` to `x <= y`
+	_ = x < y || x == y
+	/// can simplify `x == y || x < y` to `x <= y`
+	_ = x == y || x < y
+
+	/// can simplify `(x < y) || (x == y)` to `x <= y`
+	_ = (x < y) || (x == y)
+	/// can simplify `(x == y) || (x < y)` to `x <= y`
+	_ = (x == y) || (x < y)
+}
+
 func doubleNegation() {
 	/// can simplify `!!x` to `x`
 	_ = !!x


### PR DESCRIPTION
```
Added rules include:
	x > y || x == y => x >= y
	x < y || x == y => x <= y

Plus their inverted lhs/rhs forms.
```