### PR TITLE
checkers: teach wrappedFunc to handle SplitN

### DIFF
--- a/checkers/testdata/wrapperFunc/negative_tests.go
+++ b/checkers/testdata/wrapperFunc/negative_tests.go
@@ -16,9 +16,11 @@ func appliedSuggestions(s string, b []byte) {
 	buf.Reset()
 	buf.Truncate(1)
 
+	strings.Split(s, ".")
 	strings.ToTitle(s)
 	strings.ReplaceAll(s, "a", "b")
 
+	bytes.Split(b, []byte("."))
 	bytes.ToUpper(b)
 	bytes.ToLower(b)
 	bytes.ToTitle(b)

--- a/checkers/testdata/wrapperFunc/positive_tests.go
+++ b/checkers/testdata/wrapperFunc/positive_tests.go
@@ -17,11 +17,17 @@ func f(s string, b []byte) {
 	/*! use Buffer.Reset method in `buf.Truncate(0)` */
 	buf.Truncate(0)
 
+	/*! use strings.Split method in `strings.SplitN(s, ".", -1)` */
+	strings.SplitN(s, ".", -1)
+
 	/*! use strings.ToTitle method in `strings.Map(unicode.ToTitle, s)` */
 	strings.Map(unicode.ToTitle, s)
 
 	/*! use strings.ReplaceAll method in `strings.Replace(s, "a", "b", -1)` */
 	strings.Replace(s, "a", "b", -1)
+
+	/*! use bytes.Split method in `bytes.SplitN(b, []byte("."), -1)` */
+	bytes.SplitN(b, []byte("."), -1)
 
 	/*! use bytes.ToUpper method in `bytes.Map(unicode.ToUpper, b)` */
 	bytes.Map(unicode.ToUpper, b)

--- a/checkers/wrapperFunc_checker.go
+++ b/checkers/wrapperFunc_checker.go
@@ -50,6 +50,9 @@ func init() {
 				{0, "http.NotFound"},
 			},
 
+			"strings.SplitN => strings.Split": {
+				{2, "-1"},
+			},
 			"strings.Replace => strings.ReplaceAll": {
 				{3, "-1"},
 			},
@@ -60,6 +63,9 @@ func init() {
 				{0, "unicode.ToTitle"},
 			},
 
+			"bytes.SplitN => bytes.Split": {
+				{2, "-1"},
+			},
 			"bytes.Replace => bytes.ReplaceAll": {
 				{3, "-1"},
 			},


### PR DESCRIPTION
Suggest changing SplitN(a, b, -1) to Split(a, b).

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>