### PR TITLE
lint: make sizeThreshold configurable

### DIFF
--- a/lint/rangeExprCopy_checker.go
+++ b/lint/rangeExprCopy_checker.go
@@ -11,6 +11,8 @@ func init() {
 
 type rangeExprCopyChecker struct {
 	checkerBase
+
+	sizeThreshold int64
 }
 
 func (c *rangeExprCopyChecker) InitDocumentation(d *Documentation) {
@@ -26,6 +28,10 @@ var xs [256]byte
 for _, x := range &xs {
 	// Loop body.
 }`
+}
+
+func (c *rangeExprCopyChecker) Init() {
+	c.sizeThreshold = int64(c.ctx.params.Int("sizeThreshold", 96))
 }
 
 func (c *rangeExprCopyChecker) EnterFunc(fn *ast.FuncDecl) bool {
@@ -44,8 +50,7 @@ func (c *rangeExprCopyChecker) VisitStmt(stmt ast.Stmt) {
 	if _, ok := tv.Type.(*types.Array); !ok {
 		return
 	}
-	const sizeThreshold = 96 // Not recommended to set value lower than 64
-	if size := c.ctx.sizesInfo.Sizeof(tv.Type); size >= sizeThreshold {
+	if size := c.ctx.sizesInfo.Sizeof(tv.Type); size >= c.sizeThreshold {
 		c.warn(rng, size)
 	}
 }

--- a/lint/rangeValCopy_checker.go
+++ b/lint/rangeValCopy_checker.go
@@ -10,6 +10,8 @@ func init() {
 
 type rangeValCopyChecker struct {
 	checkerBase
+
+	sizeThreshold int64
 }
 
 func (c *rangeValCopyChecker) InitDocumentation(d *Documentation) {
@@ -28,6 +30,10 @@ for i := range xs {
 }`
 }
 
+func (c *rangeValCopyChecker) Init() {
+	c.sizeThreshold = int64(c.ctx.params.Int("sizeThreshold", 48))
+}
+
 func (c *rangeValCopyChecker) EnterFunc(fn *ast.FuncDecl) bool {
 	return fn.Body != nil && !c.ctx.IsUnitTestFuncDecl(fn)
 }
@@ -41,8 +47,7 @@ func (c *rangeValCopyChecker) VisitStmt(stmt ast.Stmt) {
 	if typ == nil {
 		return
 	}
-	const sizeThreshold = 48
-	if size := c.ctx.sizesInfo.Sizeof(typ); size >= sizeThreshold {
+	if size := c.ctx.sizesInfo.Sizeof(typ); size >= c.sizeThreshold {
 		c.warn(rng, size)
 	}
 }


### PR DESCRIPTION
Make hugeParam, rangeExprCopy, rangeValCopy checkers
sizeThreshold value configurable via config settings.
Default values remain unchanged.

Updates #477