### PR TITLE
checkers: proper pkg/obj check for flagName

### DIFF
--- a/checkers/flagName_checker.go
+++ b/checkers/flagName_checker.go
@@ -3,6 +3,7 @@ package checkers
 import (
 	"go/ast"
 	"go/constant"
+	"go/types"
 	"strings"
 
 	"github.com/go-lintpack/lintpack"
@@ -30,13 +31,14 @@ type flagNameChecker struct {
 
 func (c *flagNameChecker) VisitExpr(expr ast.Expr) {
 	call := astcast.ToCallExpr(expr)
-	sym := astcast.ToIdent(astcast.ToSelectorExpr(call.Fun).Sel)
-	obj := c.ctx.TypesInfo.ObjectOf(sym)
-	if obj == nil {
+	calledExpr := astcast.ToSelectorExpr(call.Fun)
+	obj, ok := c.ctx.TypesInfo.ObjectOf(astcast.ToIdent(calledExpr.X)).(*types.PkgName)
+	if !ok {
 		return
 	}
-	pkg := obj.Pkg()
-	if !isStdlibPkg(pkg) || pkg.Name() != "flag" {
+	sym := calledExpr.Sel
+	pkg := obj.Imported()
+	if !isStdlibPkg(pkg) || obj.Name() != "flag" {
 		return
 	}
 

--- a/checkers/testdata/flagName/negative_tests.go
+++ b/checkers/testdata/flagName/negative_tests.go
@@ -4,6 +4,12 @@ import (
 	"flag"
 )
 
+func methodCall() {
+	// See #784.
+	var getter flag.Getter
+	_ = getter.String()
+}
+
 func noWhitespace() {
 	_ = flag.Bool("name", false, "")
 	_ = flag.Duration("name", 0, "")


### PR DESCRIPTION
The main problem came from the flagName trying
to check method calls while it should only handle
function calls.

Fixes #784.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>