### PR TITLE
add regexpPattern checker

### DIFF
--- a/checkers/regexpPattern_checker.go
+++ b/checkers/regexpPattern_checker.go
@@ -64,6 +64,5 @@ func (c *regexpPatternChecker) VisitExpr(x ast.Expr) {
 }
 
 func (c *regexpPatternChecker) warnDomain(cause ast.Expr, domain string) {
-	c.ctx.Warn(cause, "'.%s' should probably be '\\.%s'",
-		domain, domain)
+	c.ctx.Warn(cause, "'.%s' should probably be '\\.%s'", domain, domain)
 }

--- a/checkers/regexpPattern_checker.go
+++ b/checkers/regexpPattern_checker.go
@@ -1,0 +1,68 @@
+package checkers
+
+import (
+	"go/ast"
+	"go/constant"
+	"regexp"
+	"strings"
+
+	"github.com/go-lintpack/lintpack"
+	"github.com/go-lintpack/lintpack/astwalk"
+)
+
+func init() {
+	var info lintpack.CheckerInfo
+	info.Name = "regexpPattern"
+	info.Tags = []string{"diagnostic", "experimental"}
+	info.Summary = "Detects suspicious regexp patterns"
+	info.Before = "regexp.MustCompile(`google.com|yandex.ru`)"
+	info.After = "regexp.MustCompile(`google\\.com|yandex\\.ru`)"
+
+	collection.AddChecker(&info, func(ctx *lintpack.CheckerContext) lintpack.FileWalker {
+		domains := []string{
+			"com",
+			"org",
+			"info",
+			"net",
+			"ru",
+			"de",
+		}
+
+		domainRE := regexp.MustCompile(`[^\\]\.(` + strings.Join(domains, "|") + `)\b`)
+		return astwalk.WalkerForExpr(&regexpPatternChecker{
+			ctx:      ctx,
+			domainRE: domainRE,
+		})
+	})
+}
+
+type regexpPatternChecker struct {
+	astwalk.WalkHandler
+	ctx *lintpack.CheckerContext
+
+	domainRE *regexp.Regexp
+}
+
+func (c *regexpPatternChecker) VisitExpr(x ast.Expr) {
+	call, ok := x.(*ast.CallExpr)
+	if !ok {
+		return
+	}
+
+	switch name := qualifiedName(call.Fun); name {
+	case "regexp.Compile", "regexp.CompilePOSIX", "regexp.MustCompile", "regexp.MustCompilePosix":
+		cv := c.ctx.TypesInfo.Types[call.Args[0]].Value
+		if cv == nil || cv.Kind() != constant.String {
+			return
+		}
+		s := constant.StringVal(cv)
+		if m := c.domainRE.FindStringSubmatch(s); m != nil {
+			c.warnDomain(call.Args[0], m[1])
+		}
+	}
+}
+
+func (c *regexpPatternChecker) warnDomain(cause ast.Expr, domain string) {
+	c.ctx.Warn(cause, "'.%s' should probably be '\\.%s'",
+		domain, domain)
+}

--- a/checkers/regexpPattern_checker.go
+++ b/checkers/regexpPattern_checker.go
@@ -28,7 +28,8 @@ func init() {
 			"de",
 		}
 
-		domainRE := regexp.MustCompile(`[^\\]\.(` + strings.Join(domains, "|") + `)\b`)
+		allDomains := strings.Join(domains, "|")
+		domainRE := regexp.MustCompile(`[^\\]\.(` + allDomains + `)\b`)
 		return astwalk.WalkerForExpr(&regexpPatternChecker{
 			ctx:      ctx,
 			domainRE: domainRE,

--- a/checkers/regexpPattern_checker.go
+++ b/checkers/regexpPattern_checker.go
@@ -49,7 +49,7 @@ func (c *regexpPatternChecker) VisitExpr(x ast.Expr) {
 		return
 	}
 
-	switch name := qualifiedName(call.Fun); name {
+	switch qualifiedName(call.Fun) {
 	case "regexp.Compile", "regexp.CompilePOSIX", "regexp.MustCompile", "regexp.MustCompilePosix":
 		cv := c.ctx.TypesInfo.Types[call.Args[0]].Value
 		if cv == nil || cv.Kind() != constant.String {

--- a/checkers/testdata/regexpPattern/negative_tests.go
+++ b/checkers/testdata/regexpPattern/negative_tests.go
@@ -1,0 +1,11 @@
+package checker_test
+
+import (
+	"regexp"
+)
+
+func domainDots() {
+	regexp.MustCompile(`google\.com`)
+
+	regexp.CompilePOSIX(`yandex\.ru|radio.yandex\.ru`)
+}

--- a/checkers/testdata/regexpPattern/positive_tests.go
+++ b/checkers/testdata/regexpPattern/positive_tests.go
@@ -1,0 +1,13 @@
+package checker_test
+
+import (
+	"regexp"
+)
+
+func domainDots() {
+	/*! '.com' should probably be '\.com' */
+	regexp.MustCompile(`google.com`)
+
+	/*! '.ru' should probably be '\.ru' */
+	regexp.CompilePOSIX(`yandex.ru|radio.yandex.ru`)
+}


### PR DESCRIPTION
Currently only checks whether the pattern contains
an unescaped "." near known top level domain.

So, `google.com` is probably flawed and
`google\.com` is considered to be correct.

It's not a security issue most of the time, but
it's better to keep that surface as thin as possible
to avoid potential problems.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>