### PR TITLE
checkers: fix fold-ranges for floats in boolExprSimplify

### DIFF
--- a/checkers/boolExprSimplify_checker.go
+++ b/checkers/boolExprSimplify_checker.go
@@ -235,6 +235,10 @@ func (c *boolExprSimplifyChecker) removeIncDec(cur *astutil.Cursor) bool {
 }
 
 func (c *boolExprSimplifyChecker) foldRanges(cur *astutil.Cursor) bool {
+	if c.hasFloats { // See #673
+		return false
+	}
+
 	e, ok := cur.Node().(*ast.BinaryExpr)
 	if !ok {
 		return false

--- a/checkers/boolExprSimplify_checker.go
+++ b/checkers/boolExprSimplify_checker.go
@@ -235,7 +235,7 @@ func (c *boolExprSimplifyChecker) removeIncDec(cur *astutil.Cursor) bool {
 }
 
 func (c *boolExprSimplifyChecker) foldRanges(cur *astutil.Cursor) bool {
-	if c.hasFloats { // See #673
+	if c.hasFloats { // See #848
 		return false
 	}
 

--- a/checkers/testdata/boolExprSimplify/negative_tests.go
+++ b/checkers/testdata/boolExprSimplify/negative_tests.go
@@ -58,6 +58,9 @@ func floatCompare() {
 
 	// Can't be simplified to `f1 != f2`.
 	_ = !(f1 == f2)
+
+	// Can't be simplified to `p == 1`.
+	_ = f1 > 0 && f1 <= 1
 }
 
 func balancedIncDec(x, y, z int) {


### PR DESCRIPTION
Don't apply fold ranges in boolExprSimplify for float operands.

Fixes #848

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>