### PR TITLE
checkers: fix methodExprCall false positives

### DIFF
--- a/checkers/methodExprCall_checker.go
+++ b/checkers/methodExprCall_checker.go
@@ -2,12 +2,13 @@ package checkers
 
 import (
 	"go/ast"
-	"go/types"
+	"go/token"
 
 	"github.com/go-lintpack/lintpack"
 	"github.com/go-lintpack/lintpack/astwalk"
 	"github.com/go-toolsmith/astcast"
 	"github.com/go-toolsmith/astcopy"
+	"github.com/go-toolsmith/typep"
 )
 
 func init() {
@@ -33,10 +34,12 @@ type methodExprCallChecker struct {
 func (c *methodExprCallChecker) VisitExpr(x ast.Expr) {
 	call := astcast.ToCallExpr(x)
 	s := astcast.ToSelectorExpr(call.Fun)
-	id := astcast.ToIdent(s.X)
 
-	obj := c.ctx.TypesInfo.ObjectOf(id)
-	if _, ok := obj.(*types.TypeName); ok {
+	if len(call.Args) < 1 || astcast.ToIdent(call.Args[0]).Name == "nil" {
+		return
+	}
+
+	if typep.IsTypeExpr(c.ctx.TypesInfo, s.X) {
 		c.warn(call, s)
 	}
 }
@@ -44,6 +47,11 @@ func (c *methodExprCallChecker) VisitExpr(x ast.Expr) {
 func (c *methodExprCallChecker) warn(cause *ast.CallExpr, s *ast.SelectorExpr) {
 	selector := astcopy.SelectorExpr(s)
 	selector.X = cause.Args[0]
+
+	// Remove "&" from the reciever (if any).
+	if u, ok := selector.X.(*ast.UnaryExpr); ok && u.Op == token.AND {
+		selector.X = u.X
+	}
 
 	c.ctx.Warn(cause, "consider to change `%s` to `%s`", cause.Fun, selector)
 }

--- a/checkers/methodExprCall_checker.go
+++ b/checkers/methodExprCall_checker.go
@@ -48,7 +48,7 @@ func (c *methodExprCallChecker) warn(cause *ast.CallExpr, s *ast.SelectorExpr) {
 	selector := astcopy.SelectorExpr(s)
 	selector.X = cause.Args[0]
 
-	// Remove "&" from the reciever (if any).
+	// Remove "&" from the receiver (if any).
 	if u, ok := selector.X.(*ast.UnaryExpr); ok && u.Op == token.AND {
 		selector.X = u.X
 	}

--- a/checkers/testdata/methodExprCall/negative_tests.go
+++ b/checkers/testdata/methodExprCall/negative_tests.go
@@ -4,4 +4,10 @@ func methodCalls() {
 	f := foo{}
 	f.bar(20)
 	f.bar2(20, "str")
+	f.ptrRecv()
+}
+
+func nilCall() {
+	iface.ptrRecv(nil)
+	(*foo).ptrRecv(nil)
 }

--- a/checkers/testdata/methodExprCall/positive_tests.go
+++ b/checkers/testdata/methodExprCall/positive_tests.go
@@ -4,9 +4,17 @@ type foo struct {
 	k string
 }
 
+type bar struct{}
+
+type iface interface {
+	ptrRecv()
+}
+
 func (f foo) bar(i int) {}
 
 func (f foo) bar2(i int, s string) {}
+
+func (f *foo) ptrRecv() {}
 
 func methodExprCalls() {
 	f := foo{}
@@ -14,4 +22,13 @@ func methodExprCalls() {
 	foo.bar(f, 20)
 	/*! consider to change `foo.bar2` to `f.bar2` */
 	foo.bar2(f, 20, "str")
+
+	/*! consider to change `(*foo).ptrRecv` to `f.ptrRecv` */
+	(*foo).ptrRecv(&f)
+	/*! consider to change `iface.ptrRecv` to `f.ptrRecv` */
+	iface.ptrRecv(&f)
+
+	var nilVar *foo
+	/*! consider to change `(*foo).ptrRecv` to `nilVar.ptrRecv` */
+	(*foo).ptrRecv(nilVar)
 }


### PR DESCRIPTION
Also simplify implementation by using typep.IsTypeExpr.

Fixes #681

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>