### PR TITLE
checkers: extend equalFold checker to bytes.EqualFold

### DIFF
--- a/checkers/testdata/equalFold/negative_tests.go
+++ b/checkers/testdata/equalFold/negative_tests.go
@@ -1,1 +1,18 @@
 package checker_test
+
+import (
+	"bytes"
+	"strings"
+)
+
+func stringsEqualFold(x, y string) {
+	_ = strings.EqualFold(x, y)
+	_ = strings.EqualFold(x, concat(y, "123"))
+	_ = strings.EqualFold(concat(y, "123"), x)
+}
+
+func bytesEqualFold(x, y []byte) {
+	_ = bytes.EqualFold(x, y)
+	_ = bytes.EqualFold(x, append(y, 'a'))
+	_ = bytes.EqualFold(append(y, 'a'), x)
+}

--- a/checkers/testdata/equalFold/positive_tests.go
+++ b/checkers/testdata/equalFold/positive_tests.go
@@ -1,8 +1,15 @@
 package checker_test
 
-import "strings"
+import (
+	"bytes"
+	"strings"
+)
 
-func foo(x, y string) {
+func concat(x, y string) string {
+	return x + y
+}
+
+func stringsToLower(x, y string) {
 	/*! consider replacing with strings.EqualFold(x, y) */
 	_ = strings.ToLower(x) == y
 
@@ -13,24 +20,27 @@ func foo(x, y string) {
 	_ = x == strings.ToLower(y)
 
 	/*! consider replacing with strings.EqualFold(x, "y") */
-	_ = strings.ToLower(x) == "y"
+	_ = strings.ToLower(x) != "y"
 
 	/*! consider replacing with strings.EqualFold(x, "y") */
 	_ = strings.ToLower(x) == strings.ToLower("y")
 
 	/*! consider replacing with strings.EqualFold(x, "y") */
 	_ = x == strings.ToLower("y")
+
+	/*! consider replacing with strings.EqualFold(x, concat(y, "123")) */
+	_ = strings.ToLower(x) == concat(y, "123")
 }
 
-func bar(x, y string) {
+func stringsToUpper(x, y string) {
 	/*! consider replacing with strings.EqualFold(x, y) */
 	_ = strings.ToUpper(x) == y
 
 	/*! consider replacing with strings.EqualFold(x, y) */
-	_ = strings.ToUpper(x) == strings.ToUpper(y)
+	_ = strings.ToUpper(x) != strings.ToUpper(y)
 
 	/*! consider replacing with strings.EqualFold(x, y) */
-	_ = x == strings.ToUpper(y)
+	_ = x != strings.ToUpper(y)
 
 	/*! consider replacing with strings.EqualFold(x, "y") */
 	_ = strings.ToUpper(x) == "y"
@@ -40,4 +50,47 @@ func bar(x, y string) {
 
 	/*! consider replacing with strings.EqualFold(x, "y") */
 	_ = x == strings.ToUpper("y")
+}
+
+func bytesToLower(x, y []byte) {
+	/*! consider replacing with bytes.EqualFold(x, y) */
+	_ = bytes.Equal(bytes.ToLower(x), y)
+
+	/*! consider replacing with bytes.EqualFold(x, y) */
+	_ = bytes.Equal(bytes.ToLower(x), bytes.ToLower(y))
+
+	/*! consider replacing with bytes.EqualFold(x, y) */
+	_ = !bytes.Equal(x, bytes.ToLower(y))
+
+	/*! consider replacing with bytes.EqualFold(x, []byte("y")) */
+	_ = !bytes.Equal(bytes.ToLower(x), []byte("y"))
+
+	/*! consider replacing with bytes.EqualFold(x, []byte("y")) */
+	_ = bytes.Equal(bytes.ToLower(x), bytes.ToLower([]byte("y")))
+
+	/*! consider replacing with bytes.EqualFold(x, []byte("y")) */
+	_ = bytes.Equal(x, bytes.ToLower([]byte("y")))
+
+	/*! consider replacing with bytes.EqualFold(x, append(y, 'a')) */
+	_ = bytes.Equal(bytes.ToLower(x), append(y, 'a'))
+}
+
+func bytesToUpper(x, y []byte) {
+	/*! consider replacing with bytes.EqualFold(x, y) */
+	_ = bytes.Equal(bytes.ToUpper(x), y)
+
+	/*! consider replacing with bytes.EqualFold(x, y) */
+	_ = !bytes.Equal(bytes.ToUpper(x), bytes.ToUpper(y))
+
+	/*! consider replacing with bytes.EqualFold(x, y) */
+	_ = bytes.Equal(x, bytes.ToUpper(y))
+
+	/*! consider replacing with bytes.EqualFold(x, []byte("y")) */
+	_ = bytes.Equal(bytes.ToUpper(x), []byte("y"))
+
+	/*! consider replacing with bytes.EqualFold(x, []byte("y")) */
+	_ = bytes.Equal(bytes.ToUpper(x), bytes.ToUpper([]byte("y")))
+
+	/*! consider replacing with bytes.EqualFold(x, []byte("y")) */
+	_ = bytes.Equal(x, bytes.ToUpper([]byte("y")))
 }


### PR DESCRIPTION
Handle bytes comparisons in addition to strings comparisons.

Also fix a bug that made linter suggest invalid replacements.
It happened because we haven't checked which call is under
callX and callY. If there is something that is not ToUpper
or ToLower, we should not simplify a call to its first argument.

In addition, add negative tests.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>