### PR TITLE
build for master as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
   - 1.x
+  - master
 env:
   - TEST_SUITE=tests
   - TEST_SUITE=linter

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,6 @@ script:
   - make ci
 after_success:
   - make cover
+matrix:
+  allow_failures:
+    - go: master


### PR DESCRIPTION
add to the CI master so that it's always possible to check that go-critic is ready for the next go