### PR TITLE
checkers: fix sqlQuery panic

### DIFF
--- a/checkers/testdata/sqlQuery/negative_tests.go
+++ b/checkers/testdata/sqlQuery/negative_tests.go
@@ -4,6 +4,12 @@ import (
 	"database/sql"
 )
 
+func foo() (int, int) { return 0, 0 }
+
+func notQueryCall() {
+	_, _ = foo()
+}
+
 func queryResultIsUsed(db *sql.DB, qe QueryExecer, mydb *myDatabase) {
 	const queryString = "SELECT * FROM users"
 


### PR DESCRIPTION
If astcast to SelectorExpr failed, funcExpr.Sel will be nil.

Bug reported by @un000

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>