### PR TITLE
checkers: fix integration tests

### DIFF
--- a/checkers/testdata/_integration/check_main_only/main.go
+++ b/checkers/testdata/_integration/check_main_only/main.go
@@ -212,7 +212,7 @@ loop:
 }
 
 func unlambda(func(x int) int) {
-	add1 := func(x int) int { return x + 1 }
+	// Don't use local func here, see #888.
 	unlambda(func(x int) int { return add1(x) })
 }
 
@@ -276,5 +276,9 @@ func badCall(s string) {
 	_ = strings.Replace(s, "-", "=", 0)
 }
 
+// No test functions below this line, please.
+
 func main() {
 }
+
+func add1(x int) int { return x + 1 }


### PR DESCRIPTION
They were failing due to the lack of unlambda warning.
It happened because the code used a closure (var-assigned func)
instead of a normal func. We don't warn on closures
anymore (see #888), so that warning disappeared.

For whatever reason, CI passed and we didn't notice it.
Maybe integration tests are not executed as a part of our pipeline?

Anyway, tests should be fixed now.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>