### PR TITLE
checkers: ignore `defer exit()` in exitAfterDefer

### DIFF
--- a/checkers/testdata/exitAfterDefer/negative_tests.go
+++ b/checkers/testdata/exitAfterDefer/negative_tests.go
@@ -4,6 +4,18 @@ import (
 	"os"
 )
 
+func deferExitBranches(cond bool) {
+	if cond {
+		defer os.Exit(1)
+	} else {
+		defer os.Exit(0)
+	}
+}
+
+func deferExit() {
+	defer os.Exit(1)
+}
+
 func exitInsideLambda() {
 	defer println("before return")
 	// Exit inside some anonymous function is fine.


### PR DESCRIPTION
We allow `defer os.Exit()` calls
as it's harder to determine whether they're going
to clutter anything without actually trying to
simulate the defer stack + understanding the control flow.

Fixes #995

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>