### PR TITLE
checkers: handle ^ and $ anchors

### DIFF
--- a/checkers/testdata/regexpPattern/negative_tests.go
+++ b/checkers/testdata/regexpPattern/negative_tests.go
@@ -4,8 +4,17 @@ import (
 	"regexp"
 )
 
-func domainDots() {
+func escapedDots() {
 	regexp.MustCompile(`google\.com`)
 
 	regexp.CompilePOSIX(`yandex\.ru|radio.yandex\.ru`)
+}
+
+func goodAnchors() {
+	regexp.Compile(`^100`)
+	regexp.Compile(`2\^10`)
+	regexp.Compile(`(?im)2\^10`)
+	regexp.Compile(`(?m)77^10$`)
+	regexp.Compile(`100\$\+1`)
+	regexp.Compile(`100$`)
 }

--- a/checkers/testdata/regexpPattern/positive_tests.go
+++ b/checkers/testdata/regexpPattern/positive_tests.go
@@ -11,3 +11,11 @@ func domainDots() {
 	/*! '.ru' should probably be '\.ru' */
 	regexp.CompilePOSIX(`yandex.ru|radio.yandex.ru`)
 }
+
+func unescapedAnchors() {
+	/*! unescaped ^ in the middle of the regexp */
+	regexp.Compile(`2^10`)
+
+	/*! unescaped $ in the middle of the regexp */
+	regexp.Compile(`100$\+1`)
+}


### PR DESCRIPTION
- Report unescaped use of ^ not in the beginning of the pattern
- Report unescaped use of $ not in the end of the pattern

Both warnings are disabled if pattern has multi-line mode
enabled (achieved by flags parsing).

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>