### PR TITLE
lint: commentedOutCode add false positives tests

### DIFF
--- a/checkers/commentedOutCode_checker.go
+++ b/checkers/commentedOutCode_checker.go
@@ -83,11 +83,21 @@ func (c *commentedOutCodeChecker) VisitLocalComment(cg *ast.CommentGroup) {
 		return
 	}
 
+	if stmt != strparse.BadStmt {
+		c.warn(cg)
+		return
+	}
+
+	// Don't try to parse one-liner as block statement
+	if len(cg.List) == 1 && !strings.Contains(s, "\n") {
+		return
+	}
+
 	// Add parentheses to make block statement from
 	// multiple statements.
 	stmt = strparse.Stmt(fmt.Sprintf("{ %s }", s))
 
-	if stmt != strparse.BadStmt {
+	if stmt, ok := stmt.(*ast.BlockStmt); ok && len(stmt.List) > 0 {
 		c.warn(cg)
 	}
 }

--- a/checkers/commentedOutCode_checker.go
+++ b/checkers/commentedOutCode_checker.go
@@ -97,7 +97,7 @@ func (c *commentedOutCodeChecker) VisitLocalComment(cg *ast.CommentGroup) {
 	// multiple statements.
 	stmt = strparse.Stmt(fmt.Sprintf("{ %s }", s))
 
-	if stmt, ok := stmt.(*ast.BlockStmt); ok && len(stmt.List) > 0 {
+	if stmt, ok := stmt.(*ast.BlockStmt); ok && len(stmt.List) != 0 {
 		c.warn(cg)
 	}
 }

--- a/checkers/testdata/commentedOutCode/negative_tests.go
+++ b/checkers/testdata/commentedOutCode/negative_tests.go
@@ -43,4 +43,10 @@ func permittedComments() {
 	// notAfunccall (this is not a function call)
 
 	// funccall () with period .
+
+	// pretty-print
+
+	// Output: "64 bytes or fewer"
+
+	// Result: int *int
 }

--- a/checkers/testdata/commentedOutCode/negative_tests.go
+++ b/checkers/testdata/commentedOutCode/negative_tests.go
@@ -49,4 +49,26 @@ func permittedComments() {
 	// Output: "64 bytes or fewer"
 
 	// Result: int *int
+
+	// golang.org/issue/5290
+
+	// testRead | testWriteTo | testRemaining
+
+	// WriteHeader(hdr) == wantErr
+
+	// Size: SizeOf(uint8) + SizeOf(uint32)
+
+	// Flags: ModTime
+
+	// 0 <= n <= len(b.buf)
+
+	// b.r == 0 && b.w == 0
+
+	// ignored //line directives
+
+	// invalid //line directives with one colon
+
+	// //line directives with omitted filenames lead to empty filenames
+
+	/* CINC/CINV/CNEG */
 }


### PR DESCRIPTION
For some reason tests passed well, but `gocritic check -enable commentedOutCode fmt` returns.
```
$GOROOT/src/fmt/example_test.go:242:2: commentedOutCode: may want to remove commented-out code
$GOROOT/src/fmt/example_test.go:275:2: commentedOutCode: may want to remove commented-out code
$GOROOT/src/fmt/gostringer_example_test.go:56:2: commentedOutCode: may want to remove commented-out code
```
P.S lines are from found warnings.