### PR TITLE
lint: handle simplest typos in deprecatedComment checker

### DIFF
--- a/lint/deprecatedComment_checker.go
+++ b/lint/deprecatedComment_checker.go
@@ -40,7 +40,6 @@ func (c *deprecatedCommentChecker) Init() {
 	//
 	// TODO(quasilyte): currently it only handles a single missing letter.
 	// Might want to handle other kinds of common misspell/typo kinds.
-	// For example, TODO can be misspelled as TOOD.
 	c.commonTypos = []string{
 		"Dprecated: ",
 		"Derecated: ",

--- a/lint/deprecatedComment_checker.go
+++ b/lint/deprecatedComment_checker.go
@@ -14,6 +14,7 @@ type deprecatedCommentChecker struct {
 	checkerBase
 
 	commonPatterns []*regexp.Regexp
+	commonTypos    []string
 }
 
 func (c *deprecatedCommentChecker) InitDocumentation(d *Documentation) {
@@ -33,6 +34,23 @@ func (c *deprecatedCommentChecker) Init() {
 		regexp.MustCompile(`(?i)this (?:function|type) is deprecated`),
 		regexp.MustCompile(`(?i)deprecated[.!]? use \S* instead`),
 		// TODO(quasilyte): more of these?
+	}
+
+	// TODO(quasilyte): may want to generate this list programmatically.
+	//
+	// TODO(quasilyte): currently it only handles a single missing letter.
+	// Might want to handle other kinds of common misspell/typo kinds.
+	// For example, TODO can be misspelled as TOOD.
+	c.commonTypos = []string{
+		"Dprecated: ",
+		"Derecated: ",
+		"Depecated: ",
+		"Deprcated: ",
+		"Depreated: ",
+		"Deprected: ",
+		"Deprecaed: ",
+		"Deprecatd: ",
+		"Deprecate: ",
 	}
 }
 
@@ -82,6 +100,14 @@ func (c *deprecatedCommentChecker) VisitDocComment(doc *ast.CommentGroup) {
 				return
 			}
 		}
+
+		// Detect some simple typos.
+		for _, prefixWithTypo := range c.commonTypos {
+			if strings.HasPrefix(l, prefixWithTypo) {
+				c.warnTypo(doc, l)
+				return
+			}
+		}
 	}
 }
 
@@ -96,4 +122,9 @@ func (c *deprecatedCommentChecker) warnPattern(cause ast.Node) {
 
 func (c *deprecatedCommentChecker) warnComma(cause ast.Node) {
 	c.ctx.Warn(cause, "use `:` instead of `,` in `Deprecated, `")
+}
+
+func (c *deprecatedCommentChecker) warnTypo(cause ast.Node, line string) {
+	word := strings.Split(line, ":")[0]
+	c.ctx.Warn(cause, "typo in `%s`; should be `Deprecated`", word)
 }

--- a/lint/testdata/deprecatedComment/positive_tests.go
+++ b/lint/testdata/deprecatedComment/positive_tests.go
@@ -72,3 +72,45 @@ type badNestedDoc struct {
 		}
 	}
 }
+
+/// typo in `Dprecated`; should be `Deprecated`
+// Dprecated: ...
+func withTypo1() {}
+
+var (
+	/// typo in `Dprecated`; should be `Deprecated`
+	// Dprecated: ...
+	_ = 0
+
+	/// typo in `Derecated`; should be `Deprecated`
+	// Derecated: ...
+	_ = 0
+
+	/// typo in `Depecated`; should be `Deprecated`
+	// Depecated: ...
+	_ = 0
+
+	/// typo in `Deprcated`; should be `Deprecated`
+	// Deprcated: ...
+	_ = 0
+
+	/// typo in `Depreated`; should be `Deprecated`
+	// Depreated: ...
+	_ = 0
+
+	/// typo in `Deprected`; should be `Deprecated`
+	// Deprected: ...
+	_ = 0
+
+	/// typo in `Deprecaed`; should be `Deprecated`
+	// Deprecaed: ...
+	_ = 0
+
+	/// typo in `Deprecatd`; should be `Deprecated`
+	// Deprecatd: ...
+	_ = 0
+
+	/// typo in `Deprecate`; should be `Deprecated`
+	// Deprecate: ...
+	_ = 0
+)


### PR DESCRIPTION
There is a big room for improvements, this implementation
is like a stub for further cases.