### PR TITLE
checkers: add builtinShadowDecl

### DIFF
--- a/checkers/builtinShadowDecl_checker.go
+++ b/checkers/builtinShadowDecl_checker.go
@@ -1,0 +1,63 @@
+package checkers
+
+import (
+	"go/ast"
+
+	"github.com/go-critic/go-critic/checkers/internal/astwalk"
+	"github.com/go-critic/go-critic/framework/linter"
+)
+
+func init() {
+	var info linter.CheckerInfo
+	info.Name = "builtinShadowDecl"
+	info.Tags = []string{"diagnostic", "experimental"}
+	info.Summary = "Detects top-level declarations that shadow the predeclared identifiers"
+	info.Before = `type int struct {}`
+	info.After = `type myInt struct {}`
+
+	collection.AddChecker(&info, func(ctx *linter.CheckerContext) linter.FileWalker {
+		return &builtinShadowDeclChecker{ctx: ctx}
+	})
+}
+
+type builtinShadowDeclChecker struct {
+	astwalk.WalkHandler
+	ctx *linter.CheckerContext
+}
+
+func (c *builtinShadowDeclChecker) WalkFile(f *ast.File) {
+	for _, decl := range f.Decls {
+		switch decl := decl.(type) {
+		case *ast.FuncDecl:
+			// Don't check methods. They can shadow anything safely.
+			if decl.Recv == nil {
+				c.checkName(decl.Name)
+			}
+		case *ast.GenDecl:
+			c.visitGenDecl(decl)
+		}
+	}
+}
+
+func (c *builtinShadowDeclChecker) visitGenDecl(decl *ast.GenDecl) {
+	for _, spec := range decl.Specs {
+		switch spec := spec.(type) {
+		case *ast.ValueSpec:
+			for _, name := range spec.Names {
+				c.checkName(name)
+			}
+		case *ast.TypeSpec:
+			c.checkName(spec.Name)
+		}
+	}
+}
+
+func (c *builtinShadowDeclChecker) checkName(name *ast.Ident) {
+	if isBuiltin(name.Name) {
+		c.warn(name)
+	}
+}
+
+func (c *builtinShadowDeclChecker) warn(ident *ast.Ident) {
+	c.ctx.Warn(ident, "shadowing of predeclared identifier: %s", ident)
+}

--- a/checkers/builtinShadow_checker.go
+++ b/checkers/builtinShadow_checker.go
@@ -11,7 +11,7 @@ func init() {
 	var info linter.CheckerInfo
 	info.Name = "builtinShadow"
 	info.Tags = []string{"style", "opinionated"}
-	info.Summary = "Detects when predeclared identifiers shadowed in assignments"
+	info.Summary = "Detects when predeclared identifiers are shadowed in assignments"
 	info.Before = `len := 10`
 	info.After = `length := 10`
 

--- a/checkers/testdata/builtinShadowDecl/negative_tests.go
+++ b/checkers/testdata/builtinShadowDecl/negative_tests.go
@@ -1,0 +1,22 @@
+package checker_test
+
+type myint struct{}
+
+type (
+	myint8  = int
+	myint16 = int
+)
+
+func mybool() {}
+
+var (
+	myfloat32 = 1
+	myfloat64 = 2
+)
+
+const (
+	mycomplex64  = 1
+	mycomplex128 = 2
+)
+
+func (myint) close() {}

--- a/checkers/testdata/builtinShadowDecl/positive_tests.go
+++ b/checkers/testdata/builtinShadowDecl/positive_tests.go
@@ -1,0 +1,28 @@
+package checker_test
+
+/*! shadowing of predeclared identifier: int */
+type int struct{}
+
+type (
+	/*! shadowing of predeclared identifier: int8 */
+	int8 = int
+	/*! shadowing of predeclared identifier: int16 */
+	int16 = int
+)
+
+/*! shadowing of predeclared identifier: bool */
+func bool() {}
+
+var (
+	/*! shadowing of predeclared identifier: float32 */
+	float32 = 1
+	/*! shadowing of predeclared identifier: float64 */
+	float64 = 2
+)
+
+const (
+	/*! shadowing of predeclared identifier: complex64 */
+	complex64 = 1
+	/*! shadowing of predeclared identifier: complex128 */
+	complex128 = 2
+)


### PR DESCRIPTION
Finds top-level symbols that have a name that will shadow a
builtin identifier for the entire package.

Unlike builtinShadow, it's not a style but rather a diganostic check.

Fixes #868

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>