### PR TITLE
lint: simplify underefChecker.checkStarExpr method

### DIFF
--- a/lint/testdata/underef/negative_tests.go
+++ b/lint/testdata/underef/negative_tests.go
@@ -38,3 +38,7 @@ func interfacePtr() {
 	ptrInterface := &val
 	(*(ptrInterface)).f()
 }
+
+func withUnderlyingPtrOK(p underlyingPtr) {
+	_ = p.field
+}

--- a/lint/testdata/underef/positive_tests.go
+++ b/lint/testdata/underef/positive_tests.go
@@ -42,3 +42,10 @@ func sampleCase3() {
 	/// could simplify (*k)[2] to k[2]
 	(*k)[2] = 3
 }
+
+type underlyingPtr *sampleStruct
+
+func withUnderlyingPtr(p underlyingPtr) {
+	/// could simplify (*p).field to p.field
+	_ = (*p).field
+}

--- a/lint/underef_checker.go
+++ b/lint/underef_checker.go
@@ -68,23 +68,17 @@ func (c *underefChecker) warnArray(expr *ast.IndexExpr) {
 
 // checkStarExpr checks if ast.StarExpr could be simplified.
 func (c *underefChecker) checkStarExpr(expr *ast.StarExpr) bool {
-	// Checks if expr is pointer type.
 	typ, ok := c.ctx.typesInfo.TypeOf(expr.X).(*types.Pointer)
 	if !ok {
 		return false
 	}
 
-	el := typ.Elem()
-	// Checks if dereference of typ is pointer.
-	if _, ok := el.(*types.Pointer); ok {
+	switch typ.Elem().Underlying().(type) {
+	case *types.Pointer, *types.Interface:
 		return false
+	default:
+		return true
 	}
-	// Check if dereference of typ is interface.
-	if _, ok := el.Underlying().(*types.Interface); ok {
-		return false
-	}
-
-	return true
 }
 
 func (c *underefChecker) checkArray(expr *ast.StarExpr) bool {

--- a/lint/underef_checker.go
+++ b/lint/underef_checker.go
@@ -68,7 +68,7 @@ func (c *underefChecker) warnArray(expr *ast.IndexExpr) {
 
 // checkStarExpr checks if ast.StarExpr could be simplified.
 func (c *underefChecker) checkStarExpr(expr *ast.StarExpr) bool {
-	typ, ok := c.ctx.typesInfo.TypeOf(expr.X).(*types.Pointer)
+	typ, ok := c.ctx.typesInfo.TypeOf(expr.X).Underlying().(*types.Pointer)
 	if !ok {
 		return false
 	}


### PR DESCRIPTION
Re-write 2 if statements with a single type switch.