### PR TITLE
checkers: don't warn on expressions with 2 casts

### DIFF
--- a/checkers/testdata/truncateCmp/negative_tests.go
+++ b/checkers/testdata/truncateCmp/negative_tests.go
@@ -1,5 +1,9 @@
 package checker_test
 
+func bothTruncated(x int32, y int64) {
+	_ = int16(x) < int16(y)
+}
+
 func cmpWithConst(x int64) {
 	_ = int16(x) < 0
 	_ = 0 < int16(x)


### PR DESCRIPTION
To avoid false positives, don't warn on comparisons
where both sides have integer conversions.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>