### PR TITLE
lint: don't check locals in captLocal by default

### DIFF
--- a/lint/all_checkers_test.go
+++ b/lint/all_checkers_test.go
@@ -91,22 +91,21 @@ func TestCheckers(t *testing.T) {
 			ctx := NewContext(prog.Fset, sizes)
 			ctx.SetPackageInfo(&pkgInfo.Info, pkgInfo.Pkg)
 
-			checker := NewChecker(rule, ctx, testCfg[rule.Name()])
-			checkFiles(t, checker, ctx, prog, pkgPath)
+			checkFiles(t, testRule, ctx, prog, pkgPath)
 		})
 	}
 }
 
-func checkFiles(t *testing.T, c *Checker, ctx *Context, prog *loader.Program, pkgPath string) {
+func checkFiles(t *testing.T, rule *Rule, ctx *Context, prog *loader.Program, pkgPath string) {
 	files := prog.Imported[pkgPath].Files
 
 	for _, f := range files {
 		filename := getFilename(prog, f)
-		testFilename := filepath.Join("testdata", c.Rule.Name(), filename)
+		testFilename := filepath.Join("testdata", rule.Name(), filename)
 		goldenWarns := newGoldenFile(t, testFilename)
 
 		stripDirectives(f)
-		warns := c.Check(f)
+		warns := NewChecker(rule, ctx, testCfg[rule.Name()]).Check(f)
 
 		for _, warn := range warns {
 			line := ctx.FileSet().Position(warn.Node.Pos()).Line

--- a/lint/captLocal_checker.go
+++ b/lint/captLocal_checker.go
@@ -36,16 +36,41 @@ func (c *captLocalChecker) Init() {
 	c.checkLocals = c.ctx.params.Bool("checkLocals", false)
 }
 
-func (c *captLocalChecker) VisitLocalDef(def astwalk.Name, _ ast.Expr) {
-	if !c.checkLocals && def.Kind != astwalk.NameParam {
-		return
+func (c *captLocalChecker) EnterFunc(fn *ast.FuncDecl) bool {
+	// Check func params eagerly.
+	// We do this to avoid wasting clocks when checkLocals is false.
+	if fn.Recv != nil && len(fn.Recv.List[0].Names) != 0 {
+		c.checkDef(fn.Recv.List[0].Names[0])
+	}
+	for _, p := range fn.Type.Params.List {
+		for _, id := range p.Names {
+			c.checkDef(id)
+		}
+	}
+	if fn.Type.Results != nil {
+		for _, p := range fn.Type.Results.List {
+			for _, id := range p.Names {
+				c.checkDef(id)
+			}
+		}
 	}
 
+	return c.checkLocals && fn.Body != nil
+}
+
+func (c *captLocalChecker) VisitLocalDef(def astwalk.Name, _ ast.Expr) {
+	if def.Kind == astwalk.NameParam {
+		return // Already checked during EnterFunc
+	}
+	c.checkDef(def.ID)
+}
+
+func (c *captLocalChecker) checkDef(id *ast.Ident) {
 	switch {
-	case c.upcaseNames[def.ID.Name]:
-		c.warnUpcase(def.ID)
-	case ast.IsExported(def.ID.Name):
-		c.warnCapitalized(def.ID)
+	case c.upcaseNames[id.Name]:
+		c.warnUpcase(id)
+	case ast.IsExported(id.Name):
+		c.warnCapitalized(id)
 	}
 }
 

--- a/lint/captLocal_checker.go
+++ b/lint/captLocal_checker.go
@@ -15,6 +15,7 @@ type captLocalChecker struct {
 	checkerBase
 
 	upcaseNames map[string]bool
+	checkLocals bool
 }
 
 func (c *captLocalChecker) InitDocumentation(d *Documentation) {
@@ -31,9 +32,15 @@ func (c *captLocalChecker) Init() {
 
 		// TODO: add common acronyms like HTTP and URL?
 	}
+
+	c.checkLocals = c.ctx.params.Bool("checkLocals", false)
 }
 
 func (c *captLocalChecker) VisitLocalDef(def astwalk.Name, _ ast.Expr) {
+	if !c.checkLocals && def.Kind != astwalk.NameParam {
+		return
+	}
+
 	switch {
 	case c.upcaseNames[def.ID.Name]:
 		c.warnUpcase(def.ID)


### PR DESCRIPTION
Only check params by default.
checkLocals=true enables previous behavior.
Tests are executed with checkLocals set to true.

Updates #530
Fixes #526