### PR TITLE
lint: add unlambda checker

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -89,6 +89,10 @@ This page describes checks supported by [go-critic](https://github.com/go-critic
         <td>Detects function returning only bool and suggests to add Is/Has/Contains prefix to it's name</td>
       </tr>
       <tr>
+        <td><a href="#busySelect-ref">busySelect</a></td>
+        <td>Detects default statement inside a select without a sleep that might waste a CPU time</td>
+      </tr>
+      <tr>
         <td><a href="#captLocal-ref">captLocal</a></td>
         <td>Detects capitalized names for local variables</td>
       </tr>
@@ -199,6 +203,10 @@ This page describes checks supported by [go-critic](https://github.com/go-critic
       <tr>
         <td><a href="#unexportedCall-ref">unexportedCall</a> :nerd_face:</td>
         <td>Detects calls of unexported method from unexported type outside that type</td>
+      </tr>
+      <tr>
+        <td><a href="#unlambda-ref">unlambda</a></td>
+        <td>Detects function literals that can be simplified</td>
       </tr>
       <tr>
         <td><a href="#unnamedResult-ref">unnamedResult</a></td>
@@ -335,6 +343,38 @@ println(length)
 
 
 `builtinShadow` is syntax-only checker (fast).
+<a name="busySelect-ref"></a>
+## busySelect
+Detects default statement inside a select without a sleep that might waste a CPU time.
+
+
+
+**Before:**
+```go
+for {
+	select {
+	case <-ch:
+		// ...
+	default:
+		// will waste CPU time
+	}
+}
+```
+
+**After:**
+```go
+for {
+	select {
+	case <-ch:
+		// ...
+	default:
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+```
+
+
+
 <a name="captLocal-ref"></a>
 ## captLocal
 Detects capitalized names for local variables.
@@ -1196,6 +1236,24 @@ func baz(f foo) {
 
 
 `unexportedCall` is very opinionated.
+<a name="unlambda-ref"></a>
+## unlambda
+Detects function literals that can be simplified.
+
+
+
+**Before:**
+```go
+func(x int) int { return fn(x) }
+```
+
+**After:**
+```go
+fn
+```
+
+
+
 <a name="unnamedResult-ref"></a>
 ## unnamedResult
 Detects unnamed results that may benefit from names.

--- a/lint/testdata/unlambda/.#negative_tests.go
+++ b/lint/testdata/unlambda/.#negative_tests.go
@@ -1,0 +1,1 @@
+quasilyte@lispbook.7299:1533241407

--- a/lint/testdata/unlambda/.#negative_tests.go
+++ b/lint/testdata/unlambda/.#negative_tests.go
@@ -1,1 +1,0 @@
-quasilyte@lispbook.7299:1533241407

--- a/lint/testdata/unlambda/negative_tests.go
+++ b/lint/testdata/unlambda/negative_tests.go
@@ -1,0 +1,28 @@
+package linter_test
+
+func goodFunctionLiterals() {
+	_ = returnInt
+}
+
+func goodMethodValues() {
+	var o object
+
+	_ = o.returnInt
+}
+
+func complexCalls() {
+	_ = func(x int) int {
+		// Call result is used for something else.
+		return returnInt(x) + 1
+	}
+
+	_ = func(x int) int {
+		// The argument is not just forwarded.
+		return returnInt(x + 1)
+	}
+
+	_ = func(x int) int {
+		// Creates object as a part of expression
+		return object{}.returnInt(x)
+	}
+}

--- a/lint/testdata/unlambda/negative_tests.go
+++ b/lint/testdata/unlambda/negative_tests.go
@@ -22,7 +22,18 @@ func complexCalls() {
 	}
 
 	_ = func(x int) int {
-		// Creates object as a part of expression
+		// Creates object as a part of expression.
 		return object{}.returnInt(x)
+	}
+
+	_ = func(x int) (int, error) {
+		// Return of multiple values.
+		return returnInt(x), nil
+	}
+
+	_ = func(x int) interface{} {
+		// The returnInt returns int, but enclosing func lit does
+		// return interface{}.
+		return returnInt(x)
 	}
 }

--- a/lint/testdata/unlambda/positive_tests.go
+++ b/lint/testdata/unlambda/positive_tests.go
@@ -1,0 +1,21 @@
+package linter_test
+
+func returnInt(x int) int {
+	return x
+}
+
+func functionLiterals() {
+	/// replace `func(x int) int { return returnInt(x) }` with `returnInt`
+	_ = func(x int) int { return returnInt(x) }
+}
+
+type object struct{}
+
+func (object) returnInt(x int) int { return x }
+
+func methodValues() {
+	var o object
+
+	/// replace `func(x int) int { return o.returnInt(x) }` with `o.returnInt`
+	_ = func(x int) int { return o.returnInt(x) }
+}

--- a/lint/testdata/unlambda/positive_tests.go
+++ b/lint/testdata/unlambda/positive_tests.go
@@ -1,5 +1,9 @@
 package linter_test
 
+func returnIntError(x int) (int, error) {
+	return x, nil
+}
+
 func returnInt(x int) int {
 	return x
 }
@@ -7,6 +11,9 @@ func returnInt(x int) int {
 func functionLiterals() {
 	/// replace `func(x int) int { return returnInt(x) }` with `returnInt`
 	_ = func(x int) int { return returnInt(x) }
+
+	/// replace `func(x int) (int, error) { return returnIntError(x) }` with `returnIntError`
+	_ = func(x int) (int, error) { return returnIntError(x) }
 }
 
 type object struct{}

--- a/lint/unlambda_checker.go
+++ b/lint/unlambda_checker.go
@@ -1,0 +1,65 @@
+package lint
+
+import (
+	"go/ast"
+	"go/types"
+
+	"github.com/go-toolsmith/astequal"
+)
+
+func init() {
+	addChecker(&unlambdaChecker{}, attrExperimental)
+}
+
+type unlambdaChecker struct {
+	checkerBase
+}
+
+func (c *unlambdaChecker) InitDocumentation(d *Documentation) {
+	d.Summary = "Detects function literals that can be simplified"
+	d.Before = "func(x int) int { return fn(x) }"
+	d.After = "fn"
+}
+
+func (c *unlambdaChecker) VisitExpr(x ast.Expr) {
+	fn, ok := x.(*ast.FuncLit)
+	if !ok || len(fn.Body.List) != 1 {
+		return
+	}
+
+	ret, ok := fn.Body.List[0].(*ast.ReturnStmt)
+	if !ok || len(ret.Results) != 1 {
+		return
+	}
+
+	result, ok := ret.Results[0].(*ast.CallExpr)
+	if !ok {
+		return
+	}
+	callable := qualifiedName(result.Fun)
+	if callable == "" {
+		return // Skip tricky cases; only handle simple calls
+	}
+	fnType := c.ctx.typesInfo.TypeOf(fn)
+	resultType := c.ctx.typesInfo.TypeOf(result.Fun)
+	if !types.Identical(fnType, resultType) {
+		return
+	}
+	// Now check that all arguments match the parameters.
+	n := 0
+	for _, params := range fn.Type.Params.List {
+		for _, id := range params.Names {
+			if !astequal.Expr(id, result.Args[n]) {
+				return
+			}
+			n++
+		}
+	}
+
+	c.warn(fn, callable)
+
+}
+
+func (c *unlambdaChecker) warn(cause ast.Node, suggestion string) {
+	c.ctx.Warn(cause, "replace `%s` with `%s`", cause, suggestion)
+}


### PR DESCRIPTION
Detects function literals that can be replaced by a function/method value itself.

Fixes #550