### PR TITLE
framework/lintmain/internal/check: add missing NeedName mode flag

### DIFF
--- a/framework/lintmain/internal/check/check.go
+++ b/framework/lintmain/internal/check/check.go
@@ -245,8 +245,16 @@ func (p *program) loadProgram() error {
 	}
 
 	p.fset = token.NewFileSet()
+	mode := packages.NeedName |
+		packages.NeedFiles |
+		packages.NeedCompiledGoFiles |
+		packages.NeedImports |
+		packages.NeedTypes |
+		packages.NeedSyntax |
+		packages.NeedTypesInfo |
+		packages.NeedTypesSizes
 	cfg := packages.Config{
-		Mode:  packages.NeedFiles | packages.NeedCompiledGoFiles | packages.NeedImports | packages.NeedTypes | packages.NeedSyntax | packages.NeedTypesInfo | packages.NeedTypesSizes,
+		Mode:  mode,
 		Tests: true,
 		Fset:  p.fset,
 	}


### PR DESCRIPTION
When doing packages Load(), we need to pass a packages.NeedName flag,
so our pkgload package can categorize the packages correctly.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>