### PR TITLE
* removed all redundant newlines before `}` Issue: #698

### DIFF
--- a/lint/testdata/typeUnparen/negative_tests.go
+++ b/lint/testdata/typeUnparen/negative_tests.go
@@ -38,7 +38,6 @@ func f() {
 		localC1 = (1 + (2 + 3))
 		localC2 = (1 << 2 << 3)
 	)
-
 }
 
 type ifaceToEmbed interface{}

--- a/lint/unlambda_checker.go
+++ b/lint/unlambda_checker.go
@@ -55,7 +55,6 @@ func (c *unlambdaChecker) VisitExpr(x ast.Expr) {
 	}
 
 	c.warn(fn, callable)
-
 }
 
 func (c *unlambdaChecker) warn(cause ast.Node, suggestion string) {


### PR DESCRIPTION
searched all files with grep - regex: ^\s*$\s*}