### PR TITLE
config file control enabled checkers (#570)

### DIFF
--- a/cmd/criticize/main.go
+++ b/cmd/criticize/main.go
@@ -47,6 +47,8 @@ func Main() {
 	parseArgv(&l)
 	if l.flags.ConfigFile != "" {
 		l.LoadConfig()
+	} else {
+		parseEnabledCheckers(&l)
 	}
 	l.LoadProgram()
 	l.InitCheckers()
@@ -83,7 +85,10 @@ func parseArgv(l *linter) {
 	if len(l.packages) == 0 {
 		blame("no packages specified\n")
 	}
+}
 
+// parseEnabledCheckers processes enabled checkers, intersect them with disabled, etc.
+func parseEnabledCheckers(l *linter) {
 	switch l.flags.Enable {
 	case flagparser.EnableAll:
 		for _, rule := range lint.RuleList() {
@@ -140,8 +145,10 @@ func (l *linter) LoadConfig() {
 		return
 	}
 
+	l.enabledCheckers = []string{}
 	l.checkerParams = make(map[string]map[string]interface{})
 	for k, v := range params {
+		l.enabledCheckers = append(l.enabledCheckers, k)
 		if v, ok := v.(map[string]interface{}); ok {
 			l.checkerParams[k] = v
 		} else {

--- a/cmd/criticize/main.go
+++ b/cmd/criticize/main.go
@@ -74,7 +74,7 @@ func parseArgv(l *linter) {
 		flag.PrintDefaults()
 	}
 
-	l.flags = flagparser.NewFlagParser()
+	l.flags = flagparser.NewFlagParser(flag.CommandLine)
 
 	if err := l.flags.Parse(); err != nil {
 		blame(err.Error())

--- a/cmd/internal/flagparser/flag_parser.go
+++ b/cmd/internal/flagparser/flag_parser.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"fmt"
 	"strings"
+	"errors"
+	"os"
 )
 
 // EnableAll represent all checkers value for "enable" option
@@ -16,21 +18,51 @@ const DisableAll = "all"
 func NewFlagParser() *FlagParser {
 	fp := &FlagParser{}
 
-	flag.StringVar(&fp.Enable, "enable", EnableAll,
+	fp.flagSet = flag.CommandLine
+
+	fp.flagSet.StringVar(&fp.Enable, "enable", EnableAll,
 		`comma-separated list of enabled checkers`)
-	flag.StringVar(&fp.ConfigFile, "config", "",
+	fp.flagSet.StringVar(&fp.ConfigFile, "config", "",
 		`name of JSON file containing checkers configurations`)
-	flag.StringVar(&fp.Disable, "disable", "",
+	fp.flagSet.StringVar(&fp.Disable, "disable", "",
 		`comma-separated list of disabled checkers`)
-	flag.BoolVar(&fp.WithExperimental, `withExperimental`, false,
+	fp.flagSet.BoolVar(&fp.WithExperimental, `withExperimental`, false,
 		`only for -enable=all, include experimental checks`)
-	flag.BoolVar(&fp.WithOpinionated, `withOpinionated`, false,
+	fp.flagSet.BoolVar(&fp.WithOpinionated, `withOpinionated`, false,
 		`only for -enable=all, include very opinionated checks`)
-	flag.IntVar(&fp.FailureExitCode, "failcode", 1,
+	fp.flagSet.IntVar(&fp.FailureExitCode, "failcode", 1,
 		`exit code to be used when lint issues are found`)
-	flag.BoolVar(&fp.CheckGenerated, "checkGenerated", false,
+	fp.flagSet.BoolVar(&fp.CheckGenerated, "checkGenerated", false,
 		`whether to check machine-generated files`)
-	flag.BoolVar(&fp.ShorterErrLocation, "shorterErrLocation", true,
+	fp.flagSet.BoolVar(&fp.ShorterErrLocation, "shorterErrLocation", true,
+		`whether to replace error location prefix with $GOROOT and $GOPATH`)
+
+	return fp
+}
+
+// FlagParser, where default values different from real ones, used in trick for define that
+// arguments was provided by user, or just was set up by default
+// See https://stackoverflow.com/a/51903637/4143494
+func newDefaultInvertedFlagParser() *FlagParser {
+	fp := &FlagParser{}
+
+	fp.flagSet = flag.NewFlagSet("defaultChecker", flag.ContinueOnError)
+
+	fp.flagSet.StringVar(&fp.Enable, "enable", "-",
+		`comma-separated list of enabled checkers`)
+	fp.flagSet.StringVar(&fp.ConfigFile, "config", "-",
+		`name of JSON file containing checkers configurations`)
+	fp.flagSet.StringVar(&fp.Disable, "disable", "-",
+		`comma-separated list of disabled checkers`)
+	fp.flagSet.BoolVar(&fp.WithExperimental, `withExperimental`, true,
+		`only for -enable=all, include experimental checks`)
+	fp.flagSet.BoolVar(&fp.WithOpinionated, `withOpinionated`, true,
+		`only for -enable=all, include very opinionated checks`)
+	fp.flagSet.IntVar(&fp.FailureExitCode, "failcode", 0,
+		`exit code to be used when lint issues are found`)
+	fp.flagSet.BoolVar(&fp.CheckGenerated, "checkGenerated", true,
+		`whether to check machine-generated files`)
+	fp.flagSet.BoolVar(&fp.ShorterErrLocation, "shorterErrLocation", false,
 		`whether to replace error location prefix with $GOROOT and $GOPATH`)
 
 	return fp
@@ -38,6 +70,8 @@ func NewFlagParser() *FlagParser {
 
 // FlagParser help to parse and operate with command flags, share them between commands, etc.
 type FlagParser struct {
+	flagSet *flag.FlagSet
+
 	Enable             string
 	Disable            string
 	ConfigFile         string
@@ -60,7 +94,7 @@ func (fp *FlagParser) DisabledCheckers() []string {
 
 // Parse and validate command arguments. Return error in case of validation failed.
 func (fp *FlagParser) Parse() error {
-	flag.Parse()
+	fp.flagSet.Parse(os.Args[1:])
 
 	if fp.Enable != EnableAll {
 		if fp.WithExperimental {
@@ -71,24 +105,57 @@ func (fp *FlagParser) Parse() error {
 		}
 	}
 
+	if fp.ConfigFile != "" {
+		// If config file used, we restrict to use options that control enabledChecker like "enable", "disable", etc.
+		// Purpose of this - to avoid complexity with definition which one checkers are enabled where and so on.
+		// It will be easier to use, and easier to support.
+
+		// For define that arguments was not provided by user, we use trick https://stackoverflow.com/a/51903637/4143494
+		defaultInvertedFlagParser := newDefaultInvertedFlagParser()
+		defaultInvertedFlagParser.flagSet.Parse(os.Args[1:])
+
+		if fp.Enable == defaultInvertedFlagParser.Enable {
+			return errors.New("-enable cannot be used with -config option")
+		}
+		if fp.Disable == defaultInvertedFlagParser.Disable {
+			return errors.New("-disable cannot be used with -config option")
+		}
+		if fp.WithExperimental == defaultInvertedFlagParser.WithExperimental {
+			return errors.New("-withExperimental cannot be used with -config option")
+		}
+		if fp.WithOpinionated == defaultInvertedFlagParser.WithOpinionated {
+			return errors.New("-withOpionated cannot be used with -config option")
+		}
+	}
+
 	return nil
 }
 
 // ParsedArgs return parsed command line arguments
 func (fp *FlagParser) ParsedArgs() []string {
-	return flag.Args()
+	return fp.flagSet.Args()
 }
 
 // Args return slice of arguments, that can be used as arguments for exec command
 func (fp *FlagParser) Args() []string {
-	return []string{
-		"-enable=" + fp.Enable,
-		"-disable=" + fp.Disable,
+	args := []string{
 		"-config=" + fp.ConfigFile,
-		"-withExperimental=" + fmt.Sprint(fp.WithExperimental),
-		"-withOpinionated=" + fmt.Sprint(fp.WithOpinionated),
 		"-failcode=" + fmt.Sprint(fp.FailureExitCode),
 		"-checkGenerated=" + fmt.Sprint(fp.CheckGenerated),
 		"-shorterErrLocation=" + fmt.Sprint(fp.ShorterErrLocation),
 	}
+
+	if fp.ConfigFile == "" {
+		args = append(
+			args,
+			[]string{
+				"-enable=" + fp.Enable,
+				"-disable=" + fp.Disable,
+				"-withExperimental=" + fmt.Sprint(fp.WithExperimental),
+				"-withOpinionated=" + fmt.Sprint(fp.WithOpinionated),
+			}...
+		)
+	}
+
+	return args
 }

--- a/cmd/internal/flagparser/flag_parser.go
+++ b/cmd/internal/flagparser/flag_parser.go
@@ -1,11 +1,11 @@
 package flagparser
 
 import (
+	"errors"
 	"flag"
 	"fmt"
-	"strings"
-	"errors"
 	"os"
+	"strings"
 )
 
 // EnableAll represent all checkers value for "enable" option
@@ -94,7 +94,11 @@ func (fp *FlagParser) DisabledCheckers() []string {
 
 // Parse and validate command arguments. Return error in case of validation failed.
 func (fp *FlagParser) Parse() error {
-	fp.flagSet.Parse(os.Args[1:])
+	err := fp.flagSet.Parse(os.Args[1:])
+
+	if err != nil {
+		return err
+	}
 
 	if fp.Enable != EnableAll {
 		if fp.WithExperimental {
@@ -112,7 +116,11 @@ func (fp *FlagParser) Parse() error {
 
 		// For define that arguments was not provided by user, we use trick https://stackoverflow.com/a/51903637/4143494
 		defaultInvertedFlagParser := newDefaultInvertedFlagParser()
-		defaultInvertedFlagParser.flagSet.Parse(os.Args[1:])
+		err := defaultInvertedFlagParser.flagSet.Parse(os.Args[1:])
+
+		if err != nil {
+			return err
+		}
 
 		if fp.Enable == defaultInvertedFlagParser.Enable {
 			return errors.New("-enable cannot be used with -config option")
@@ -153,7 +161,7 @@ func (fp *FlagParser) Args() []string {
 				"-disable=" + fp.Disable,
 				"-withExperimental=" + fmt.Sprint(fp.WithExperimental),
 				"-withOpinionated=" + fmt.Sprint(fp.WithOpinionated),
-			}...
+			}...,
 		)
 	}
 

--- a/cmd/lintwalk/main.go
+++ b/cmd/lintwalk/main.go
@@ -43,7 +43,11 @@ func Main() {
 	checkHidden := flag.Bool("checkHidden", false,
 		`whether to visit dirs those name start with "." or "_"`)
 
-	flag.Parse()
+	err := flags.Parse()
+
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	if flag.NArg() != 1 {
 		log.Fatalf("expected exactly one project root argument")
@@ -54,7 +58,7 @@ func Main() {
 	}
 	srcRoot = filepath.Clean(srcRoot)
 
-	srcRoot, err := filepath.Abs(srcRoot)
+	srcRoot, err = filepath.Abs(srcRoot)
 
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/lintwalk/main.go
+++ b/cmd/lintwalk/main.go
@@ -36,7 +36,7 @@ func dirIsHidden(dir string) bool {
 
 // Main implements gocritic sub-command entry point.
 func Main() {
-	flags := flagparser.NewFlagParser()
+	flags := flagparser.NewFlagParser(flag.CommandLine)
 
 	exclude := flag.String("exclude", `testdata/|vendor/|builtin/`,
 		`regexp used to skip package names`)


### PR DESCRIPTION
PR for #570

There is two commits, one is super simple and made required changes (enabled checkers controlled by config), second one add complexity and restrict to use config option together with "enable", "disable", etc. Some options that can control enabled checkers. 
This on my mind reduce complexity of support and made it more simple to use and understand.