### PR TITLE
feat: allow go:generate directives

### DIFF
--- a/checkers/commentFormatting_checker.go
+++ b/checkers/commentFormatting_checker.go
@@ -21,9 +21,10 @@ func init() {
 
 	collection.AddChecker(&info, func(ctx *lintpack.CheckerContext) lintpack.FileWalker {
 		parts := []string{
-			`^//\w+:.*$`,      //key: value
-			`^//nolint$`,      //nolint
-			`^//line /.*:\d+`, //line /path/to/file:123
+			`^//go:generate .*$`, //go:generate value
+			`^//\w+:.*$`,         //key: value
+			`^//nolint$`,         //nolint
+			`^//line /.*:\d+`,    //line /path/to/file:123
 		}
 		pat := "(?m)" + strings.Join(parts, "|")
 		pragmaRE := regexp.MustCompile(pat)

--- a/checkers/testdata/commentFormatting/negative_tests.go
+++ b/checkers/testdata/commentFormatting/negative_tests.go
@@ -13,6 +13,8 @@ are ignored
 
 //directive: abc
 
+//go:generate abc
+
 //#ifdef foo
 //#endif
 


### PR DESCRIPTION
Similar to this change https://github.com/go-critic/go-critic/pull/756/files

but support for `go:generate`