### PR TITLE
checkers: fix panic in flagName

### DIFF
--- a/checkers/importShadow_checker.go
+++ b/checkers/importShadow_checker.go
@@ -39,8 +39,7 @@ func (c *importShadowChecker) VisitLocalDef(def astwalk.Name, _ ast.Expr) {
 }
 
 func (c *importShadowChecker) warn(id ast.Node, importedName string, pkg *types.Package) {
-	if pkg.Path() == pkg.Name() {
-		// Сheck for standart library packages.
+	if isStdlibPkg(pkg) {
 		c.ctx.Warn(id, "shadow of imported package '%s'", importedName)
 	} else {
 		c.ctx.Warn(id, "shadow of imported from '%s' package '%s'", pkg.Path(), importedName)

--- a/checkers/testdata/_importable/flag/flag.go
+++ b/checkers/testdata/_importable/flag/flag.go
@@ -1,0 +1,5 @@
+package flag
+
+func Bool() bool {
+	return false
+}

--- a/checkers/testdata/flagName/negative_tests2.go
+++ b/checkers/testdata/flagName/negative_tests2.go
@@ -1,0 +1,7 @@
+package checker_test
+
+import (
+	"github.com/go-critic/go-critic/checkers/testdata/_importable/flag"
+)
+
+var _ = flag.Bool()

--- a/checkers/utils.go
+++ b/checkers/utils.go
@@ -8,6 +8,11 @@ import (
 	"github.com/go-lintpack/lintpack"
 )
 
+// isStdlibPkg reports whether pkg is a package from the Go standard library.
+func isStdlibPkg(pkg *types.Package) bool {
+	return pkg.Path() == pkg.Name()
+}
+
 // isUnitTestFunc reports whether FuncDecl declares testing function.
 func isUnitTestFunc(ctx *lintpack.CheckerContext, fn *ast.FuncDecl) bool {
 	if !strings.HasPrefix(fn.Name.Name, "Test") {


### PR DESCRIPTION
Verify that "flag.Xxx" function comes from the standard
library, not from just any package that is called flag and
happen to have something like Bool or Int8 function that
look like something from the standard flag package.

Move stdlib pkg check to utils.go and use that in
importShadow checker as well.

Fixes #734

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>