### PR TITLE
astwalk: LocalExprVisitor now contains only body expressions

### DIFF
--- a/lint/internal/astwalk/local_expr_walker.go
+++ b/lint/internal/astwalk/local_expr_walker.go
@@ -12,7 +12,7 @@ func (w *localExprWalker) WalkFile(f *ast.File) {
 		if !ok || !w.visitor.EnterFunc(decl) {
 			continue
 		}
-		ast.Inspect(decl, func(x ast.Node) bool {
+		ast.Inspect(decl.Body, func(x ast.Node) bool {
 			if x, ok := x.(ast.Expr); ok {
 				w.visitor.VisitLocalExpr(x)
 				return w.visitor.EnterChilds(x)


### PR DESCRIPTION
Checked file
```
func main() {
}
```

Checker
```
func (c *myChecker) VisitLocalExpr(expr ast.Expr) {
  fmt.Printf("%#v \n\n", expr)
}
```

this will print
```
&ast.Ident{NamePos:183, Name:"main", Obj:(*ast.Object)(0xc4200bd810)}
&ast.FuncType{Func:178, Params:(*ast.FieldList)(0xc42015c3f0), Results:(*ast.FieldList)(nil)}
```

This visitor mustn't contain func declaration expressions