### PR TITLE
lint: simplify code by using helper convertion funcs

### DIFF
--- a/lint/appendCombine_checker.go
+++ b/lint/appendCombine_checker.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/token"
 
+	"github.com/go-critic/go-critic/lint/internal/lintutil"
 	"github.com/go-toolsmith/astequal"
 )
 
@@ -66,15 +67,11 @@ func (c *appendCombineChecker) matchAppend(stmt ast.Stmt, slice ast.Expr) *ast.C
 	// xs are 0-N append arguments, but not variadic argument,
 	// because it makes append combining impossible.
 
-	assign, ok := stmt.(*ast.AssignStmt)
-	{
-		cond := ok &&
-			len(assign.Lhs) == 1 &&
-			len(assign.Rhs) == 1
-		if !cond {
-			return nil
-		}
+	assign := lintutil.AsAssignStmt(stmt)
+	if len(assign.Lhs) != 1 || len(assign.Rhs) != 1 {
+		return nil
 	}
+
 	call, ok := assign.Rhs[0].(*ast.CallExpr)
 	{
 		cond := ok &&

--- a/lint/emptyFmt_checker.go
+++ b/lint/emptyFmt_checker.go
@@ -2,6 +2,8 @@ package lint
 
 import (
 	"go/ast"
+
+	"github.com/go-critic/go-critic/lint/internal/lintutil"
 )
 
 func init() {
@@ -23,11 +25,7 @@ errors.New("wherever")`
 }
 
 func (c *emptyFmtChecker) VisitExpr(expr ast.Expr) {
-	call, ok := expr.(*ast.CallExpr)
-	if !ok {
-		return
-	}
-
+	call := lintutil.AsCallExpr(expr)
 	name := qualifiedName(call.Fun)
 
 	switch len(call.Args) {

--- a/lint/internal/lintutil/coerce.go
+++ b/lint/internal/lintutil/coerce.go
@@ -1,0 +1,121 @@
+package lintutil
+
+import (
+	"go/ast"
+	"go/token"
+)
+
+var (
+	nilIdent        = &ast.Ident{}
+	nilSelectorExpr = &ast.SelectorExpr{}
+	nilUnaryExpr    = &ast.UnaryExpr{}
+	nilBinaryExpr   = &ast.BinaryExpr{}
+	nilCallExpr     = &ast.CallExpr{}
+	nilParenExpr    = &ast.ParenExpr{}
+	nilAssignStmt   = &ast.AssignStmt{}
+)
+
+// IsNil reports whether x is nil.
+// Unlike simple nil check, also detects nil AST sentinels.
+func IsNil(x ast.Node) bool {
+	switch x := x.(type) {
+	case *ast.Ident:
+		return x == nilIdent || x == nil
+	case *ast.SelectorExpr:
+		return x == nilSelectorExpr || x == nil
+	case *ast.UnaryExpr:
+		return x == nilUnaryExpr || x == nil
+	case *ast.BinaryExpr:
+		return x == nilBinaryExpr || x == nil
+	case *ast.CallExpr:
+		return x == nilCallExpr || x == nil
+	case *ast.ParenExpr:
+		return x == nilParenExpr || x == nil
+	case *ast.AssignStmt:
+		return x == nilAssignStmt || x == nil
+
+	default:
+		return x == nil
+	}
+}
+
+// AsIdent coerces x into non-nil ident.
+func AsIdent(x ast.Node) *ast.Ident {
+	e, ok := x.(*ast.Ident)
+	if !ok {
+		return nilIdent
+	}
+	return e
+}
+
+// AsSelectorExpr coerces x into non-nil selector expr.
+func AsSelectorExpr(x ast.Node) *ast.SelectorExpr {
+	e, ok := x.(*ast.SelectorExpr)
+	if !ok {
+		return nilSelectorExpr
+	}
+	return e
+}
+
+// AsUnaryExpr coerces x into non-nil unary expr.
+func AsUnaryExpr(x ast.Node) *ast.UnaryExpr {
+	e, ok := x.(*ast.UnaryExpr)
+	if !ok {
+		return nilUnaryExpr
+	}
+	return e
+}
+
+// AsUnaryExprOp is like AsUnaryExpr, but also checks for op token.
+func AsUnaryExprOp(x ast.Node, op token.Token) *ast.UnaryExpr {
+	e, ok := x.(*ast.UnaryExpr)
+	if !ok || e.Op != op {
+		return nilUnaryExpr
+	}
+	return e
+}
+
+// AsBinaryExpr coerces x into non-nil binary expr.
+func AsBinaryExpr(x ast.Node) *ast.BinaryExpr {
+	e, ok := x.(*ast.BinaryExpr)
+	if !ok {
+		return nilBinaryExpr
+	}
+	return e
+}
+
+// AsBinaryExprOp is like AsBinaryExpr, but also checks for op token.
+func AsBinaryExprOp(x ast.Node, op token.Token) *ast.BinaryExpr {
+	e, ok := x.(*ast.BinaryExpr)
+	if !ok || e.Op != op {
+		return nilBinaryExpr
+	}
+	return e
+}
+
+// AsCallExpr coerces x into non-nil call expr.
+func AsCallExpr(x ast.Node) *ast.CallExpr {
+	e, ok := x.(*ast.CallExpr)
+	if !ok {
+		return nilCallExpr
+	}
+	return e
+}
+
+// AsParenExpr coerces x into non-nil paren expr.
+func AsParenExpr(x ast.Node) *ast.ParenExpr {
+	e, ok := x.(*ast.ParenExpr)
+	if !ok {
+		return nilParenExpr
+	}
+	return e
+}
+
+// AsAssignStmt coerces x into non-nil assign stmt.
+func AsAssignStmt(x ast.Node) *ast.AssignStmt {
+	stmt, ok := x.(*ast.AssignStmt)
+	if !ok {
+		return nilAssignStmt
+	}
+	return stmt
+}

--- a/lint/methodExprCall_checker.go
+++ b/lint/methodExprCall_checker.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/types"
 
+	"github.com/go-critic/go-critic/lint/internal/lintutil"
 	"github.com/go-toolsmith/astcopy"
 )
 
@@ -24,20 +25,9 @@ f.bar()`
 }
 
 func (c *methodExprCallChecker) VisitExpr(x ast.Expr) {
-	call, ok := x.(*ast.CallExpr)
-	if !ok {
-		return
-	}
-
-	s, ok := call.Fun.(*ast.SelectorExpr)
-	if !ok {
-		return
-	}
-
-	id, ok := s.X.(*ast.Ident)
-	if !ok {
-		return
-	}
+	call := lintutil.AsCallExpr(x)
+	s := lintutil.AsSelectorExpr(call.Fun)
+	id := lintutil.AsIdent(s.X)
 
 	obj := c.ctx.typesInfo.ObjectOf(id)
 	if _, ok := obj.(*types.TypeName); ok {

--- a/lint/underef_checker.go
+++ b/lint/underef_checker.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/types"
 
+	"github.com/go-critic/go-critic/lint/internal/lintutil"
 	"github.com/go-toolsmith/astp"
 )
 
@@ -34,10 +35,7 @@ func (c *underefChecker) Init() {
 func (c *underefChecker) VisitExpr(expr ast.Expr) {
 	switch n := expr.(type) {
 	case *ast.SelectorExpr:
-		expr, ok := n.X.(*ast.ParenExpr)
-		if !ok {
-			return
-		}
+		expr := lintutil.AsParenExpr(n.X)
 		if c.skipRecvCopy && c.isPtrRecvMethodCall(n.Sel) {
 			return
 		}
@@ -48,10 +46,7 @@ func (c *underefChecker) VisitExpr(expr ast.Expr) {
 			}
 		}
 	case *ast.IndexExpr:
-		expr, ok := n.X.(*ast.ParenExpr)
-		if !ok {
-			return
-		}
+		expr := lintutil.AsParenExpr(n.X)
 		if expr, ok := expr.X.(*ast.StarExpr); ok {
 			if !c.checkStarExpr(expr) {
 				return

--- a/lint/unlambda_checker.go
+++ b/lint/unlambda_checker.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/types"
 
+	"github.com/go-critic/go-critic/lint/internal/lintutil"
 	"github.com/go-toolsmith/astequal"
 )
 
@@ -32,10 +33,7 @@ func (c *unlambdaChecker) VisitExpr(x ast.Expr) {
 		return
 	}
 
-	result, ok := ret.Results[0].(*ast.CallExpr)
-	if !ok {
-		return
-	}
+	result := lintutil.AsCallExpr(ret.Results[0])
 	callable := qualifiedName(result.Fun)
 	if callable == "" {
 		return // Skip tricky cases; only handle simple calls


### PR DESCRIPTION
Use nil sentinel objects to reduce the amount of nil checks.
This idiom leads to more readable and short code.