### PR TITLE
lint: mark unusedParam as very opinionated

### DIFF
--- a/lint/unusedParam_checker.go
+++ b/lint/unusedParam_checker.go
@@ -5,7 +5,7 @@ import (
 )
 
 func init() {
-	addChecker(&unusedParamChecker{}, attrExperimental)
+	addChecker(&unusedParamChecker{}, attrExperimental, attrVeryOpinionated)
 }
 
 type unusedParamChecker struct {


### PR DESCRIPTION
We still need to make it less noisy when enabled.

Updates #516