### PR TITLE
checkers: add prefix/suffix factoring in regexpSimplify

### DIFF
--- a/checkers/testdata/regexpSimplify/negative_tests.go
+++ b/checkers/testdata/regexpSimplify/negative_tests.go
@@ -12,6 +12,15 @@ func shouldNotSimplify() {
 	regexp.MustCompile(`[)]`)
 }
 
+func noCommonPrefixSuffix() {
+	regexp.MustCompile(`aa|a`) // Too short to bother
+
+	regexp.MustCompile(`foo|fa`) // Doesn't match our criteria
+	regexp.MustCompile(`1path|2path`)
+
+	regexp.MustCompile(`(?:http|https|ftp)://`) // More than 2 alternatives
+}
+
 func cantSimplify() {
 	// Most of these patterns come from the projects available at GitHub.
 

--- a/checkers/testdata/regexpSimplify/positive_tests.go
+++ b/checkers/testdata/regexpSimplify/positive_tests.go
@@ -16,6 +16,23 @@ func multiPass() {
 	regexp.MustCompile(`(?:a|b|c)`)
 }
 
+func altCommonPrefixSuffix() {
+	/*! can re-write `foo|fo` as `foo?` */
+	regexp.MustCompile(`foo|fo`)
+
+	/*! can re-write `(?:http|https)://` as `(?:https?)://` */
+	regexp.MustCompile(`(?:http|https)://`)
+
+	/*! can re-write `xpath|path` as `x?path` */
+	regexp.MustCompile(`xpath|path`)
+
+	// Should also work with multi-byte runes.
+	/*! can re-write `❤path|path` as `❤?path` */
+	regexp.MustCompile(`❤path|path`)
+	/*! can re-write `fo|fo❤` as `fo❤?` */
+	regexp.MustCompile(`fo|fo❤`)
+}
+
 // xx* -> x+
 func merge() {
 	/*! can re-write `x[abcd][abcd]*y` as `x[abcd]+y` */


### PR DESCRIPTION
Handles simplest common suffixes and prefixes.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>