### PR TITLE
checkers: don't do invertComparison for floats

### DIFF
--- a/checkers/testdata/boolExprSimplify/negative_tests.go
+++ b/checkers/testdata/boolExprSimplify/negative_tests.go
@@ -40,3 +40,10 @@ func cantCombine() {
 	_ = x < y || x > z
 	_ = x > z || x < y
 }
+
+func floatCompare() {
+	var f1, f2 float32
+
+	// Can't be simplified to `f1 != f2`.
+	_ = !(f1 == f2)
+}


### PR DESCRIPTION
This fixes a bug in boolExprSimplify checker.

Fixes #673

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>