### PR TITLE
checkers: fix "Output:" false positive in commentedOutCode

### DIFF
--- a/checkers/testdata/commentedOutCode/negative_tests.go
+++ b/checkers/testdata/commentedOutCode/negative_tests.go
@@ -1,5 +1,11 @@
 package checker_test
 
+func ExampleFoo() {
+	// Output:
+	// blah
+	// blah
+}
+
 func permittedComments() {
 	// TODO: foo(1+2)
 

--- a/checkers/utils.go
+++ b/checkers/utils.go
@@ -241,6 +241,11 @@ func isStdlibPkg(pkg *types.Package) bool {
 	return pkg != nil && goStdlib[pkg.Path()]
 }
 
+// isExampleTestFunc reports whether FuncDecl looks like a testable example function.
+func isExampleTestFunc(fn *ast.FuncDecl) bool {
+	return len(fn.Type.Params.List) == 0 && strings.HasPrefix(fn.Name.String(), "Example")
+}
+
 // isUnitTestFunc reports whether FuncDecl declares testing function.
 func isUnitTestFunc(ctx *lintpack.CheckerContext, fn *ast.FuncDecl) bool {
 	if !strings.HasPrefix(fn.Name.Name, "Test") {


### PR DESCRIPTION
Recognize "Output:" comment inside example tests.

Fixes #851

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>