### PR TITLE
checkers: restrict unnecessaryDefer to const expr only

### DIFF
--- a/checkers/testdata/unnecessaryDefer/negative_tests.go
+++ b/checkers/testdata/unnecessaryDefer/negative_tests.go
@@ -53,3 +53,16 @@ func foo_8() int {
 	}
 	return 0
 }
+
+type sharedData struct {
+	value int
+}
+
+func (*sharedData) Lock()   {}
+func (*sharedData) Unlock() {}
+
+func issue941(d *sharedData) int {
+	d.Lock()
+	defer d.Unlock()
+	return d.value
+}

--- a/checkers/testdata/unnecessaryDefer/positive_tests.go
+++ b/checkers/testdata/unnecessaryDefer/positive_tests.go
@@ -56,3 +56,11 @@ func foo7() {
 	}
 	return
 }
+
+func returnConstExpr(s *sharedData) (string, bool, int) {
+	const foo = "12"
+	s.Lock()
+	/*! defer s.Unlock() is placed just before return */
+	defer s.Unlock()
+	return foo + "3", false, len(foo) + 1
+}


### PR DESCRIPTION
If return results contain something that is not a constant
expression, do not emit a warning.

Fixes #941

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>