### PR TITLE
New dupImports checker

### DIFF
--- a/checkers/dupImports_checker.go
+++ b/checkers/dupImports_checker.go
@@ -1,0 +1,76 @@
+package checkers
+
+import (
+	"fmt"
+	"go/ast"
+
+	"github.com/go-lintpack/lintpack"
+)
+
+func init() {
+	var info lintpack.CheckerInfo
+	info.Name = "dupImports"
+	info.Tags = []string{"style", "experimental"}
+	info.Summary = "Detects multiple imports of the same package under different aliases."
+	info.Before = `
+import (
+	"fmt"
+	priting "fmt"
+)
+
+func helloWorld() {
+	fmt.Println("Hello")
+	printing.Println("World")
+}`
+	info.After = `
+import(
+	"fmt"
+)
+
+func helloWorld() {
+	fmt.Println("Hello")
+	fmt.Println("World")
+}`
+
+	collection.AddChecker(&info, func(ctx *lintpack.CheckerContext) lintpack.FileWalker {
+		return &dupImportChecker{ctx: ctx}
+	})
+}
+
+type dupImportChecker struct {
+	ctx *lintpack.CheckerContext
+}
+
+func (c *dupImportChecker) WalkFile(f *ast.File) {
+	imports := make(map[string][]*ast.ImportSpec)
+	for _, importDcl := range f.Imports {
+		pkg := importDcl.Path.Value
+		imports[pkg] = append(imports[pkg], importDcl)
+	}
+
+	fPos := c.ctx.FileSet.File(f.Pos())
+	if fPos == nil {
+		// Bail out if we can't, for any reason, determine
+		// the source file we are dealing with.
+		return
+	}
+	for _, importList := range imports {
+		if len(importList) == 1 {
+			continue
+		}
+
+		msg := fmt.Sprintf("package is imported %d times under different aliases on lines", len(importList))
+		for idx, importDcl := range importList {
+			switch {
+			case idx == len(importList)-1:
+				msg += " and"
+			case idx > 0:
+				msg += ","
+			}
+			msg += fmt.Sprintf(" %d", fPos.Line(importDcl.Pos()))
+		}
+		for _, importDcl := range importList {
+			c.ctx.Warn(importDcl, msg)
+		}
+	}
+}

--- a/checkers/testdata/dupImports/negative_tests.go
+++ b/checkers/testdata/dupImports/negative_tests.go
@@ -1,0 +1,9 @@
+package checker_test
+
+import "fmt"
+
+func negativeHelloworld() {
+	fmt.Println("Hello")
+	fmt.Println("Shiny")
+	fmt.Println("World")
+}

--- a/checkers/testdata/dupImports/positive_tests.go
+++ b/checkers/testdata/dupImports/positive_tests.go
@@ -1,0 +1,17 @@
+package checker_test
+
+/*! package is imported 3 times under different aliases on lines 4, 8 and 10 */
+import printing "fmt"
+
+import (
+	/*! package is imported 3 times under different aliases on lines 4, 8 and 10 */
+	"fmt"
+	/*! package is imported 3 times under different aliases on lines 4, 8 and 10 */
+	print "fmt"
+)
+
+func positiveHelloworld() {
+	fmt.Println("Hello")
+	print.Println("Shiny")
+	printing.Println("World")
+}


### PR DESCRIPTION
Am proposing a new "style" checker that verifies that you are not importing the same package twice in the same Go file under different aliases.

This is not using one of the `astwalk.WalkerFor*` interfaces (which are proxies for `lintpack.FileWalker`) as those do not give access to a file's imports. Instead it directly reimplements the `lintpack.FileWalker` interface itself.

Have added the required positive and negative test files as well.

Example output:
```text
 -> gocritic check -enable=dupImports checkers/testdata/dupImports/positive_tests.go
./checkers/testdata/dupImports/positive_tests.go:4:8: dupImports: package is imported 3 times under different aliases on lines 4, 8 and 10
./checkers/testdata/dupImports/positive_tests.go:8:2: dupImports: package is imported 3 times under different aliases on lines 4, 8 and 10
./checkers/testdata/dupImports/positive_tests.go:10:2: dupImports: package is imported 3 times under different aliases on lines 4, 8 and 10
```