### PR TITLE
lint: remove "performance" attr from appendAssignChecker

### DIFF
--- a/lint/appendAssign_checker.go
+++ b/lint/appendAssign_checker.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	addChecker(&appendAssignChecker{}, attrExperimental, attrPerformance)
+	addChecker(&appendAssignChecker{}, attrExperimental)
 }
 
 type appendAssignChecker struct {


### PR DESCRIPTION
lint: remove "performance" attr from appendAssignChecker
fix #685 