### PR TITLE
checkers: fix panic on shadowing "copy" builtin

### DIFF
--- a/checkers/dupArg_checker.go
+++ b/checkers/dupArg_checker.go
@@ -24,6 +24,9 @@ func init() {
 		// args[xIndex] and args[yIndex] are equal.
 		newMatcherFunc := func(xIndex, yIndex int) func(*ast.CallExpr) bool {
 			return func(call *ast.CallExpr) bool {
+				if len(call.Args) <= xIndex || len(call.Args) <= yIndex {
+					return false
+				}
 				x := call.Args[xIndex]
 				y := call.Args[yIndex]
 				return astequal.Expr(x, y)

--- a/checkers/testdata/dupArg/negative_tests.go
+++ b/checkers/testdata/dupArg/negative_tests.go
@@ -53,6 +53,10 @@ func differentArgs() {
 	_ = types.Identical(typ, typ2)
 	_ = types.IdenticalIgnoreTags(typ, typ2)
 
+	// shadowing builtin "copy"
+	copy := func(x int) int { return x }
+	_ = copy(1)
+
 	{
 		var area image.Rectangle
 		var point image.Point


### PR DESCRIPTION
The dupArg checker assumes "copy" has at least two arguments. Builtins can be redefined though, so this assumption may not be true!

Fixes #870.