### PR TITLE
checkers: avoid eager copy in boolExprSimplify

### DIFF
--- a/checkers/boolExprSimplify_checker.go
+++ b/checkers/boolExprSimplify_checker.go
@@ -36,8 +36,12 @@ type boolExprSimplifyChecker struct {
 }
 
 func (c *boolExprSimplifyChecker) VisitExpr(x ast.Expr) {
-	// TODO: avoid eager copy?
-	// Can't be stable until wasted copying is fixed.
+	// Throw away non-bool expressions and awoid redundant
+	// AST copying below.
+	if !typep.HasBoolKind(c.ctx.TypesInfo.TypeOf(x)) {
+		return
+	}
+
 	y := c.simplifyBool(astcopy.Expr(x))
 	if !astequal.Expr(x, y) {
 		c.warn(x, y)


### PR DESCRIPTION
Don't copy AST expressions those type is not bool.
We still do a lot of copying, but at least it's only
performed for boolean-typed expressions.

Refs #493

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>