### PR TITLE
Add make target for gocritic binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.dll
 *.so
 *.dylib
+gocritic
 
 pkg/
 

--- a/Makefile
+++ b/Makefile
@@ -39,5 +39,8 @@ cover:
 	go install github.com/mattn/goveralls
 	goveralls -package github.com/go-critic/go-critic/checkers -coverprofile=coverage.out -service travis-ci -repotoken ${COVERALLS_TOKEN}
 
+gocritic:
+	lintpack build -o gocritic -linter.version='v0.3.4' -linter.name='gocritic' github.com/go-critic/go-critic/checkers
+
 install:
 	go install ./cmd/gocritic

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ Get `go-critic` checkers:
 go get -v github.com/go-critic/go-critic/...
 ```
 
-After that, you can create `go-critic` binary by running:
+After that, you can create `gocritic` binary by running:
 
 ```bash
-lintpack build -o gocritic -linter.version='v0.3.4' -linter.name='gocritic' github.com/go-critic/go-critic/checkers
+make gocritic
 ```
 
 > Windows note: `lintpack build` might emit a warning. See https://github.com/go-critic/go-critic/issues/760.


### PR DESCRIPTION
I felt this as friction when following the installation steps in README.md, so I thought I'd simplify it a bit.