### PR TITLE
lint: fix concurrent map write in Checker.Check(file)

### DIFF
--- a/cmd/criticize/main.go
+++ b/cmd/criticize/main.go
@@ -237,7 +237,7 @@ func (l *linter) CheckPackage(pkgPath string) {
 		if !l.flags.CheckGenerated && l.isGenerated(f) {
 			continue
 		}
-		l.ctx.SetFileInfo(l.getFilename(f))
+		l.ctx.SetFileInfo(l.getFilename(f), f)
 		l.checkFile(f)
 	}
 }

--- a/lint/all_checkers_test.go
+++ b/lint/all_checkers_test.go
@@ -101,6 +101,7 @@ func checkFiles(t *testing.T, rule *Rule, ctx *Context, prog *loader.Program, pk
 
 	for _, f := range files {
 		filename := getFilename(prog, f)
+		ctx.SetFileInfo(filename, f)
 		testFilename := filepath.Join("testdata", rule.Name(), filename)
 		goldenWarns := newGoldenFile(t, testFilename)
 

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -92,12 +92,6 @@ type Checker struct {
 // Check runs rule checker over file f.
 func (c *Checker) Check(f *ast.File) []Warning {
 	c.ctx.warnings = c.ctx.warnings[:0]
-	if c.ctx.require.pkgObjects {
-		resolvePkgObjects(c.ctx.Context, f)
-	}
-	if c.ctx.require.pkgRenames {
-		resolvePkgRenames(c.ctx.Context, f)
-	}
 	c.walker.WalkFile(f)
 	return c.ctx.warnings
 }
@@ -187,8 +181,14 @@ func (c *Context) SetPackageInfo(info *types.Info, pkg *types.Package) {
 // SetFileInfo sets file-related metadata.
 //
 // Must be called for every source code file being checked.
-func (c *Context) SetFileInfo(filename string) {
-	c.filename = filename
+func (c *Context) SetFileInfo(name string, f *ast.File) {
+	c.filename = name
+	if c.require.pkgObjects {
+		resolvePkgObjects(c, f)
+	}
+	if c.require.pkgRenames {
+		resolvePkgRenames(c, f)
+	}
 }
 
 // Documentation holds rule structured documentation.


### PR DESCRIPTION
Move file-related resource loading into Context.SetFileInfo.
This way, integrating code can resolve these Context.require
fields before running checkers concurrently.

Fixes #617