### PR TITLE
checkers: recognize //line and //nolint in commentFormatting

### DIFF
--- a/checkers/commentFormatting_checker.go
+++ b/checkers/commentFormatting_checker.go
@@ -20,7 +20,13 @@ func init() {
 	info.After = `// This is a comment`
 
 	collection.AddChecker(&info, func(ctx *lintpack.CheckerContext) lintpack.FileWalker {
-		pragmaRE := regexp.MustCompile(`(?m)^//\w+:.*$`)
+		parts := []string{
+			`^//\w+:.*$`,      //key: value
+			`^//nolint$`,      //nolint
+			`^//line /.*:\d+`, //line /path/to/file:123
+		}
+		pat := "(?m)" + strings.Join(parts, "|")
+		pragmaRE := regexp.MustCompile(pat)
 		return astwalk.WalkerForComment(&commentFormattingChecker{
 			ctx:      ctx,
 			pragmaRE: pragmaRE,

--- a/checkers/testdata/commentFormatting/negative_tests.go
+++ b/checkers/testdata/commentFormatting/negative_tests.go
@@ -18,8 +18,17 @@ are ignored
 
 //!something
 
+//nolint
+
+//line /foo/bar.go:10
+
+//line /foo/bar/f-ad/a_d.go:13
+//line /bar.go:14
+
 //go:noinline
 func f1() {
+	//nolint
+
 	//	code
 	//	example
 	//	leading tabs


### PR DESCRIPTION
Updates #755

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>