### PR TITLE
checkers: fix go-namecheck complaints

### DIFF
--- a/checkers/rangeValCopy_checker.go
+++ b/checkers/rangeValCopy_checker.go
@@ -70,6 +70,6 @@ func (c *rangeValCopyChecker) VisitStmt(stmt ast.Stmt) {
 	}
 }
 
-func (c *rangeValCopyChecker) warn(node ast.Node, size int64) {
-	c.ctx.Warn(node, "each iteration copies %d bytes (consider pointers or indexing)", size)
+func (c *rangeValCopyChecker) warn(n ast.Node, size int64) {
+	c.ctx.Warn(n, "each iteration copies %d bytes (consider pointers or indexing)", size)
 }

--- a/checkers/typeSwitchVar_checker.go
+++ b/checkers/typeSwitchVar_checker.go
@@ -83,6 +83,6 @@ func (c *typeSwitchVarChecker) checkTypeSwitch(root *ast.TypeSwitchStmt) {
 	}
 }
 
-func (c *typeSwitchVarChecker) warn(node ast.Node, caseIndex int) {
-	c.ctx.Warn(node, "case %d can benefit from type switch with assignment", caseIndex)
+func (c *typeSwitchVarChecker) warn(n ast.Node, caseIndex int) {
+	c.ctx.Warn(n, "case %d can benefit from type switch with assignment", caseIndex)
 }

--- a/naming_conventions.json
+++ b/naming_conventions.json
@@ -1,3 +1,6 @@
 {
-    "ast\\.Node": {"param": {"node": "n"}}
+    "ast\\.Node": {"param": {"node": "n"}},
+    "lintpack.CheckerContext": {
+        "param+local+field": {"ctxt": "ctx"}
+    }
 }


### PR DESCRIPTION
Also add a rule for ctxt->ctx renaming.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>