### PR TITLE
checkers: add mapKey checker

### DIFF
--- a/checkers/mapKey_checker.go
+++ b/checkers/mapKey_checker.go
@@ -1,0 +1,124 @@
+package checkers
+
+import (
+	"go/ast"
+	"go/types"
+	"strings"
+
+	"github.com/go-critic/go-critic/checkers/internal/lintutil"
+	"github.com/go-lintpack/lintpack"
+	"github.com/go-lintpack/lintpack/astwalk"
+	"github.com/go-toolsmith/astcast"
+	"github.com/go-toolsmith/astp"
+	"github.com/go-toolsmith/typep"
+)
+
+func init() {
+	var info lintpack.CheckerInfo
+	info.Name = "mapKey"
+	info.Tags = []string{"diagnostic", "experimental"}
+	info.Summary = "Detects suspicious map literal keys"
+	info.Before = `
+_ = map[string]int{
+	"foo": 1,
+	"bar ": 2,
+}`
+	info.After = `
+_ = map[string]int{
+	"foo": 1,
+	"bar": 2,
+}`
+
+	collection.AddChecker(&info, func(ctx *lintpack.CheckerContext) lintpack.FileWalker {
+		return astwalk.WalkerForExpr(&mapKeyChecker{ctx: ctx})
+	})
+}
+
+type mapKeyChecker struct {
+	astwalk.WalkHandler
+	ctx *lintpack.CheckerContext
+
+	astSet lintutil.AstSet
+}
+
+func (c *mapKeyChecker) VisitExpr(expr ast.Expr) {
+	lit := astcast.ToCompositeLit(expr)
+	if len(lit.Elts) < 2 {
+		return
+	}
+
+	typ, ok := c.ctx.TypesInfo.TypeOf(lit).Underlying().(*types.Map)
+	if !ok {
+		return
+	}
+	if !typep.HasStringKind(typ.Key().Underlying()) {
+		return
+	}
+
+	c.checkWhitespace(lit)
+	c.checkDuplicates(lit)
+}
+
+func (c *mapKeyChecker) checkDuplicates(lit *ast.CompositeLit) {
+	c.astSet.Clear()
+
+	for _, elt := range lit.Elts {
+		kv := astcast.ToKeyValueExpr(elt)
+		if astp.IsBasicLit(kv.Key) {
+			// Basic lits are handled by the compiler.
+			continue
+		}
+		if !typep.SideEffectFree(c.ctx.TypesInfo, kv.Key) {
+			continue
+		}
+		if !c.astSet.Insert(kv.Key) {
+			c.warnDupKey(kv.Key)
+		}
+	}
+}
+
+func (c *mapKeyChecker) checkWhitespace(lit *ast.CompositeLit) {
+	var whitespaceKey ast.Node
+	for _, elt := range lit.Elts {
+		key := astcast.ToBasicLit(astcast.ToKeyValueExpr(elt).Key)
+		if len(key.Value) < len(`" "`) {
+			continue
+		}
+		// s is unquoted string literal value.
+		s := key.Value[len(`"`) : len(key.Value)-len(`"`)]
+		if !strings.Contains(s, " ") {
+			continue
+		}
+		if whitespaceKey != nil {
+			// Already seen something with a whitespace.
+			// More than one entry => not suspicious.
+			return
+		}
+		if s == " " {
+			// If space is used as a key, maybe this map
+			// has something to do with spaces. Give up.
+			return
+		}
+		// Check if it has exactly 1 space prefix or suffix.
+		bad := strings.HasPrefix(s, " ") && !strings.HasPrefix(s, "  ") ||
+			strings.HasSuffix(s, " ") && !strings.HasSuffix(s, "  ")
+		if !bad {
+			// These spaces can be a padding,
+			// or a legitimate part of a key. Give up.
+			return
+		}
+		whitespaceKey = key
+	}
+
+	if whitespaceKey != nil {
+		c.warnWhitespace(whitespaceKey)
+	}
+}
+
+func (c *mapKeyChecker) warnWhitespace(key ast.Node) {
+	c.ctx.Warn(key, "suspucious whitespace in %s key", key)
+}
+
+func (c *mapKeyChecker) warnDupKey(key ast.Node) {
+	c.ctx.Warn(key, "suspicious duplicate %s key", key)
+}

--- a/checkers/testdata/mapKey/negative_tests.go
+++ b/checkers/testdata/mapKey/negative_tests.go
@@ -1,0 +1,85 @@
+package checker_test
+
+func negativeTests() {
+	// Non-string keys -- OK.
+	_ = map[int]int{
+		1: 1,
+		2: 2,
+		3: 3,
+	}
+
+	// No spaces -- OK.
+	_ = map[string]int{
+		"foo": 1,
+		"bar": 2,
+		"baz": 3,
+	}
+
+	_ = map[string]int{}
+
+	_ = map[string]int{"": 1}
+
+	// Single element.
+	_ = map[string]int{
+		"foo ": 1,
+	}
+
+	// Tests below check that we check underlying maps as well.
+
+	type myMap map[string]int
+
+	// More than 1 space.
+	_ = myMap{
+		"a ": 1,
+		"b ": 2,
+		"c ": 3,
+	}
+
+	// More than 1 space.
+	_ = myMap{
+		" a": 1,
+		" b": 2,
+		" c": 3,
+	}
+
+	// More than 1 space.
+	_ = myMap{
+		" a ": 1,
+		" b ": 2,
+		" c ": 3,
+	}
+
+	// Single-value map is an exception.
+	_ = myMap{
+		"a  ": 1,
+	}
+
+	// More than 1 space is not suspicious.
+	_ = myMap{
+		"a  ": 1,
+		"b  ": 2,
+	}
+
+	// A whitespace itself is not suspicious.
+	_ = myMap{
+		"a": 1,
+		" ": 2,
+	}
+
+	_ = myMap{
+		"a":  1,
+		"a ": 2,
+		"  ": 3,
+	}
+
+	// Function call inside a key disables our duplicated key check.
+	_ = map[string]int{
+		getKeys()[0]: 1,
+		getKeys()[1]: 2,
+		getKeys()[0]: 3,
+	}
+}
+
+func getKeys() []string {
+	return []string{"a", "b"}
+}

--- a/checkers/testdata/mapKey/positive_tests.go
+++ b/checkers/testdata/mapKey/positive_tests.go
@@ -1,0 +1,45 @@
+package checker_test
+
+func suspiciousWhitespace() {
+	_ = map[string]int{
+		/*! suspucious whitespace in `foo ` key */
+		`foo `: 1,
+		`bar`:  2,
+		`baz`:  3,
+	}
+
+	_ = map[string]int{
+		"foo": 1,
+		"bar": 2,
+		/*! suspucious whitespace in " baz" key */
+		" baz": 3,
+	}
+
+	type myMap map[string]int
+
+	_ = myMap{
+		"foo": 1,
+		/*! suspucious whitespace in "bar " key */
+		"bar ": 2,
+		"baz":  3,
+	}
+}
+
+func suspiciousDupKey() {
+	k := "abc"
+
+	keys := []string{"a", "b"}
+
+	_ = map[string]int{
+		k: 1,
+		/*! suspicious duplicate k key */
+		k: 2,
+	}
+
+	_ = map[string]int{
+		keys[0]: 1,
+		keys[1]: 2,
+		/*! suspicious duplicate keys[0] key */
+		keys[0]: 3,
+	}
+}


### PR DESCRIPTION
Detects suspicious whitespace inside map literal keys.

Detects duplicated map keys that are not basic literals.
Basic literals are handled by Go compiler.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>