### PR TITLE
#669 renames package name from checker_tests into checker_test

### DIFF
--- a/lint/testdata/appendAssign/negative_tests.go
+++ b/lint/testdata/appendAssign/negative_tests.go
@@ -1,4 +1,4 @@
-package checker_tests
+package checker_test
 
 func normalAppends() {
 	var xs, ys []int

--- a/lint/testdata/appendAssign/positive_tests.go
+++ b/lint/testdata/appendAssign/positive_tests.go
@@ -1,4 +1,4 @@
-package checker_tests
+package checker_test
 
 func suspeciousAppends() {
 	var xs []int

--- a/lint/testdata/boolExprSimplify/negative_tests.go
+++ b/lint/testdata/boolExprSimplify/negative_tests.go
@@ -1,4 +1,4 @@
-package checker_tests
+package checker_test
 
 func idealExpressions() {
 	// No negations:

--- a/lint/testdata/boolExprSimplify/positive_tests.go
+++ b/lint/testdata/boolExprSimplify/positive_tests.go
@@ -1,4 +1,4 @@
-package checker_tests
+package checker_test
 
 var (
 	x, y, z bool

--- a/lint/testdata/commentedOutCode/negative_tests.go
+++ b/lint/testdata/commentedOutCode/negative_tests.go
@@ -1,4 +1,4 @@
-package checker_tests
+package checker_test
 
 func permittedComments() {
 	// TODO: foo(1+2)

--- a/lint/testdata/commentedOutCode/positive_tests.go
+++ b/lint/testdata/commentedOutCode/positive_tests.go
@@ -1,4 +1,4 @@
-package checker_tests
+package checker_test
 
 func singleLineCode() {
 	/// may want to remove commented-out code

--- a/lint/testdata/deadCodeAfterLogFatal/negative_tests.go
+++ b/lint/testdata/deadCodeAfterLogFatal/negative_tests.go
@@ -1,4 +1,4 @@
-package checker_tests
+package checker_test
 
 import (
 	"log"

--- a/lint/testdata/deadCodeAfterLogFatal/positive_tests.go
+++ b/lint/testdata/deadCodeAfterLogFatal/positive_tests.go
@@ -1,4 +1,4 @@
-package checker_tests
+package checker_test
 
 import "log"
 

--- a/lint/testdata/dupCase/negative_tests.go
+++ b/lint/testdata/dupCase/negative_tests.go
@@ -1,4 +1,4 @@
-package checker_tests
+package checker_test
 
 func goodBoolSwitch(x, y int, v []int) {
 	switch {

--- a/lint/testdata/dupCase/positive_tests.go
+++ b/lint/testdata/dupCase/positive_tests.go
@@ -1,4 +1,4 @@
-package checker_tests
+package checker_test
 
 func boolSwitch(x, y int, v []int) {
 	switch {

--- a/lint/testdata/emptyFallthrough/negative_tests.go
+++ b/lint/testdata/emptyFallthrough/negative_tests.go
@@ -1,4 +1,4 @@
-package checker_tests
+package checker_test
 
 import "fmt"
 

--- a/lint/testdata/emptyFallthrough/positive_tests.go
+++ b/lint/testdata/emptyFallthrough/positive_tests.go
@@ -1,4 +1,4 @@
-package checker_tests
+package checker_test
 
 import (
 	"fmt"

--- a/lint/testdata/evalOrder/negative_tests.go
+++ b/lint/testdata/evalOrder/negative_tests.go
@@ -1,4 +1,4 @@
-package checker_tests
+package checker_test
 
 import "unsafe"
 

--- a/lint/testdata/evalOrder/positive_tests.go
+++ b/lint/testdata/evalOrder/positive_tests.go
@@ -1,4 +1,4 @@
-package checker_tests
+package checker_test
 
 func mayMutateInt1(x *int) int { return 0 }
 

--- a/lint/testdata/indexAlloc/negative_tests.go
+++ b/lint/testdata/indexAlloc/negative_tests.go
@@ -1,4 +1,4 @@
-package checker_tests
+package checker_test
 
 import (
 	"bytes"

--- a/lint/testdata/indexAlloc/positive_tests.go
+++ b/lint/testdata/indexAlloc/positive_tests.go
@@ -1,4 +1,4 @@
-package checker_tests
+package checker_test
 
 import "strings"
 

--- a/lint/testdata/namedConst/negative_tests.go
+++ b/lint/testdata/namedConst/negative_tests.go
@@ -1,4 +1,4 @@
-package checker_tests
+package checker_test
 
 import (
 	"time"

--- a/lint/testdata/namedConst/positive_tests.go
+++ b/lint/testdata/namedConst/positive_tests.go
@@ -1,4 +1,4 @@
-package checker_tests
+package checker_test
 
 import (
 	mytime "time"

--- a/lint/testdata/regexpMust/negative_tests.go
+++ b/lint/testdata/regexpMust/negative_tests.go
@@ -1,4 +1,4 @@
-package checker_tests
+package checker_test
 
 import "regexp"
 

--- a/lint/testdata/regexpMust/positive_tests.go
+++ b/lint/testdata/regexpMust/positive_tests.go
@@ -1,4 +1,4 @@
-package checker_tests
+package checker_test
 
 import "regexp"
 

--- a/lint/testdata/sqlRowsClose/negative_tests.go
+++ b/lint/testdata/sqlRowsClose/negative_tests.go
@@ -1,4 +1,4 @@
-package checker_tests
+package checker_test
 
 import "database/sql"
 

--- a/lint/testdata/sqlRowsClose/positive_tests.go
+++ b/lint/testdata/sqlRowsClose/positive_tests.go
@@ -1,4 +1,4 @@
-package checker_tests
+package checker_test
 
 import "database/sql"
 

--- a/lint/testdata/underef/negative_tests.go
+++ b/lint/testdata/underef/negative_tests.go
@@ -1,4 +1,4 @@
-package checker_tests
+package checker_test
 
 func (s *sampleStruct) method() {
 }

--- a/lint/testdata/underef/positive_tests.go
+++ b/lint/testdata/underef/positive_tests.go
@@ -1,4 +1,4 @@
-package checker_tests
+package checker_test
 
 type sampleStruct struct {
 	field        int


### PR DESCRIPTION
# Fixes #669 

I have renamed package checker_tests into checker_test. Now, It has resulted as below.
```
$ grep -nr 'package checker_test$' | wc -l
115
$ grep -nr 'package checker_tests$' | wc -l
0
```