### PR TITLE
lint: update floatCompare checker

### DIFF
--- a/lint/floatCompare_checker.go
+++ b/lint/floatCompare_checker.go
@@ -34,8 +34,10 @@ func (c *floatCompareChecker) VisitLocalExpr(expr ast.Expr) {
 		return
 	}
 	if binexpr.Op == token.EQL || binexpr.Op == token.NEQ {
-		if c.isFloatExpr(binexpr) && c.isMultiBinaryExpr(binexpr) &&
-			!c.isNaNCheckExpr(binexpr) && !c.isInfCheckExpr(binexpr) {
+		if c.isFloatExpr(binexpr) &&
+			c.isMultiBinaryExpr(binexpr) &&
+			!c.isNaNCheckExpr(binexpr) &&
+			!c.isInfCheckExpr(binexpr) {
 			c.warn(binexpr)
 		}
 	}
@@ -56,7 +58,7 @@ func (c *floatCompareChecker) isNaNCheckExpr(binexpr *ast.BinaryExpr) bool {
 func (c *floatCompareChecker) isInfCheckExpr(binexpr *ast.BinaryExpr) bool {
 	binx := astutil.Unparen(binexpr.X)
 	biny := astutil.Unparen(binexpr.Y)
-	expr, bin, ok := identExpr(binx, biny)
+	expr, bin, ok := c.identExpr(binx, biny)
 	if !ok {
 		return false
 	}
@@ -72,7 +74,7 @@ func (c *floatCompareChecker) isMultiBinaryExpr(binexpr *ast.BinaryExpr) bool {
 	return astp.IsBinaryExpr(exprx) || astp.IsBinaryExpr(expry)
 }
 
-func identExpr(x ast.Node, y ast.Node) (ast.Expr, *ast.BinaryExpr, bool) {
+func (c *floatCompareChecker) identExpr(x, y ast.Node) (ast.Expr, *ast.BinaryExpr, bool) {
 	expr1, ok1 := x.(*ast.BinaryExpr)
 	expr2, ok2 := y.(*ast.BinaryExpr)
 	switch {

--- a/lint/floatCompare_checker.go
+++ b/lint/floatCompare_checker.go
@@ -4,6 +4,10 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
+
+	"github.com/go-toolsmith/astequal"
+	"github.com/go-toolsmith/astp"
+	"golang.org/x/tools/go/ast/astutil"
 )
 
 func init() {
@@ -30,20 +34,66 @@ func (c *floatCompareChecker) VisitLocalExpr(expr ast.Expr) {
 		return
 	}
 	if binexpr.Op == token.EQL || binexpr.Op == token.NEQ {
-		typx, ok := c.ctx.typesInfo.TypeOf(binexpr.X).(*types.Basic)
-		if ok && typx.Info()&types.IsFloat != 0 {
+		if c.isFloatExpr(binexpr) && c.isMultiBinaryExpr(binexpr) &&
+			!c.isNaNCheckExpr(binexpr) && !c.isInfCheckExpr(binexpr) {
 			c.warn(binexpr)
 		}
 	}
 }
 
+func (c *floatCompareChecker) isFloatExpr(binexpr *ast.BinaryExpr) bool {
+	exprx := astutil.Unparen(binexpr.X)
+	typx, ok := c.ctx.typesInfo.TypeOf(exprx).(*types.Basic)
+	return ok && typx.Info()&types.IsFloat != 0
+}
+
+func (c *floatCompareChecker) isNaNCheckExpr(binexpr *ast.BinaryExpr) bool {
+	exprx := astutil.Unparen(binexpr.X)
+	expry := astutil.Unparen(binexpr.Y)
+	return astequal.Expr(exprx, expry)
+}
+
+func (c *floatCompareChecker) isInfCheckExpr(binexpr *ast.BinaryExpr) bool {
+	binx := astutil.Unparen(binexpr.X)
+	biny := astutil.Unparen(binexpr.Y)
+	expr, bin, ok := identExpr(binx, biny)
+	if !ok {
+		return false
+	}
+	x := astutil.Unparen(expr)
+	y := astutil.Unparen(bin.X)
+	z := astutil.Unparen(bin.Y)
+	return astequal.Expr(x, y) && astequal.Expr(y, z)
+}
+
+func (c *floatCompareChecker) isMultiBinaryExpr(binexpr *ast.BinaryExpr) bool {
+	exprx := astutil.Unparen(binexpr.X)
+	expry := astutil.Unparen(binexpr.Y)
+	return astp.IsBinaryExpr(exprx) || astp.IsBinaryExpr(expry)
+}
+
+func identExpr(x ast.Node, y ast.Node) (ast.Expr, *ast.BinaryExpr, bool) {
+	expr1, ok1 := x.(*ast.BinaryExpr)
+	expr2, ok2 := y.(*ast.BinaryExpr)
+	switch {
+	case ok1 && !ok2:
+		return y.(ast.Expr), expr1, true
+	case !ok1 && ok2:
+		return x.(ast.Expr), expr2, true
+
+	default:
+		return nil, nil, false
+	}
+}
+
 func (c *floatCompareChecker) warn(expr *ast.BinaryExpr) {
-	var op string
+	op := ">="
 	if expr.Op == token.EQL {
 		op = "<"
-	} else {
-		op = ">="
 	}
-	c.ctx.Warn(expr, "change `%s` to `math.Abs(%s - %s) %s eps`",
-		expr, expr.X, expr.Y, op)
+	format := "change `%s` to `math.Abs(%s - %s) %s eps`"
+	if astp.IsBinaryExpr(expr.Y) {
+		format = "change `%s` to `math.Abs(%s - (%s)) %s eps`"
+	}
+	c.ctx.Warn(expr, format, expr, expr.X, expr.Y, op)
 }

--- a/lint/testdata/floatCompare/negative_tests.go
+++ b/lint/testdata/floatCompare/negative_tests.go
@@ -1,5 +1,9 @@
 package checker_test
 
+func foo1() float64 {
+	return 9.0
+}
+
 func g1() bool {
 	var a, b float64 = 10.0, 20.0
 	return a < b
@@ -13,9 +17,49 @@ func g2() bool {
 func g3() {
 	var a, b float64 = 10.0, 20.0
 
+	x := []float64{4.0, 5.0, 9.0, 10.0}
+
+	var p *float64 = &a
+
+	_ = b == 0.5
+
+	_ = 'a' == 'b'
+
 	_ = a >= b
 
-	_ = a - b
+	_ = a == b
+
+	_ = a != 0.6
 
 	_ = b < a && a >= b
+
+	_ = a+b != a+b
+
+	_ = a+b != (a + b)
+
+	_ = (a + b) != (a + b)
+
+	_ = foo1() == a
+
+	_ = x[0] == a
+
+	_ = *p == a
+
+	_ = a == a+a
+
+	_ = a+a != a
+
+	_ = (a + a) == a
+
+	_ = foo1()+foo1() == foo1()
+
+	_ = x[0] != x[0]
+
+	_ = x[0]+x[0] == x[0]
+
+	_ = *p+*p == *p
+
+	_ = x[0]+(x[0]) == x[0]
+
+	_ = a+b == a+b
 }

--- a/lint/testdata/floatCompare/positive_tests.go
+++ b/lint/testdata/floatCompare/positive_tests.go
@@ -1,56 +1,32 @@
 package checker_test
 
+func foo() float32 {
+	return 9.0
+}
+
 func f1() bool {
-	var a float32 = 10.0
-	var b int = 5.0
-	/// change `a == float32(b)` to `math.Abs(a - float32(b)) < eps`
-	return a == float32(b)
+	var p float32 = 10.0
+	var q float32 = 5.0
+	/// change `(p + q) == foo()` to `math.Abs((p + q) - foo()) < eps`
+	return (p + q) == foo()
 }
 
 func f2() bool {
 	var a float32 = 10.0
-	var b int = 5.0
-	/// change `a != float32(b)` to `math.Abs(a - float32(b)) >= eps`
-	return a != float32(b)
+	var b float32 = 5.0
+	/// change `2*a+4*b == 0.5` to `math.Abs(2*a + 4*b - 0.5) < eps`
+	return 2*a+4*b == 0.5
 }
 
 func f3() bool {
 	var a float32 = 10.0
-	var b int = 5.0
-	/// change `float32(a) != float32(b)` to `math.Abs(float32(a) - float32(b)) >= eps`
-	return float32(a) != float32(b)
+	var c float32 = 5.0
+	/// change `c == (a + 5)` to `math.Abs(c - (a + 5)) < eps`
+	return c == (a + 5)
 }
 
-func f4(a, b float64) {
-
-	/// change `a == b` to `math.Abs(a - b) < eps`
-	_ = a == b
-
-	/// change `a == b` to `math.Abs(a - b) < eps`
-	_ = !(a == b)
-
-	/// change `a == (b + a)` to `math.Abs(a - (b + a)) < eps`
-	_ = a == (b + a)
-
-	/// change `a != 40.0` to `math.Abs(a - 40.0) >= eps`
-	_ = a != 40.0
-
-	/// change `a*2 == b` to `math.Abs(a * 2 - b) < eps`
-	_ = a*2 == b
-
-	/// change `a == (b + 4)` to `math.Abs(a - (b + 4)) < eps`
-	_ = a == (b + 4)
-
-	/// change `a == b` to `math.Abs(a - b) < eps`
-	/// change `b != a` to `math.Abs(b - a) >= eps`
-	_ = a == b && b != a
-
-	/// change `a == b` to `math.Abs(a - b) < eps`
-	/// change `b != a` to `math.Abs(b - a) >= eps`
-	/// change `a != b` to `math.Abs(a - b) >= eps`
-	_ = a == b && b != a || !(a != b)
-
-	// TODO: change `a == b+a` to `math.Abs(a - (b+a)) < eps`
-	/// change `a == b+a` to `math.Abs(a - b + a) < eps`
-	_ = a == b+a
+func f4() bool {
+	var a float32 = 10.0
+	/// change `foo()+foo() == a+a` to `math.Abs(foo() + foo() - (a + a)) < eps`
+	return foo()+foo() == a+a
 }


### PR DESCRIPTION
1. Fix print 'binaryExpr' as second argument
2. Add detection NaNCheckExpr: 'x != x' and InfCheckExpr: 'x + x == x'.
Result: less false-positives.