### PR TITLE
lint: follow-up for PR566

### DIFF
--- a/lint/testdata/emptyFallthrough/negative_tests.go
+++ b/lint/testdata/emptyFallthrough/negative_tests.go
@@ -2,26 +2,48 @@ package checker_tests
 
 import "fmt"
 
-func noWarningsNonEmptyFallthrough(i int) int {
+func noWarningsNonEmptyFallthrough(i int) bool {
 	switch i {
 	case 0:
 		fmt.Print("")
 		fallthrough
 	case 1:
-		return 1
+		return true
 	default:
-		return 2
+		return false
 	}
 }
 
-func noWarningsNonEmptyFallthroughToDefault(i int) int {
+func noWarningsNonEmptyFallthroughToDefault(i int) bool {
 	switch i {
 	case 0:
-		return 0
+		return true
 	case 1:
 		fmt.Print("")
 		fallthrough
 	default:
-		return 1
+		return false
+	}
+}
+
+func noWarningsNonEmptyFallthroughInNestedSwitch(i, j int) bool {
+	switch i {
+	case 0:
+		return true
+	case 1:
+		switch j {
+		case 0:
+			fmt.Print("")
+			fallthrough
+		case 1:
+			return true
+		default:
+			return false
+		}
+	case 2:
+		fmt.Print("")
+		fallthrough
+	default:
+		return false
 	}
 }

--- a/lint/testdata/emptyFallthrough/positive_tests.go
+++ b/lint/testdata/emptyFallthrough/positive_tests.go
@@ -1,6 +1,7 @@
 package checker_tests
 
 import (
+	"fmt"
 	"reflect"
 )
 
@@ -59,5 +60,36 @@ func warningsEmptyFallthroughToNonLastDefault(i int) bool {
 		return false
 	case 3:
 		return true
+	}
+}
+
+func warningsNestedSwitchMixedFallthroughs(i, j int) bool {
+	switch i {
+	case 0:
+		/// replace empty case containing only fallthrough with expression list
+		fallthrough
+	case 1:
+		switch j {
+		case 0:
+			/// replace empty case containing only fallthrough with expression list
+			fallthrough
+		case 1:
+			fmt.Println("")
+			fallthrough
+		case 2:
+			return true
+		case 3:
+			/// remove empty case containing only fallthrough to default case
+			fallthrough
+		default:
+			return false
+		}
+	case 2:
+		return true
+	case 3:
+		/// remove empty case containing only fallthrough to default case
+		fallthrough
+	default:
+		return false
 	}
 }


### PR DESCRIPTION
Add some tests for nested switch-case-fallthrough statements
to prevent the checker logic to be simplified accidentally.
Harmonize tests.