### PR TITLE
makefile: correct linter.version argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ cover:
 	goveralls -package github.com/go-critic/go-critic/checkers -coverprofile=coverage.out -service travis-ci -repotoken ${COVERALLS_TOKEN}
 
 gocritic:
-	lintpack build -o gocritic -linter.version='v0.3.4' -linter.name='gocritic' github.com/go-critic/go-critic/checkers
+	lintpack build -o gocritic -linter.version='v0.4.0' -linter.name='gocritic' github.com/go-critic/go-critic/checkers
 
 install:
 	go install ./cmd/gocritic


### PR DESCRIPTION
* Correct linter.version argument in `Makefile`.

After `make gocritic` I get wrong version in output of `gocritic version` - `v0.3.4`, correct is `v0.4.0`.