### PR TITLE
framework/linttest: fail on pkg errors by default

### DIFF
--- a/checkers/checkers_test.go
+++ b/checkers/checkers_test.go
@@ -22,7 +22,13 @@ func TestCheckers(t *testing.T) {
 		}
 	}
 
-	linttest.TestCheckers(t)
+	cfg := linttest.CheckersTest{
+		IgnoreErrors: []string{
+			"caseOrder",
+		},
+	}
+
+	cfg.Run(t)
 }
 
 func TestIntegration(t *testing.T) {

--- a/checkers/testdata/commentFormatting/negative_tests.go
+++ b/checkers/testdata/commentFormatting/negative_tests.go
@@ -32,7 +32,7 @@ func myfunc() {
 }
 
 //go:noinline
-func f1() {
+func f2() {
 	//nolint
 
 	//	code

--- a/checkers/testdata/filepathJoin/negative_tests.go
+++ b/checkers/testdata/filepathJoin/negative_tests.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 )
 
-func badArgs() {
+func goodArgs() {
 	filename := "file.go"
 	dir := "testdata"
 

--- a/checkers/testdata/octalLiteral/negative_tests.go
+++ b/checkers/testdata/octalLiteral/negative_tests.go
@@ -23,10 +23,6 @@ func calculateString(x string) string {
 	return x
 }
 
-func calculateIntPair(x, y int) (int, int) {
-	return x, y
-}
-
 func NoWarningsCalc() {
 	_ = calculateInt(0)
 	_ = calculateInt(1)
@@ -35,7 +31,7 @@ func NoWarningsCalc() {
 	_ = calculateInt(12)
 	_ = calculateInt(1 + 2)
 
-	var int x = 03
+	var x = 03
 	_ = calculateInt(x)
 
 	_ = calculateHex(0x0)
@@ -51,9 +47,9 @@ func NoWarningsCalc() {
 	_ = calculateString("01")
 	_ = calculateString("0.1")
 
-	_ = calculateIntPair(1, 2)
-	_ = calculateIntPair(-1, 2)
-	_ = calculateIntPair(0, 2)
+	_, _ = calculateIntPair(1, 2)
+	_, _ = calculateIntPair(-1, 2)
+	_, _ = calculateIntPair(0, 2)
 
 	_ = math.Exp(12)
 	_ = math.Exp(0x12)
@@ -72,5 +68,5 @@ func NoWarningsOs() {
 }
 
 func NoWarningsIoutil() {
-	_ = ioutil.WriteFile("notes.txt", []byte(), 0666)
+	_ = ioutil.WriteFile("notes.txt", nil, 0666)
 }

--- a/checkers/testdata/octalLiteral/positive_tests.go
+++ b/checkers/testdata/octalLiteral/positive_tests.go
@@ -4,10 +4,6 @@ import (
 	"math"
 )
 
-func calculateInt(x int) int {
-	return x
-}
-
 func calculateIntPair(x, y int) (int, int) {
 	return x, y
 }
@@ -30,27 +26,27 @@ func warningsCalc() {
 	_ = calculateInt(calculateInt(012))
 
 	/*! suspicious octal args in `calculateIntPair(01, 2)` */
-	_ = calculateIntPair(01, 2)
+	_, _ = calculateIntPair(01, 2)
 
 	/*! suspicious octal args in `calculateIntPair(-1, -012)` */
-	_ = calculateIntPair(-1, -012)
+	_, _ = calculateIntPair(-1, -012)
 
 	/*! suspicious octal args in `calculateIntPair(01, 02)` */
-	_ = calculateIntPair(01, 02)
+	_, _ = calculateIntPair(01, 02)
 
 	/*! suspicious octal args in `calculateInt(01)` */
 	/*! suspicious octal args in `calculateInt(02)` */
-	_ = calculateIntPair(calculateInt(01), calculateInt(02))
+	_, _ = calculateIntPair(calculateInt(01), calculateInt(02))
 
 	/*! suspicious octal args in `calculateIntPair(01, calculateInt(02))` */
 	/*! suspicious octal args in `calculateInt(02)` */
-	_ = calculateIntPair(01, calculateInt(02))
+	_, _ = calculateIntPair(01, calculateInt(02))
 
 	/*! suspicious octal args in `calculateManyArgs(11, "12", 013)` */
-	_ = calculateManyArgs(11, "12", 013)
+	_, _, _ = calculateManyArgs(11, "12", 013)
 
 	/*! suspicious octal args in `calculateManyArgs(-02, "3", -04)` */
-	_ = calculateManyArgs(-02, "3", -04)
+	_, _, _ = calculateManyArgs(-02, "3", -04)
 
 	/*! suspicious octal args in `math.Exp(012)` */
 	_ = math.Exp(012)

--- a/checkers/testdata/regexpPattern/negative_tests.go
+++ b/checkers/testdata/regexpPattern/negative_tests.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 )
 
-func domainDots() {
+func domainDotsEscaped() {
 	regexp.MustCompile(`google\.com`)
 
 	regexp.CompilePOSIX(`yandex\.ru|radio.yandex\.ru`)

--- a/framework/linttest/linttest.go
+++ b/framework/linttest/linttest.go
@@ -61,35 +61,63 @@ type IntegrationTest struct {
 	Dir string
 }
 
-// TestCheckers runs end2end tests over all registered checkers using default options.
+type CheckersTest struct {
+	// IgnoreErrors is a checker names list those tests ignore parse/typecheck errors.
+	IgnoreErrors []string
+}
+
+// Run executes every registered checker tests.
 //
 // TODO(quasilyte): document default options.
-// TODO(quasilyte): make it possible to run tests with different options.
-func TestCheckers(t *testing.T) {
+func (cfg *CheckersTest) Run(t *testing.T) {
 	checkers := linter.GetCheckersInfo()
+
+	ignoreErrors := make(map[string]bool, len(cfg.IgnoreErrors))
+	for _, checkerName := range cfg.IgnoreErrors {
+		ignoreErrors[checkerName] = true
+	}
 
 	// See #980.
 	for i := range checkers {
 		info := checkers[i]
 		t.Run(info.Name+"/debug", func(t *testing.T) {
 			debugFile := filepath.Join("testdata", info.Name, "debug.go")
-			checkTarget(t, debugFile, info)
+			target := lintTarget{
+				pattern:      debugFile,
+				ignoreErrors: ignoreErrors[info.Name],
+			}
+			checkTarget(t, target, info)
 		})
 	}
 
 	for _, info := range saneCheckersList(t, checkers) {
 		t.Run(info.Name, func(t *testing.T) {
 			pkgPath := "./testdata/" + info.Name
-			checkTarget(t, pkgPath, info)
+			target := lintTarget{
+				pattern:      pkgPath,
+				ignoreErrors: ignoreErrors[info.Name],
+			}
+			checkTarget(t, target, info)
 		})
 	}
 }
 
-func checkTarget(t *testing.T, pattern string, info *linter.CheckerInfo) {
+type lintTarget struct {
+	pattern      string
+	ignoreErrors bool
+}
+
+func checkTarget(t *testing.T, target lintTarget, info *linter.CheckerInfo) {
 	t.Helper()
 	fset := token.NewFileSet()
-	pkgs := newPackages(t, pattern, fset)
+	pkgs := newPackages(t, target.pattern, fset)
 	for _, pkg := range pkgs {
+		if len(pkg.Errors) != 0 && !target.ignoreErrors {
+			for _, err := range pkg.Errors {
+				t.Error(err)
+			}
+			return
+		}
 		ctx := &linter.Context{
 			SizesInfo: sizes,
 			FileSet:   fset,


### PR DESCRIPTION
If a package loaded from the testdata contains errors,
fail the test unless there is an entry in IgnoreErrors slice
that asks the linttest to skip error checking for that checker.

Fixes #977

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>