### PR TITLE
checkers: add truncateCmp checker

### DIFF
--- a/checkers/testdata/truncateCmp/negative_tests.go
+++ b/checkers/testdata/truncateCmp/negative_tests.go
@@ -1,0 +1,68 @@
+package checker_test
+
+func cmpWithConst(x int64) {
+	_ = int16(x) < 0
+	_ = 0 < int16(x)
+}
+
+func sameSizes(x, y int16) {
+	_ = int16(y) < x
+	_ = x < int16(y)
+
+	_ = y < x
+	_ = x < y
+}
+
+func mixedSignedness1(x uint8, y int16) {
+	_ = uint8(y) < x
+	_ = x < uint8(y)
+}
+
+func mixedSignedness2(x int8, y uint16) {
+	_ = int8(y) < x
+	_ = x < int8(y)
+}
+
+func goodInt8(x int8, y int16) {
+	_ = y < int16(x)
+	_ = int16(x) < y
+
+	_ = y <= int16(x)
+	_ = int16(x) <= y
+
+	_ = y > int16(x)
+	_ = int16(x) > y
+
+	_ = y >= int16(x)
+	_ = int16(x) >= y
+
+	_ = y == int16(x)
+	_ = int16(x) == y
+
+	_ = y != int16(x)
+	_ = int16(x) != y
+}
+
+func goodInt16(x1 int8, x2 int16, y int32) {
+	_ = y == int32(x1)
+	_ = int32(x1) == y
+
+	_ = y == int32(x2)
+	_ = int32(x2) == y
+}
+
+func goodInt32(x1 int8, x2 int16, x3 int32, y int64) {
+	_ = y == int64(x1)
+	_ = int64(x1) == y
+
+	_ = y == int64(x2)
+	_ = int64(x2) == y
+
+	_ = y == int64(x3)
+	_ = int64(3) == y
+}
+
+func goodUint8(x uint8, y uint16) {
+	_ = y == uint16(x)
+	_ = uint16(x) == y
+}

--- a/checkers/testdata/truncateCmp/positive_tests.go
+++ b/checkers/testdata/truncateCmp/positive_tests.go
@@ -1,0 +1,98 @@
+package checker_test
+
+func badInt8(x int8, y int16) {
+	/*! truncation in comparison 16->8 bit; cast the other operand to int16 instead */
+	_ = int8(y) < x
+	/*! truncation in comparison 16->8 bit; cast the other operand to int16 instead */
+	_ = x < int8(y)
+
+	/*! truncation in comparison 16->8 bit; cast the other operand to int16 instead */
+	_ = int8(y) <= x
+	/*! truncation in comparison 16->8 bit; cast the other operand to int16 instead */
+	_ = x <= int8(y)
+
+	/*! truncation in comparison 16->8 bit; cast the other operand to int16 instead */
+	_ = int8(y) > x
+	/*! truncation in comparison 16->8 bit; cast the other operand to int16 instead */
+	_ = x > int8(y)
+
+	/*! truncation in comparison 16->8 bit; cast the other operand to int16 instead */
+	_ = int8(y) >= x
+	/*! truncation in comparison 16->8 bit; cast the other operand to int16 instead */
+	_ = x >= int8(y)
+
+	/*! truncation in comparison 16->8 bit; cast the other operand to int16 instead */
+	_ = int8(y) == x
+	/*! truncation in comparison 16->8 bit; cast the other operand to int16 instead */
+	_ = x == int8(y)
+
+	/*! truncation in comparison 16->8 bit; cast the other operand to int16 instead */
+	_ = int8(y) != x
+	/*! truncation in comparison 16->8 bit; cast the other operand to int16 instead */
+	_ = x != int8(y)
+}
+
+func badInt16(x1 int8, x2 int16, y int32) {
+	/*! truncation in comparison 32->8 bit; cast the other operand to int32 instead */
+	_ = int8(y) == x1
+	/*! truncation in comparison 32->8 bit; cast the other operand to int32 instead */
+	_ = x1 == int8(y)
+
+	/*! truncation in comparison 32->16 bit; cast the other operand to int32 instead */
+	_ = int16(y) == x2
+	/*! truncation in comparison 32->16 bit; cast the other operand to int32 instead */
+	_ = x2 == int16(y)
+}
+
+func badInt32(x1 int8, x2 int16, x3 int32, y int64) {
+	/*! truncation in comparison 64->8 bit; cast the other operand to int64 instead */
+	_ = uint8(y) == x1
+	/*! truncation in comparison 64->8 bit; cast the other operand to int64 instead */
+	_ = x1 == uint8(y)
+
+	/*! truncation in comparison 64->16 bit; cast the other operand to int64 instead */
+	_ = int16(y) == x2
+	/*! truncation in comparison 64->16 bit; cast the other operand to int64 instead */
+	_ = x2 == int16(y)
+
+	/*! truncation in comparison 64->32 bit; cast the other operand to int64 instead */
+	_ = int32(y) == x3
+	/*! truncation in comparison 64->32 bit; cast the other operand to int64 instead */
+	_ = x3 == int32(y)
+}
+
+func badUint8(x uint8, y uint16) {
+	/*! truncation in comparison 16->8 bit; cast the other operand to uint16 instead */
+	_ = uint8(y) == x
+	/*! truncation in comparison 16->8 bit; cast the other operand to uint16 instead */
+	_ = x == uint8(y)
+}
+
+func badUint16(x1 uint8, x2 uint16, y uint32) {
+	/*! truncation in comparison 32->8 bit; cast the other operand to uint32 instead */
+	_ = uint8(y) == x1
+	/*! truncation in comparison 32->8 bit; cast the other operand to uint32 instead */
+	_ = x1 == uint8(y)
+
+	/*! truncation in comparison 32->16 bit; cast the other operand to uint32 instead */
+	_ = uint16(y) == x2
+	/*! truncation in comparison 32->16 bit; cast the other operand to uint32 instead */
+	_ = x2 == uint16(y)
+}
+
+func badUint32(x1 uint8, x2 uint16, x3 uint32, y uint64) {
+	/*! truncation in comparison 64->8 bit; cast the other operand to uint64 instead */
+	_ = uint8(y) == x1
+	/*! truncation in comparison 64->8 bit; cast the other operand to uint64 instead */
+	_ = x1 == uint8(y)
+
+	/*! truncation in comparison 64->16 bit; cast the other operand to uint64 instead */
+	_ = uint16(y) == x2
+	/*! truncation in comparison 64->16 bit; cast the other operand to uint64 instead */
+	_ = x2 == uint16(y)
+
+	/*! truncation in comparison 64->32 bit; cast the other operand to uint64 instead */
+	_ = uint32(y) == x3
+	/*! truncation in comparison 64->32 bit; cast the other operand to uint64 instead */
+	_ = x3 == uint32(y)
+}

--- a/checkers/truncateCmp_checker.go
+++ b/checkers/truncateCmp_checker.go
@@ -1,0 +1,108 @@
+package checkers
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+
+	"github.com/go-lintpack/lintpack"
+	"github.com/go-lintpack/lintpack/astwalk"
+	"github.com/go-toolsmith/astcast"
+	"github.com/go-toolsmith/astp"
+)
+
+func init() {
+	var info lintpack.CheckerInfo
+	info.Name = "truncateCmp"
+	info.Tags = []string{"diagnostic", "experimental"}
+	info.Params = lintpack.CheckerParams{
+		"skipArchDependent": {
+			Value: true,
+			Usage: "whether to skip int/uint/uintptr types",
+		},
+	}
+	info.Summary = "Detects potential truncation issues when comparing ints of different sizes"
+	info.Before = `
+func f(x int32, y int16) bool {
+  return int16(x) < y
+}`
+	info.After = `
+func f(x int32, int16) bool {
+  return x < int32(y)
+}`
+
+	collection.AddChecker(&info, func(ctx *lintpack.CheckerContext) lintpack.FileWalker {
+		c := &truncateCmpChecker{ctx: ctx}
+		c.skipArchDependent = info.Params.Bool("skipArchDependent")
+		return astwalk.WalkerForExpr(c)
+	})
+}
+
+type truncateCmpChecker struct {
+	astwalk.WalkHandler
+	ctx *lintpack.CheckerContext
+
+	skipArchDependent bool
+}
+
+func (c *truncateCmpChecker) VisitExpr(expr ast.Expr) {
+	cmp := astcast.ToBinaryExpr(expr)
+	switch cmp.Op {
+	case token.LSS, token.GTR, token.LEQ, token.GEQ, token.EQL, token.NEQ:
+		if astp.IsBasicLit(cmp.X) || astp.IsBasicLit(cmp.Y) {
+			return // Don't bother about untyped consts
+		}
+		if !c.checkCmp(cmp.X, cmp.Y) {
+			c.checkCmp(cmp.Y, cmp.X)
+		}
+	default:
+		return
+	}
+}
+
+func (c *truncateCmpChecker) checkCmp(cmpX, cmpY ast.Expr) bool {
+	// Check if we have a cast to a type that can truncate.
+	xcast := astcast.ToCallExpr(cmpX)
+	switch astcast.ToIdent(xcast.Fun).Name {
+	case "int8", "int16", "int32", "uint8", "uint16", "uint32":
+		// OK.
+	default:
+		return false
+	}
+	if len(xcast.Args) != 1 {
+		return false // Just in case of the shadowed builtin
+	}
+
+	x := xcast.Args[0]
+	y := cmpY
+
+	// Check that both x and y are signed or unsigned int-typed.
+	xtyp, ok := c.ctx.TypesInfo.TypeOf(x).Underlying().(*types.Basic)
+	if !ok || xtyp.Info()&types.IsInteger == 0 {
+		return false
+	}
+	ytyp, ok := c.ctx.TypesInfo.TypeOf(y).Underlying().(*types.Basic)
+	if !ok || xtyp.Info() != ytyp.Info() {
+		return false
+	}
+
+	xsize := c.ctx.SizesInfo.Sizeof(xtyp)
+	ysize := c.ctx.SizesInfo.Sizeof(ytyp)
+	if xsize <= ysize {
+		return false
+	}
+
+	if c.skipArchDependent {
+		switch xtyp.Kind() {
+		case types.Int, types.Uint, types.Uintptr:
+			return false
+		}
+	}
+
+	c.warn(xcast, xsize*8, ysize*8, xtyp.String())
+	return true
+}
+
+func (c *truncateCmpChecker) warn(cause ast.Expr, xsize, ysize int64, suggest string) {
+	c.ctx.Warn(cause, "truncation in comparison %d->%d bit; cast the other operand to %s instead", xsize, ysize, suggest)
+}


### PR DESCRIPTION
Checks when numeric types are compared with truncated conversion on
the either side.

Problematic code example:
```
	func f(x int32, y int16) bool {
	  return int16(x) < y
	}
```

Fixed code example:
```
	func f(x int32, int16) bool {
	  return x < int32(y)
	}
```
See https://github.com/golang/go/issues/35010

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>