### PR TITLE
lint: reduce underef checker false-positives rate

### DIFF
--- a/lint/testdata/underef/negative_tests.go
+++ b/lint/testdata/underef/negative_tests.go
@@ -7,6 +7,11 @@ func sampleCase2(k sampleInterface) {
 	k.(*sampleStruct).method()
 }
 
+func methodCall(v *sampleStruct) {
+	(*v).method() // Call on copy
+	v.method()
+}
+
 func multipleIndir1() {
 	type point struct{ x, y int }
 	pt := point{}

--- a/lint/testdata/underef/positive_tests.go
+++ b/lint/testdata/underef/positive_tests.go
@@ -28,9 +28,6 @@ func sampleCase() {
 	var k *sampleStruct
 	/// could simplify (*k).field to k.field
 	(*k).field = 5
-	//TODO: could simplify (*k).method() to k.method()
-	/// could simplify (*k).method to k.method
-	(*k).method()
 	//TODO: could simplify (*k).nestedStruct.nestedField to k.nestedStruct.nestedField
 	/// could simplify (*k).nestedStruct to k.nestedStruct
 	(*k).nestedStruct.nestedField = 6


### PR DESCRIPTION
By default, don't trigger (*v).method() if method
accpets receiver by pointer, since that may lead
to unwanted side-effects if method does mutate its receiver.

Fixes #520