### PR TITLE
 lint: add indexAlloc checker

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -181,6 +181,10 @@ This page describes checks supported by [go-critic](https://github.com/go-critic
         <td>Detects when imported package names shadowed in assignments</td>
       </tr>
       <tr>
+        <td><a href="#indexAlloc-ref">indexAlloc</a></td>
+        <td>Detects strings.Index calls that may cause unwanted allocs</td>
+      </tr>
+      <tr>
         <td><a href="#indexOnlyLoop-ref">indexOnlyLoop</a></td>
         <td>Detects for loops that can benefit from rewrite to range loop</td>
       </tr>
@@ -906,6 +910,24 @@ func myFunc(filepath string) {
 ```go
 func myFunc(filename string) {
 }
+```
+
+
+
+<a name="indexAlloc-ref"></a>
+## indexAlloc
+Detects strings.Index calls that may cause unwanted allocs.
+
+
+
+**Before:**
+```go
+strings.Index(string(x), y)
+```
+
+**After:**
+```go
+bytes.Index(x, []byte(y))
 ```
 
 

--- a/lint/assignOp_checker.go
+++ b/lint/assignOp_checker.go
@@ -28,7 +28,7 @@ func (c *assignOpChecker) VisitStmt(stmt ast.Stmt) {
 		assign.Tok == token.ASSIGN &&
 		len(assign.Lhs) == 1 &&
 		len(assign.Rhs) == 1 &&
-		isSafeExpr(assign.Lhs[0])
+		isSafeExpr(c.ctx.typesInfo, assign.Lhs[0])
 	if !cond {
 		return
 	}

--- a/lint/boolExprSimplify_checker.go
+++ b/lint/boolExprSimplify_checker.go
@@ -113,7 +113,7 @@ func (c *boolExprSimplifyChecker) combineChecks(cur *astutil.Cursor) bool {
 	if !astequal.Expr(lhs.X, rhs.X) || !astequal.Expr(lhs.Y, rhs.Y) {
 		return false
 	}
-	if !isSafeExpr(lhs.X) || !isSafeExpr(lhs.Y) {
+	if !isSafeExpr(c.ctx.typesInfo, lhs.X) || !isSafeExpr(c.ctx.typesInfo, lhs.Y) {
 		return false
 	}
 

--- a/lint/dupSubExpr_checker.go
+++ b/lint/dupSubExpr_checker.go
@@ -80,7 +80,7 @@ func (c *dupSubExprChecker) checkBinaryExpr(expr *ast.BinaryExpr) {
 	if c.resultIsFloat(expr.X) && c.floatOpsSet[expr.Op] {
 		return
 	}
-	if isSafeExpr(expr) && c.opSet[expr.Op] && astequal.Expr(expr.X, expr.Y) {
+	if isSafeExpr(c.ctx.typesInfo, expr) && c.opSet[expr.Op] && astequal.Expr(expr.X, expr.Y) {
 		c.warn(expr)
 	}
 }

--- a/lint/indexAlloc_checker.go
+++ b/lint/indexAlloc_checker.go
@@ -18,6 +18,7 @@ func (c *indexAllocChecker) InitDocumentation(d *Documentation) {
 	d.Summary = "Detects strings.Index calls that may cause unwanted allocs"
 	d.Before = `strings.Index(string(x), y)`
 	d.After = `bytes.Index(x, []byte(y))`
+	d.Note = `See Go issue for details: https://github.com/golang/go/issues/25864`
 }
 
 func (c *indexAllocChecker) VisitExpr(e ast.Expr) {
@@ -31,10 +32,9 @@ func (c *indexAllocChecker) VisitExpr(e ast.Expr) {
 	}
 	x := stringConv.Args[0]
 	y := call.Args[1]
-	if !isSafeExpr(c.ctx.typesInfo, x) || !isSafeExpr(c.ctx.typesInfo, y) {
-		return
+	if isSafeExpr(c.ctx.typesInfo, x) && isSafeExpr(c.ctx.typesInfo, y) {
+		c.warn(e, x, y)
 	}
-	c.warn(e, x, y)
 }
 
 func (c *indexAllocChecker) warn(cause ast.Node, x, y ast.Expr) {

--- a/lint/indexAlloc_checker.go
+++ b/lint/indexAlloc_checker.go
@@ -1,0 +1,43 @@
+package lint
+
+import (
+	"go/ast"
+
+	"github.com/go-critic/go-critic/lint/internal/lintutil"
+)
+
+func init() {
+	addChecker(&indexAllocChecker{}, attrExperimental, attrPerformance)
+}
+
+type indexAllocChecker struct {
+	checkerBase
+}
+
+func (c *indexAllocChecker) InitDocumentation(d *Documentation) {
+	d.Summary = "Detects strings.Index calls that may cause unwanted allocs"
+	d.Before = `strings.Index(string(x), y)`
+	d.After = `bytes.Index(x, []byte(y))`
+}
+
+func (c *indexAllocChecker) VisitExpr(e ast.Expr) {
+	call := lintutil.AsCallExpr(e)
+	if qualifiedName(call.Fun) != "strings.Index" {
+		return
+	}
+	stringConv := lintutil.AsCallExpr(call.Args[0])
+	if qualifiedName(stringConv.Fun) != "string" {
+		return
+	}
+	x := stringConv.Args[0]
+	y := call.Args[1]
+	if !isSafeExpr(c.ctx.typesInfo, x) || !isSafeExpr(c.ctx.typesInfo, y) {
+		return
+	}
+	c.warn(e, x, y)
+}
+
+func (c *indexAllocChecker) warn(cause ast.Node, x, y ast.Expr) {
+	c.ctx.Warn(cause, "consider replacing %s with bytes.Index(%s, []byte(%s))",
+		cause, x, y)
+}

--- a/lint/nilValReturn_checker.go
+++ b/lint/nilValReturn_checker.go
@@ -44,7 +44,7 @@ func (c *nilValReturnChecker) VisitStmt(stmt ast.Stmt) {
 	expr, ok := ifStmt.Cond.(*ast.BinaryExpr)
 	cond := ok &&
 		expr.Op == token.EQL &&
-		isSafeExpr(expr.X) &&
+		isSafeExpr(c.ctx.typesInfo, expr.X) &&
 		qualifiedName(expr.Y) == "nil" &&
 		astequal.Expr(expr.X, ret.Results[0])
 	if cond {

--- a/lint/testdata/indexAlloc/negative_tests.go
+++ b/lint/testdata/indexAlloc/negative_tests.go
@@ -1,0 +1,23 @@
+package checker_tests
+
+import "bytes"
+
+func fixedCode(x []byte, y string) {
+	_ = bytes.Index(x, []byte(y))
+	_ = bytes.Index([]byte("12"), []byte(y))
+	_ = bytes.Index([]byte{'1', '2'}, []byte(y))
+	_ = bytes.Index(x, []byte("a"+y))
+}
+
+func getBytes() []byte  { return nil }
+func getString() string { return "" }
+
+func unsafeArgs(x []byte, y string) {
+	_ = bytes.Index(getBytes(), []byte(y))
+	_ = bytes.Index(getBytes(), []byte("a"+y))
+
+	_ = bytes.Index(x, []byte(getString()))
+	_ = bytes.Index([]byte("12"), []byte(getString()))
+	_ = bytes.Index([]byte{'1', '2'}, []byte(getString()))
+	_ = bytes.Index(x, []byte("a"+getString()))
+}

--- a/lint/testdata/indexAlloc/negative_tests.go
+++ b/lint/testdata/indexAlloc/negative_tests.go
@@ -1,6 +1,9 @@
 package checker_tests
 
-import "bytes"
+import (
+	"bytes"
+	"strings"
+)
 
 func fixedCode(x []byte, y string) {
 	_ = bytes.Index(x, []byte(y))
@@ -20,4 +23,11 @@ func unsafeArgs(x []byte, y string) {
 	_ = bytes.Index([]byte("12"), []byte(getString()))
 	_ = bytes.Index([]byte{'1', '2'}, []byte(getString()))
 	_ = bytes.Index(x, []byte("a"+getString()))
+
+	_ = strings.Index(string(getBytes()), y)
+	_ = strings.Index(string(getBytes()), "a"+y)
+
+	_ = strings.Index(string(x), getString())
+	_ = strings.Index(string([]byte(getString())), getString())
+	_ = strings.Index(string(x), "a"+getString())
 }

--- a/lint/testdata/indexAlloc/positive_tests.go
+++ b/lint/testdata/indexAlloc/positive_tests.go
@@ -1,0 +1,17 @@
+package checker_tests
+
+import "strings"
+
+func positiveTests(x []byte, y string) {
+	/// consider replacing strings.Index(string(x), y) with bytes.Index(x, []byte(y))
+	_ = strings.Index(string(x), y)
+
+	/// consider replacing strings.Index(string([]byte("12")), y) with bytes.Index([]byte("12"), []byte(y))
+	_ = strings.Index(string([]byte("12")), y)
+
+	/// consider replacing strings.Index(string([]byte{'1', '2'}), y) with bytes.Index([]byte{'1', '2'}, []byte(y))
+	_ = strings.Index(string([]byte{'1', '2'}), y)
+
+	/// consider replacing strings.Index(string(x), "a"+y) with bytes.Index(x, []byte("a" + y))
+	_ = strings.Index(string(x), "a"+y)
+}

--- a/lint/util.go
+++ b/lint/util.go
@@ -129,16 +129,23 @@ func isSafeExpr(info *types.Info, expr ast.Expr) bool {
 	case *ast.ParenExpr:
 		return isSafeExpr(info, expr.X)
 	case *ast.CompositeLit:
-		for _, x := range expr.Elts {
-			if !isSafeExpr(info, x) {
-				return false
-			}
-		}
-		return true
+		return isSafeExprList(info, expr.Elts)
 	case *ast.CallExpr:
-		return lintutil.IsTypeExpr(info, expr.Fun)
+		return lintutil.IsTypeExpr(info, expr.Fun) &&
+			isSafeExprList(info, expr.Args)
 
 	default:
 		return false
 	}
+}
+
+// isSafeExprList reports whether every expr in list is safe.
+// See isSafeExpr.
+func isSafeExprList(info *types.Info, list []ast.Expr) bool {
+	for _, expr := range list {
+		if !isSafeExpr(info, expr) {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Performance check.

Suggests to replace strings.Index with bytes.Index
where it can make code more efficient.

See golang/go#25864