### PR TITLE
lint: fix blank import warning for importShadow checker

### DIFF
--- a/lint/all_checkers_test.go
+++ b/lint/all_checkers_test.go
@@ -101,14 +101,14 @@ func checkFiles(t *testing.T, rule *Rule, ctx *Context, prog *loader.Program, pk
 
 	for _, f := range files {
 		filename := getFilename(prog, f)
-		ctx.SetFileInfo(filename, f)
 		testFilename := filepath.Join("testdata", rule.Name(), filename)
 		goldenWarns := newGoldenFile(t, testFilename)
 
+		c := NewChecker(rule, ctx, testCfg[rule.Name()])
 		stripDirectives(f)
-		warns := NewChecker(rule, ctx, testCfg[rule.Name()]).Check(f)
+		ctx.SetFileInfo(filename, f)
 
-		for _, warn := range warns {
+		for _, warn := range c.Check(f) {
 			line := ctx.FileSet().Position(warn.Node.Pos()).Line
 
 			if w := goldenWarns.find(line, warn.Text); w != nil {

--- a/lint/importShadow_checker.go
+++ b/lint/importShadow_checker.go
@@ -32,7 +32,7 @@ func (c *importShadowChecker) Init() {
 
 func (c *importShadowChecker) VisitLocalDef(def astwalk.Name, _ ast.Expr) {
 	for pkgObj, name := range c.ctx.pkgObjects {
-		if name == def.ID.Name {
+		if name == def.ID.Name && name != "_" {
 			c.warnImportShadowed(def.ID, name, pkgObj.Imported())
 		}
 	}

--- a/lint/testdata/importShadow/negative_tests.go
+++ b/lint/testdata/importShadow/negative_tests.go
@@ -23,4 +23,6 @@ var _ = 10
 
 func blankParam(_ int) {
 	_ = 10
+	_, x := 1, 2
+	_ = x
 }


### PR DESCRIPTION
Also fixed broken negative tests for checkers that depend
on the SetFileInfo being called before Check(f).

Fixes #665

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>