### PR TITLE
lint/testdata: use "checker_test" package everywhere

### DIFF
--- a/lint/testdata/deprecatedComment/negative_tests.go
+++ b/lint/testdata/deprecatedComment/negative_tests.go
@@ -1,4 +1,4 @@
-package linter_test
+package checker_test
 
 // Deprecated: part of the old API; use API v2
 func ProperDeprecationComment() {}

--- a/lint/testdata/deprecatedComment/positive_tests.go
+++ b/lint/testdata/deprecatedComment/positive_tests.go
@@ -1,4 +1,4 @@
-package linter_test
+package checker_test
 
 /// use `Deprecated: ` (note the casing) instead of `deprecated: `
 // deprecated: part of the old API; use API v2

--- a/lint/testdata/unlambda/negative_tests.go
+++ b/lint/testdata/unlambda/negative_tests.go
@@ -1,4 +1,4 @@
-package linter_test
+package checker_test
 
 func goodFunctionLiterals() {
 	_ = returnInt

--- a/lint/testdata/unlambda/positive_tests.go
+++ b/lint/testdata/unlambda/positive_tests.go
@@ -1,4 +1,4 @@
-package linter_test
+package checker_test
 
 func returnIntError(x int) (int, error) {
 	return x, nil


### PR DESCRIPTION
There were 2 checkers that used "linter_test" package.