### PR TITLE
checkers: remove redundant cond in exitAfterDefer

### DIFF
--- a/checkers/exitAfterDefer_checker.go
+++ b/checkers/exitAfterDefer_checker.go
@@ -61,9 +61,6 @@ func (c *exitAfterDeferChecker) VisitFuncDecl(fn *ast.FuncDecl) {
 				return true
 			}
 			if deferStmt != nil {
-				if deferStmt.Call == n {
-					return true
-				}
 				switch qualifiedName(n.Fun) {
 				case "log.Fatal", "log.Fatalf", "log.Fatalln", "os.Exit":
 					c.warn(n, deferStmt)


### PR DESCRIPTION
Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>