### PR TITLE
Add whyNoLint checker.

### DIFF
--- a/checkers/testdata/whyNoLint/negative_tests.go
+++ b/checkers/testdata/whyNoLint/negative_tests.go
@@ -1,0 +1,13 @@
+package checker_test
+
+/* canonical forms */
+//nolint // reason
+//nolint:gocritic // reason
+//nolint:gocritic,whyNoLint // reason
+
+/* variants we're okay enough with not to warn on; some other checker be strict about spacing */
+//nolint //reason
+//nolint//reason
+// nolint // reason
+
+//yeslint

--- a/checkers/testdata/whyNoLint/positive_tests.go
+++ b/checkers/testdata/whyNoLint/positive_tests.go
@@ -1,0 +1,19 @@
+package checker_test
+
+/*! include an explanation for nolint directive */
+//nolint
+
+/*! include an explanation for nolint directive */
+//nolint:gocritic
+
+/*! include an explanation for nolint directive */
+//nolint:gocritic,whyNoLint
+
+/*! include an explanation for nolint directive */
+// nolint
+
+/*! include an explanation for nolint directive */
+//nolint nonsense
+
+/*! include an explanation for nolint directive */
+//nolint //

--- a/checkers/whyNoLint_checker.go
+++ b/checkers/whyNoLint_checker.go
@@ -1,0 +1,52 @@
+package checkers
+
+import (
+	"go/ast"
+	"regexp"
+	"strings"
+
+	"github.com/go-lintpack/lintpack"
+	"github.com/go-lintpack/lintpack/astwalk"
+)
+
+func init() {
+	info := lintpack.CheckerInfo{
+		Name:    "whyNoLint",
+		Tags:    []string{"style", "experimental"},
+		Summary: "Ensures that //nolint comments include an explanation",
+		Before:  `//nolint`,
+		After:   `//nolint // reason`,
+	}
+	re := regexp.MustCompile(`^// *nolint(?::[^ ]+)? *(.*)$`)
+
+	collection.AddChecker(&info, func(ctx *lintpack.CheckerContext) lintpack.FileWalker {
+		return astwalk.WalkerForComment(&whyNoLintChecker{
+			ctx: ctx,
+			re:  re,
+		})
+	})
+}
+
+type whyNoLintChecker struct {
+	astwalk.WalkHandler
+
+	ctx *lintpack.CheckerContext
+	re  *regexp.Regexp
+}
+
+func (c whyNoLintChecker) VisitComment(cg *ast.CommentGroup) {
+	if strings.HasPrefix(cg.List[0].Text, "/*") {
+		return
+	}
+	for _, comment := range cg.List {
+		sl := c.re.FindStringSubmatch(comment.Text)
+		if len(sl) < 2 {
+			continue
+		}
+
+		if !strings.HasPrefix(sl[1], "//") || len(strings.TrimPrefix(sl[1], "//")) == 0 {
+			c.ctx.Warn(cg, "include an explanation for nolint directive")
+			return
+		}
+	}
+}

--- a/checkers/whyNoLint_checker.go
+++ b/checkers/whyNoLint_checker.go
@@ -13,7 +13,7 @@ func init() {
 	info := lintpack.CheckerInfo{
 		Name:    "whyNoLint",
 		Tags:    []string{"style", "experimental"},
-		Summary: "Ensures that //nolint comments include an explanation",
+		Summary: "Ensures that `//nolint` comments include an explanation",
 		Before:  `//nolint`,
 		After:   `//nolint // reason`,
 	}

--- a/checkers/whyNoLint_checker.go
+++ b/checkers/whyNoLint_checker.go
@@ -44,7 +44,7 @@ func (c whyNoLintChecker) VisitComment(cg *ast.CommentGroup) {
 			continue
 		}
 
-		if !strings.HasPrefix(sl[1], "//") || len(strings.TrimPrefix(sl[1], "//")) == 0 {
+		if s := sl[1]; !strings.HasPrefix(s, "//") || len(strings.TrimPrefix(s, "//")) == 0 {
 			c.ctx.Warn(cg, "include an explanation for nolint directive")
 			return
 		}


### PR DESCRIPTION
This checker inspects machine-readable //nolint comments (per the
conventions from https://github.com/golangci/golangci-lint#nolint) to
ensure that they are accompanied by human-readable explanatory
comments on the same line.

The intention is to enable teams to enforce a policy of not disabling
linters without providing an explicit justification.