### PR TITLE
checkers: add new patterns to boolExprSimplify

### DIFF
--- a/checkers/boolExprSimplify_checker.go
+++ b/checkers/boolExprSimplify_checker.go
@@ -327,7 +327,7 @@ func (c *boolExprSimplifyChecker) int64val(x ast.Expr) (int64, bool) {
 	if !ok {
 		return 0, false
 	}
-	v, err := strconv.ParseInt(lit.Value, 10, 0)
+	v, err := strconv.ParseInt(lit.Value, 10, 64)
 	if err != nil {
 		return 0, false
 	}

--- a/checkers/testdata/boolExprSimplify/negative_tests.go
+++ b/checkers/testdata/boolExprSimplify/negative_tests.go
@@ -39,6 +39,18 @@ func cantCombine() {
 	// OK: unrelated operations.
 	_ = x < y || x > z
 	_ = x > z || x < y
+
+	_ = x < 11 || x > 14
+	_ = x <= 10 || x >= z
+	_ = x <= 10 || x >= 100
+
+	_ = x < 11 || y > 14
+	_ = x <= 10 || y >= z
+	_ = x <= 10 || y >= 100
+
+	_ = x < 11 || fn() > 14
+	_ = fn() <= 10 || x >= z
+	_ = fn() <= 10 || fn() >= 100
 }
 
 func floatCompare() {

--- a/checkers/testdata/boolExprSimplify/positive_tests.go
+++ b/checkers/testdata/boolExprSimplify/positive_tests.go
@@ -175,3 +175,23 @@ func removeIncDec(x, y, z int) {
 	/*! can simplify `x >= y+1` to `x > y` */
 	_ = x >= y+1
 }
+
+func foldRanges(x, y int) {
+	/*! can simplify `x > 10 && x < 12` to `x == 11` */
+	_ = x > 10 && x < 12
+	/*! can simplify `x >= 11 && x < 12` to `x == 11` */
+	_ = x >= 11 && x < 12
+	/*! can simplify `x > 10 && x <= 11` to `x == 11` */
+	_ = x > 10 && x <= 11
+	/*! can simplify `x >= 11 && x <= 11` to `x == 11` */
+	_ = x >= 11 && x <= 11
+
+	/*! can simplify `x < 11 || x > 11` to `x != 11` */
+	_ = x < 11 || x > 11
+	/*! can simplify `x <= 10 || x > 11` to `x != 11` */
+	_ = x <= 10 || x > 11
+	/*! can simplify `x < 11 || x >= 12` to `x != 11` */
+	_ = x < 11 || x >= 12
+	/*! can simplify `x <= 10 || x >= 12` to `x != 11` */
+	_ = x <= 10 || x >= 12
+}


### PR DESCRIPTION
New patterns:

  `x > c && x < c+2` => `x == c+1`
  `x >= c && x < c+1` => `x == c`
  `x > c && x <= c+1` => `x == c+1`
  `x >= c && x <= c` => `x == c`
  `x < c || x > c` => `x != c`
  `x <= c || x > c+1` => `x != c+1`
  `x < c || x >= c+1` => `x != c`
  `x <= c || x >= c+2` => `x != c+1`

Updates #616

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>