### PR TITLE
lint: don't warn on balanced if-else in elseif checker

### DIFF
--- a/lint/testdata/elseif/negative_tests.go
+++ b/lint/testdata/elseif/negative_tests.go
@@ -5,6 +5,18 @@ func simpleIf() {
 	}
 }
 
+func balanced() {
+	if true {
+		if true {
+			println("1")
+		}
+	} else {
+		if false {
+			println("2")
+		}
+	}
+}
+
 func properElseIf() {
 	var cond1, cond2 bool
 


### PR DESCRIPTION
Change default behavior not to warn on balanced statements.

A balanced if statement is a one where both branches
contain if statement, like in example below:

```go
	if cond {
		if x == 1 {
		}
	} else {
		if x == 2 {
		}
	}
```

gocritic can be instructed to warn on these too by changing
skipBalanced value to false.

Fixes #420 