### PR TITLE
lint: mark longChain as opinionated (temporary solution)

### DIFF
--- a/lint/longChain_checker.go
+++ b/lint/longChain_checker.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	addChecker(&longChainChecker{}, attrExperimental)
+	addChecker(&longChainChecker{}, attrExperimental, attrVeryOpinionated)
 }
 
 type longChainChecker struct {


### PR DESCRIPTION
Make it easier to avoid using it for the users that
do provide -withExperimental flag.

If not proven to be useful or fixable, should be
removed completely in near time.

Updates #445