### PR TITLE
lint/emptyFmt: add case for pkg/errors.Wrapf

### DIFF
--- a/lint/emptyFmt_checker.go
+++ b/lint/emptyFmt_checker.go
@@ -45,8 +45,11 @@ func (c *emptyFmtChecker) VisitExpr(expr ast.Expr) {
 			c.warn(call, "errors.New")
 		}
 	case 2:
-		if name == "fmt.Fprintf" {
+		switch name {
+		case "fmt.Fprintf":
 			c.warn(call, "fmt.Fprint")
+		case "errors.Wrapf":
+			c.warn(call, "errors.Wrap")
 		}
 	}
 }

--- a/lint/testdata/emptyFmt/negative_tests.go
+++ b/lint/testdata/emptyFmt/negative_tests.go
@@ -3,6 +3,8 @@ package checker_test
 import (
 	"fmt"
 	"log"
+
+	"github.com/pkg/errors"
 )
 
 func g1() {
@@ -13,4 +15,6 @@ func g1() {
 	_ = fmt.Errorf("%s", "whereever")
 
 	log.Printf("%s", "whenever")
+
+	errors.Wrapf(nil, "%s", "however")
 }

--- a/lint/testdata/emptyFmt/positive_tests.go
+++ b/lint/testdata/emptyFmt/positive_tests.go
@@ -3,6 +3,8 @@ package checker_test
 import (
 	"fmt"
 	"log"
+
+	"github.com/pkg/errors"
 )
 
 func f() {
@@ -23,4 +25,7 @@ func f() {
 
 	/// consider to change function to log.Fatal
 	log.Fatalf("oh :(")
+
+	/// consider to change function to errors.Wrap
+	errors.Wrapf(nil, "kernel panic")
 }


### PR DESCRIPTION
Adding case for this func https://godoc.org/github.com/pkg/errors#Wrapf