### PR TITLE
checkers: add commentFormatting checker

### DIFF
--- a/checkers/commentFormatting_checker.go
+++ b/checkers/commentFormatting_checker.go
@@ -49,16 +49,20 @@ func (c *commentFormattingChecker) VisitComment(cg *ast.CommentGroup) {
 
 		// Make a decision based on a first comment text rune.
 		r, _ := utf8.DecodeRuneInString(comment.Text[len("//"):])
-		switch r {
-		case '+', '-', '#', '!':
-			// Permitted list to avoid false-positives.
-			continue
-		default:
-			if !unicode.IsSpace(r) {
-				c.warn(cg)
-				return
-			}
+		if !c.specialChar(r) && !unicode.IsSpace(r) {
+			c.warn(cg)
+			return
 		}
+	}
+}
+
+func (c *commentFormattingChecker) specialChar(r rune) bool {
+	// Permitted list to avoid false-positives.
+	switch r {
+	case '+', '-', '#', '!':
+		return true
+	default:
+		return false
 	}
 }
 

--- a/checkers/commentFormatting_checker.go
+++ b/checkers/commentFormatting_checker.go
@@ -1,0 +1,67 @@
+package checkers
+
+import (
+	"go/ast"
+	"regexp"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/go-lintpack/lintpack"
+	"github.com/go-lintpack/lintpack/astwalk"
+)
+
+func init() {
+	var info lintpack.CheckerInfo
+	info.Name = "commentFormatting"
+	info.Tags = []string{"style", "experimental"}
+	info.Summary = "Detects comments with non-idiomatic formatting"
+	info.Before = `//This is a comment`
+	info.After = `// This is a comment`
+
+	collection.AddChecker(&info, func(ctx *lintpack.CheckerContext) lintpack.FileWalker {
+		pragmaRE := regexp.MustCompile(`(?m)^//\w+:.*$`)
+		return astwalk.WalkerForComment(&commentFormattingChecker{
+			ctx:      ctx,
+			pragmaRE: pragmaRE,
+		})
+	})
+}
+
+type commentFormattingChecker struct {
+	astwalk.WalkHandler
+	ctx *lintpack.CheckerContext
+
+	pragmaRE *regexp.Regexp
+}
+
+func (c *commentFormattingChecker) VisitComment(cg *ast.CommentGroup) {
+	if strings.HasPrefix(cg.List[0].Text, "/*") {
+		return
+	}
+	for _, comment := range cg.List {
+		if len(comment.Text) <= len("// ") {
+			continue
+		}
+		if c.pragmaRE.MatchString(comment.Text) {
+			continue
+		}
+
+		// Make a decision based on a first comment text rune.
+		r, _ := utf8.DecodeRuneInString(comment.Text[len("//"):])
+		switch r {
+		case '+', '-', '#', '!':
+			// Permitted list to avoid false-positives.
+			continue
+		default:
+			if !unicode.IsSpace(r) {
+				c.warn(cg)
+				return
+			}
+		}
+	}
+}
+
+func (c *commentFormattingChecker) warn(cg *ast.CommentGroup) {
+	c.ctx.Warn(cg, "put a space between `//` and comment text")
+}

--- a/checkers/testdata/_integration/check_main_only/linttest.golden
+++ b/checkers/testdata/_integration/check_main_only/linttest.golden
@@ -6,6 +6,7 @@ exit status 1
 ./main.go:30:20: builtinShadow: shadowing of predeclared identifier: new
 ./main.go:32:16: captLocal: `THIS' should not be capitalized
 ./main.go:37:2: caseOrder: case int must go before the interface{} case
+./main.go:241:2: commentFormatting: put a space between `//` and comment text
 ./main.go:42:2: commentedOutCode: may want to remove commented-out code
 ./main.go:49:2: defaultCaseOrder: consider to make `default` case as first or as last case
 ./main.go:58:1: deprecatedComment: the proper format is `Deprecated: <text>`

--- a/checkers/testdata/_integration/check_main_only/main.go
+++ b/checkers/testdata/_integration/check_main_only/main.go
@@ -237,5 +237,9 @@ func flagName() {
 	_ = flag.String(" foo ", "1", "")
 }
 
+func commentFormatting() {
+	//"123"
+}
+
 func main() {
 }

--- a/checkers/testdata/commentFormatting/negative_tests.go
+++ b/checkers/testdata/commentFormatting/negative_tests.go
@@ -1,0 +1,33 @@
+package checker_test
+
+/*
+multi-line comments
+are ignored
+*/
+
+// Special kinds of comments are permitted:
+//+build
+//-foo
+
+//-style comments
+
+//directive: abc
+
+//#ifdef foo
+//#endif
+
+//!something
+
+//go:noinline
+func f1() {
+	//	code
+	//	example
+	//	leading tabs
+
+	// comment with normal style
+
+	// this comment has empty lines
+	//
+	//
+	// inside it.
+}

--- a/checkers/testdata/commentFormatting/positive_tests.go
+++ b/checkers/testdata/commentFormatting/positive_tests.go
@@ -1,0 +1,19 @@
+package checker_test
+
+/*! put a space between `//` and comment text */
+//this is a comment without leading space
+
+func f1() {
+	/*! put a space between `//` and comment text */
+	//block with
+	//sevaral lines
+	//without leading space
+}
+
+var (
+	/*! put a space between `//` and comment text */
+	//only several
+	//lines don't follow
+	// the convention
+	x = 10
+)


### PR DESCRIPTION
Detects comments like this:
```
	//this is a comment without a leading space
```

Suggested fix is:
```
	// this is a comment with a leading space
```

Fixes #469
Updates #470

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>