### PR TITLE
Clarifies exitAfterDefer warning verbaige

### DIFF
--- a/checkers/exitAfterDefer_checker.go
+++ b/checkers/exitAfterDefer_checker.go
@@ -72,5 +72,5 @@ func (c *exitAfterDeferChecker) warn(cause *ast.CallExpr, deferStmt *ast.DeferSt
 		// collapse the function literals.
 		s = "defer " + astfmt.Sprint(fnlit.Type) + "{...}(...)"
 	}
-	c.ctx.Warn(cause, "%s clutters `%s`", cause.Fun, s)
+	c.ctx.Warn(cause, "%s will exit, and `%s` will not run", cause.Fun, s)
 }

--- a/checkers/testdata/_integration/check_main_only/linttest.golden
+++ b/checkers/testdata/_integration/check_main_only/linttest.golden
@@ -22,7 +22,7 @@ exit status 1
 ./main.go:91:9: elseif: can replace 'else {if cond {}}' with 'else if cond {}'
 ./main.go:102:3: emptyFallthrough: replace empty case containing only fallthrough with expression list
 ./main.go:100:3: emptyFallthrough: replace empty case containing only fallthrough with expression list
-./main.go:255:2: exitAfterDefer: log.Fatal clutters `defer func(){...}(...)`
+./main.go:255:2: exitAfterDefer: log.Fatal will exit, and `defer func(){...}(...)` will not run
 ./main.go:111:6: flagDeref: immediate deref in *flag.String("str", "", "usage") is most likely an error; consider using flag.StringVar
 ./main.go:238:6: flagName: flag name " foo " contains whitespace
 ./main.go:114:16: hugeParam: x is heavy (80000 bytes); consider passing it by pointer

--- a/checkers/testdata/exitAfterDefer/positive_tests.go
+++ b/checkers/testdata/exitAfterDefer/positive_tests.go
@@ -6,14 +6,14 @@ import (
 
 func simpleExitAfterDefer() {
 	defer println("before return")
-	/*! os.Exit clutters `defer println("before return")` */
+	/*! os.Exit will exit, and `defer println("before return")` will not run */
 	os.Exit(0)
 }
 
 func conditionalExitAfterDefer(cond bool) {
 	defer println("I'm deferred")
 	if cond {
-		/*! os.Exit clutters `defer println("I'm deferred")` */
+		/*! os.Exit will exit, and `defer println("I'm deferred")` will not run */
 		os.Exit(0)
 	}
 }
@@ -26,7 +26,7 @@ func twoExits1(cond1, cond2 bool) {
 	}
 	defer println("")
 	if cond2 {
-		/*! os.Exit clutters `defer println("")` */
+		/*! os.Exit will exit, and `defer println("")` will not run */
 		os.Exit(0)
 	}
 }
@@ -35,7 +35,7 @@ func twoExits2() {
 	// Only the first exit gives a warning.
 
 	defer println("")
-	/*! os.Exit clutters `defer println("")` */
+	/*! os.Exit will exit, and `defer println("")` will not run */
 	os.Exit(0)
 	os.Exit(0)
 }
@@ -45,6 +45,6 @@ func deferLambda() {
 		println(x)
 	}(1)
 
-	/*! os.Exit clutters `defer func(x int){...}(...)` */
+	/*! os.Exit will exit, and `defer func(x int){...}(...)` will not run */
 	os.Exit(0)
 }


### PR DESCRIPTION
Clarifies the verbiage that the `exitAfterDefer` rule uses to warn the user to improve clarification as to the issue and consequences