### PR TITLE
lint: fix commentedOutCode handling of "f ()"

### DIFF
--- a/lint/testdata/commentedOutCode/negative_tests.go
+++ b/lint/testdata/commentedOutCode/negative_tests.go
@@ -31,4 +31,16 @@ func permittedComments() {
 	// type myInt int
 
 	// <-ch
+
+	// functionCall (1, 2)
+
+	// fooooooooooo (())
+
+	// funcfuncfunc0_1 ()
+
+	// FcallIntString  (1, "123")
+
+	// notAfunccall (this is not a function call)
+
+	// funccall () with period .
 }


### PR DESCRIPTION
Skip ast.CallExpr something looks like a function call, but there
is an extra whitespace between a callable expression and
parameter list.