### PR TITLE
checkers: fix nil pointer dereference in flagName

### DIFF
--- a/checkers/utils.go
+++ b/checkers/utils.go
@@ -10,7 +10,7 @@ import (
 
 // isStdlibPkg reports whether pkg is a package from the Go standard library.
 func isStdlibPkg(pkg *types.Package) bool {
-	return pkg.Path() == pkg.Name()
+	return pkg != nil && pkg.Path() == pkg.Name()
 }
 
 // isUnitTestFunc reports whether FuncDecl declares testing function.


### PR DESCRIPTION
`isStdlibPkg` now checks the argument for nil (built-in types don't have a package).

Fixes #749