### PR TITLE
lint: add deprecatedComment checker

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -117,6 +117,10 @@ This page describes checks supported by [go-critic](https://github.com/go-critic
         <td>Detects defer in loop and warns that it will not be executed till the end of function's scope</td>
       </tr>
       <tr>
+        <td><a href="#deprecatedComment-ref">deprecatedComment</a></td>
+        <td>Detects malformed "deprecated" doc-comments</td>
+      </tr>
+      <tr>
         <td><a href="#docStub-ref">docStub</a></td>
         <td>Detects comments that silence go lint complaints about doc-comment</td>
       </tr>
@@ -155,6 +159,10 @@ This page describes checks supported by [go-critic](https://github.com/go-critic
       <tr>
         <td><a href="#hugeParam-ref">hugeParam</a></td>
         <td>Detects params that incur excessive amount of copying</td>
+      </tr>
+      <tr>
+        <td><a href="#importPackageName-ref">importPackageName</a></td>
+        <td>Detects when imported package names are unnecessary renamed</td>
       </tr>
       <tr>
         <td><a href="#importShadow-ref">importShadow</a></td>
@@ -519,6 +527,26 @@ for i := range [10]int{} {
 
 
 
+<a name="deprecatedComment-ref"></a>
+## deprecatedComment
+Detects malformed "deprecated" doc-comments.
+
+
+
+**Before:**
+```go
+// deprecated, use FuncNew instead
+func FuncOld() int
+```
+
+**After:**
+```go
+// Deprecated: use FuncNew instead
+func FuncOld() int
+```
+
+
+`deprecatedComment` is syntax-only checker (fast).
 <a name="docStub-ref"></a>
 ## docStub
 Detects comments that silence go lint complaints about doc-comment.
@@ -794,6 +822,24 @@ default:
 Permits single else or else-if; repeated else-if or else + else-if
 will trigger suggestion to use switch statement.
 `ifElseChain` is syntax-only checker (fast).
+<a name="importPackageName-ref"></a>
+## importPackageName
+Detects when imported package names are unnecessary renamed.
+
+
+
+**Before:**
+```go
+import lint "github.com/go-critic/go-critic/lint"
+```
+
+**After:**
+```go
+import "github.com/go-critic/go-critic/lint"
+```
+
+
+
 <a name="importShadow-ref"></a>
 ## importShadow
 Detects when imported package names shadowed in assignments.

--- a/lint/deprecatedComment_checker.go
+++ b/lint/deprecatedComment_checker.go
@@ -1,0 +1,95 @@
+package lint
+
+import (
+	"go/ast"
+	"regexp"
+	"strings"
+)
+
+func init() {
+	addChecker(&deprecatedCommentChecker{}, attrExperimental, attrSyntaxOnly)
+}
+
+type deprecatedCommentChecker struct {
+	checkerBase
+}
+
+func (c *deprecatedCommentChecker) InitDocumentation(d *Documentation) {
+	d.Summary = `Detects malformed "deprecated" doc-comments`
+	d.Before = `
+// deprecated, use FuncNew instead
+func FuncOld() int
+`
+	d.After = `
+// Deprecated: use FuncNew instead
+func FuncOld() int
+`
+}
+
+func (c *deprecatedCommentChecker) VisitDocComment(doc *ast.CommentGroup) {
+	// There are 3 accepted forms of deprecation comments:
+	//
+	// 1. inline, that can't be handled with a DocCommentVisitor.
+	//    Note that "Deprecated: " may not even be the comment prefix there.
+	//    Example: "The line number in the input. Deprecated: Kept for compatibility."
+	//    TODO(quasilyte): fix it.
+	//
+	// 2. Longer form-1. It's a doc-comment that only contains "deprecation" notice.
+	//
+	// 3. Like form-2, but may also include doc-comment text.
+	//    Distinguished by an empty line.
+	//
+	// See https://github.com/golang/go/issues/10909#issuecomment-136492606.
+	//
+	// It's desirable to see how people make mistakes with the format,
+	// this is why there is currently no special treatment for these cases.
+	// TODO(quasilyte): do more audits and grow the negative tests suite.
+	//
+	// TODO(quasilyte): there are also multi-line deprecation comments.
+
+	commonPatterns := []*regexp.Regexp{
+		regexp.MustCompile(`(?i)this (?:function|type) is deprecated`),
+		regexp.MustCompile(`(?i)deprecated[.!]? use \S* instead`),
+		// TODO(quasilyte): more of these?
+	}
+
+	for _, l := range strings.Split(doc.Text(), "\n") {
+		if len(l) < len("Deprecated: ") {
+			continue
+		}
+
+		// Check whether someone messed up with a prefix casing.
+		upcase := strings.ToUpper(l)
+		if strings.HasPrefix(upcase, "DEPRECATED: ") && !strings.HasPrefix(l, "Deprecated: ") {
+			c.warnCasing(doc, l)
+			return
+		}
+
+		// Check is someone used comma instead of a colon.
+		if strings.HasPrefix(l, "Deprecated, ") {
+			c.warnComma(doc)
+			return
+		}
+
+		// Check for other commonly used patterns.
+		for _, pat := range commonPatterns {
+			if pat.MatchString(l) {
+				c.warnPattern(doc)
+				return
+			}
+		}
+	}
+}
+
+func (c *deprecatedCommentChecker) warnCasing(cause ast.Node, line string) {
+	prefix := line[:len("DEPRECATED: ")]
+	c.ctx.Warn(cause, "use `Deprecated: ` (note the casing) instead of `%s`", prefix)
+}
+
+func (c *deprecatedCommentChecker) warnPattern(cause ast.Node) {
+	c.ctx.Warn(cause, "the proper format is `Deprecated: <text>`")
+}
+
+func (c *deprecatedCommentChecker) warnComma(cause ast.Node) {
+	c.ctx.Warn(cause, "use `:` instead of `,` in `Deprecated, `")
+}

--- a/lint/internal/astwalk/doc_comment_visitor.go
+++ b/lint/internal/astwalk/doc_comment_visitor.go
@@ -34,9 +34,7 @@ func (w *docCommentVisitor) WalkFile(f *ast.File) {
 						w.visitor.VisitDocComment(spec.Doc)
 					}
 					ast.Inspect(spec.Type, func(n ast.Node) bool {
-						switch n := n.(type) {
-						// TODO: handling of nested type decls?
-						case *ast.Field:
+						if n, ok := n.(*ast.Field); ok {
 							if n.Doc != nil {
 								w.visitor.VisitDocComment(n.Doc)
 							}

--- a/lint/internal/astwalk/doc_comment_visitor.go
+++ b/lint/internal/astwalk/doc_comment_visitor.go
@@ -1,0 +1,50 @@
+package astwalk
+
+import (
+	"go/ast"
+)
+
+type docCommentVisitor struct {
+	visitor DocCommentVisitor
+}
+
+func (w *docCommentVisitor) WalkFile(f *ast.File) {
+	for _, decl := range f.Decls {
+		switch decl := decl.(type) {
+		case *ast.FuncDecl:
+			if decl.Doc != nil {
+				w.visitor.VisitDocComment(decl.Doc)
+			}
+		case *ast.GenDecl:
+			if decl.Doc != nil {
+				w.visitor.VisitDocComment(decl.Doc)
+			}
+			for _, spec := range decl.Specs {
+				switch spec := spec.(type) {
+				case *ast.ImportSpec:
+					if spec.Doc != nil {
+						w.visitor.VisitDocComment(spec.Doc)
+					}
+				case *ast.ValueSpec:
+					if spec.Doc != nil {
+						w.visitor.VisitDocComment(spec.Doc)
+					}
+				case *ast.TypeSpec:
+					if spec.Doc != nil {
+						w.visitor.VisitDocComment(spec.Doc)
+					}
+					ast.Inspect(spec.Type, func(n ast.Node) bool {
+						switch n := n.(type) {
+						// TODO: handling of nested type decls?
+						case *ast.Field:
+							if n.Doc != nil {
+								w.visitor.VisitDocComment(n.Doc)
+							}
+						}
+						return true
+					})
+				}
+			}
+		}
+	}
+}

--- a/lint/internal/astwalk/visitor.go
+++ b/lint/internal/astwalk/visitor.go
@@ -68,6 +68,14 @@ type (
 		walkerEvents
 		VisitLocalComment(*ast.CommentGroup)
 	}
+
+	// DocCommentVisitor visits every doc-comment.
+	// Does not visit doc-comments for function-local definitions (types, etc).
+	// Also does not visit package doc-comment (file-level doc-comments).
+	DocCommentVisitor interface {
+		walkerEvents
+		VisitDocComment(*ast.CommentGroup)
+	}
 )
 
 // walkerEvents describes common hooks available for every visitor.

--- a/lint/internal/astwalk/walker.go
+++ b/lint/internal/astwalk/walker.go
@@ -55,3 +55,8 @@ func WalkerForTypeExpr(v TypeExprVisitor, info *types.Info) FileWalker {
 func WalkerForLocalComment(v LocalCommentVisitor) FileWalker {
 	return &localCommentVisitor{visitor: v}
 }
+
+// WalkerForDocComment returns file walker implementation for DocCommentVisitor.
+func WalkerForDocComment(v DocCommentVisitor) FileWalker {
+	return &docCommentVisitor{visitor: v}
+}

--- a/lint/lint_private.go
+++ b/lint/lint_private.go
@@ -151,6 +151,8 @@ func addChecker(c abstractChecker, attrs ...checkerAttribute) {
 			return astwalk.WalkerForTypeExpr(v, ctx.typesInfo)
 		case astwalk.LocalCommentVisitor:
 			return astwalk.WalkerForLocalComment(v)
+		case astwalk.DocCommentVisitor:
+			return astwalk.WalkerForDocComment(v)
 		default:
 			panic(fmt.Sprintf("%T does not implement known visitor interface", c))
 		}

--- a/lint/testdata/deprecatedComment/negative_tests.go
+++ b/lint/testdata/deprecatedComment/negative_tests.go
@@ -1,0 +1,13 @@
+package linter_test
+
+// Deprecated: part of the old API; use API v2
+func ProperDeprecationComment() {}
+
+// This is not a Deprecated: comment at all.
+func FalsePositive1() {}
+
+// Deprecated is a function name.
+func Deprecated() {}
+
+// deprecated is a type name.
+type deprecated struct{}

--- a/lint/testdata/deprecatedComment/positive_tests.go
+++ b/lint/testdata/deprecatedComment/positive_tests.go
@@ -1,0 +1,56 @@
+package linter_test
+
+/// use `Deprecated: ` (note the casing) instead of `deprecated: `
+// deprecated: part of the old API; use API v2
+func LowerCasePrefix() {}
+
+/// use `Deprecated: ` (note the casing) instead of `DEPRECATED: `
+// DEPRECATED: part of the old API; use API v2
+func UpperCasePrefix() {}
+
+/// use `:` instead of `,` in `Deprecated, `
+// Deprecated, use XYZ instead.
+func CommaInsteadOfColon() {}
+
+/// the proper format is `Deprecated: <text>`
+// BadFormat1 is an example.
+// This function is deprecated, use XYZ instead.
+func BadFormat1() {}
+
+/// the proper format is `Deprecated: <text>`
+// BadFormat2 is an example, too.
+//
+// this function is deprecated, use XYZ instead.
+func BadFormat2() {}
+
+/// the proper format is `Deprecated: <text>`
+// BadFormat3 is an example, too.
+//
+// This type is deprecated, use XYZ instead.
+type BadFormat3 int
+
+/// the proper format is `Deprecated: <text>`
+// this type is deprecated, use XYZ instead.
+type badFormat4 int
+
+/// the proper format is `Deprecated: <text>`
+// deprecated! use something-else/a.f() instead
+const BadFormat5 int = 10
+
+/// the proper format is `Deprecated: <text>`
+//
+//
+// deprecated use XYZ instead
+const BadFormat6 int = 10
+
+/// the proper format is `Deprecated: <text>`
+//
+// DEPRECATED. use XYZ instead
+const BadFormat7 int = 10
+
+/// the proper format is `Deprecated: <text>`
+//
+// (This is why we're using case-insensitive patterns.)
+//
+// Deprecated! USE ANYTHING INSTEAD!
+const BadFormat8 = 10

--- a/lint/testdata/deprecatedComment/positive_tests.go
+++ b/lint/testdata/deprecatedComment/positive_tests.go
@@ -54,3 +54,21 @@ const BadFormat7 int = 10
 //
 // Deprecated! USE ANYTHING INSTEAD!
 const BadFormat8 = 10
+
+type badNestedDoc struct {
+	/// use `Deprecated: ` (note the casing) instead of `deprecated: `
+	// deprecated: ha-ha
+	foo struct {
+		/// use `:` instead of `,` in `Deprecated, `
+		// Deprecated, first deprecated field
+		field int
+
+		/// use `Deprecated: ` (note the casing) instead of `deprecated: `
+		// deprecated: another one
+		bar struct {
+			/// use `Deprecated: ` (note the casing) instead of `deprecated: `
+			// deprecated: deprecated field
+			field int
+		}
+	}
+}


### PR DESCRIPTION
Detects malformed deprecation comments.
When possible, suggests how to fix it.