### PR TITLE
lint: mark regexpMust as stable

### DIFF
--- a/lint/regexpMust_checker.go
+++ b/lint/regexpMust_checker.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	addChecker(&regexpMustChecker{}, attrExperimental)
+	addChecker(&regexpMustChecker{})
 }
 
 type regexpMustChecker struct {

--- a/lint/testdata/regexpMust/negative_tests.go
+++ b/lint/testdata/regexpMust/negative_tests.go
@@ -9,3 +9,14 @@ func noWarnings() {
 	_ = regexp.MustCompile(`go-critic linter`)
 	_ = regexp.MustCompilePOSIX(`go-critic linter`)
 }
+
+func nonConstPatterns(pat string) {
+	re, err := regexp.Compile(pat)
+	if err != nil {
+		panic(err)
+	}
+	_ = re
+
+	_, _ = regexp.Compile(pat)
+	_, _ = regexp.CompilePOSIX(pat)
+}


### PR DESCRIPTION
None false positives so far.
Implementation is trivial and there is almost no room for bugs.