### PR TITLE
checkers: add filepath.Join checker

### DIFF
--- a/checkers/filepathJoin_checker.go
+++ b/checkers/filepathJoin_checker.go
@@ -1,0 +1,50 @@
+package checkers
+
+import (
+	"go/ast"
+	"strings"
+
+	"github.com/go-lintpack/lintpack"
+	"github.com/go-lintpack/lintpack/astwalk"
+	"github.com/go-toolsmith/astcast"
+)
+
+func init() {
+	var info lintpack.CheckerInfo
+	info.Name = "filepathJoin"
+	info.Tags = []string{"diagnostic", "experimental"}
+	info.Summary = "Detects problems in filepath.Join() function calls"
+	info.Before = `filepath.Join("dir/", filename)`
+	info.After = `filepath.Join("dir", filename)`
+
+	collection.AddChecker(&info, func(ctx *lintpack.CheckerContext) lintpack.FileWalker {
+		return astwalk.WalkerForExpr(&filepathJoinChecker{ctx: ctx})
+	})
+}
+
+type filepathJoinChecker struct {
+	astwalk.WalkHandler
+	ctx *lintpack.CheckerContext
+}
+
+func (c *filepathJoinChecker) VisitExpr(expr ast.Expr) {
+	call := astcast.ToCallExpr(expr)
+	if qualifiedName(call.Fun) != "filepath.Join" {
+		return
+	}
+
+	for _, arg := range call.Args {
+		arg, ok := arg.(*ast.BasicLit)
+		if ok && c.hasSeparator(arg) {
+			c.warnSeparator(arg)
+		}
+	}
+}
+
+func (c *filepathJoinChecker) hasSeparator(v *ast.BasicLit) bool {
+	return strings.ContainsAny(v.Value, `/\`)
+}
+
+func (c *filepathJoinChecker) warnSeparator(sep ast.Expr) {
+	c.ctx.Warn(sep, "%s contains a path separator", sep)
+}

--- a/checkers/testdata/filepathJoin/negative_tests.go
+++ b/checkers/testdata/filepathJoin/negative_tests.go
@@ -1,0 +1,16 @@
+package checker_test
+
+import (
+	"path/filepath"
+)
+
+func badArgs() {
+	filename := "file.go"
+	dir := "testdata"
+
+	_ = filepath.Join("testdata", filename)
+
+	_ = filepath.Join(dir, "file.go")
+
+	_ = filepath.Join(`testdata`, `a`, `b.txt`)
+}

--- a/checkers/testdata/filepathJoin/positive_tests.go
+++ b/checkers/testdata/filepathJoin/positive_tests.go
@@ -1,0 +1,20 @@
+package checker_test
+
+import (
+	"path/filepath"
+)
+
+func badArgs() {
+	filename := "file.go"
+	dir := "testdata"
+
+	/*! "testdata/" contains a path separator */
+	_ = filepath.Join("testdata/", filename)
+
+	/*! "/file.go" contains a path separator */
+	_ = filepath.Join(dir, "/file.go")
+
+	/*! `\a\b.txt` contains a path separator */
+	/*! `testdata\` contains a path separator */
+	_ = filepath.Join(`testdata\`, `\a\b.txt`)
+}


### PR DESCRIPTION
```
Reports filepath.Join() string literal arguments that contain
'/' or '\' as it kinda defeats the purpose of using that function.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>
```