### PR TITLE
checkers: don't warn on single case if it contains a break

### DIFF
--- a/checkers/testdata/singleCaseSwitch/negative_tests.go
+++ b/checkers/testdata/singleCaseSwitch/negative_tests.go
@@ -29,3 +29,25 @@ func caseWithTwoValues(x int) {
 	case 1, 2:
 	}
 }
+
+func caseWithBreak(x interface{}) {
+	switch x.(type) {
+	case int:
+		println(x)
+		break
+	}
+
+	switch x.(int) {
+	case 0:
+		println(x)
+		break
+	}
+
+	for {
+		switch x.(int) {
+		case 0:
+			println(x)
+			break
+		}
+	}
+}

--- a/checkers/testdata/singleCaseSwitch/positive_tests.go
+++ b/checkers/testdata/singleCaseSwitch/positive_tests.go
@@ -25,3 +25,24 @@ func switchWithOneCase(x int) {
 	case 1:
 	}
 }
+
+func badCaseWithBreak(x, y int) {
+	/*! should rewrite switch statement to if statement */
+	switch x {
+	case 0:
+		println(x)
+		for {
+			break
+		}
+	}
+
+	/*! should rewrite switch statement to if statement */
+	switch x {
+	case 0:
+		println(x)
+		switch y {
+		case 2:
+			break
+		}
+	}
+}


### PR DESCRIPTION
If we re-write switch to an if, break statements may become an issue.
To avoid false positives, singleCaseSwitch checker won't report
switch statements of 1 case if it contains a break statement
(unless that statement is inside for/select/switch itself.)

Fixes #682

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>