### PR TITLE
checkers: add badLock checker

### DIFF
--- a/checkers/badLock_checker.go
+++ b/checkers/badLock_checker.go
@@ -1,0 +1,116 @@
+package checkers
+
+import (
+	"go/ast"
+
+	"github.com/go-critic/go-critic/checkers/internal/astwalk"
+	"github.com/go-critic/go-critic/framework/linter"
+	"github.com/go-toolsmith/astequal"
+)
+
+func init() {
+	var info linter.CheckerInfo
+	info.Name = "badLock"
+	info.Tags = []string{"diagnostic", "experimental"}
+	info.Summary = "Detects suspicious mutex lock/unlock operations"
+	info.Before = `
+mu.Lock()
+mu.Unlock()`
+	info.After = `
+mu.Lock()
+defer mu.Unlock()`
+
+	collection.AddChecker(&info, func(ctx *linter.CheckerContext) linter.FileWalker {
+		return astwalk.WalkerForStmtList(&badLockChecker{ctx: ctx})
+	})
+}
+
+type badLockChecker struct {
+	astwalk.WalkHandler
+	ctx *linter.CheckerContext
+}
+
+func (c *badLockChecker) VisitStmtList(list []ast.Stmt) {
+	if len(list) < 2 {
+		return
+	}
+
+	for i := 0; i < len(list)-1; i++ {
+		current, ok := list[i].(*ast.ExprStmt)
+		if !ok {
+			continue
+		}
+		deferred := false
+		var next ast.Expr
+		switch x := list[i+1].(type) {
+		case *ast.ExprStmt:
+			next = x.X
+		case *ast.DeferStmt:
+			next = x.Call
+			deferred = true
+		default:
+			continue
+		}
+
+		mutex1, lockFunc, ok := c.asLockedMutex(current.X)
+		if !ok {
+			continue
+		}
+		mutex2, unlockFunc, ok := c.asUnlockedMutex(next)
+		if !ok {
+			continue
+		}
+		if !astequal.Expr(mutex1, mutex2) {
+			continue
+		}
+
+		switch {
+		case !deferred:
+			c.warnImmediateUnlock(mutex2)
+		case lockFunc == "Lock" && unlockFunc == "RUnlock":
+			c.warnMismatchingUnlock(mutex2, "Unlock")
+		case lockFunc == "RLock" && unlockFunc == "Unlock":
+			c.warnMismatchingUnlock(mutex2, "RUnlock")
+		}
+	}
+}
+
+func (c *badLockChecker) asLockedMutex(e ast.Expr) (ast.Expr, string, bool) {
+	call, ok := e.(*ast.CallExpr)
+	if !ok || len(call.Args) != 0 {
+		return nil, "", false
+	}
+	switch fn := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		if fn.Sel.Name == "Lock" || fn.Sel.Name == "RLock" {
+			return fn.X, fn.Sel.Name, true
+		}
+		return nil, "", false
+	default:
+		return nil, "", false
+	}
+}
+
+func (c *badLockChecker) asUnlockedMutex(e ast.Expr) (ast.Expr, string, bool) {
+	call, ok := e.(*ast.CallExpr)
+	if !ok || len(call.Args) != 0 {
+		return nil, "", false
+	}
+	switch fn := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		if fn.Sel.Name == "Unlock" || fn.Sel.Name == "RUnlock" {
+			return fn.X, fn.Sel.Name, true
+		}
+		return nil, "", false
+	default:
+		return nil, "", false
+	}
+}
+
+func (c *badLockChecker) warnImmediateUnlock(cause ast.Node) {
+	c.ctx.Warn(cause, "defer is missing, mutex is unlocked immediately")
+}
+
+func (c *badLockChecker) warnMismatchingUnlock(cause ast.Node, suggestion string) {
+	c.ctx.Warn(cause, "suspicious unlock, maybe %s was intended?", suggestion)
+}

--- a/checkers/testdata/badLock/negative_tests.go
+++ b/checkers/testdata/badLock/negative_tests.go
@@ -1,0 +1,39 @@
+package checker_test
+
+import (
+	"sync"
+)
+
+func deferredUnlock(mu *sync.Mutex, op func()) {
+	mu.Lock()
+	defer mu.Unlock()
+	op()
+}
+
+func goodUnlock(mu *sync.RWMutex, op func()) {
+	mu.Lock()
+	defer mu.Unlock()
+	op()
+}
+
+func goodRUnlock(mu *sync.RWMutex, op func()) {
+	mu.RLock()
+	defer mu.RUnlock()
+	op()
+}
+
+func differentMutexes(mu1, mu2 *sync.RWMutex, op func()) {
+	{
+		mu2.RLock()
+		mu1.Lock()
+		mu2.RUnlock()
+		mu1.Unlock()
+	}
+
+	{
+		mu1.Lock()
+		mu2.Lock()
+		mu1.Unlock()
+		mu2.Unlock()
+	}
+}

--- a/checkers/testdata/badLock/positive_tests.go
+++ b/checkers/testdata/badLock/positive_tests.go
@@ -1,0 +1,51 @@
+package checker_test
+
+import (
+	"sync"
+)
+
+type withMutex struct {
+	mu sync.RWMutex
+}
+
+func immediateUnlock(mu *sync.Mutex, op func()) {
+	mu.Lock()
+	/*! defer is missing, mutex is unlocked immediately */
+	mu.Unlock()
+	op()
+}
+
+func immediateUnlockStruct(x *withMutex, op func()) {
+	x.mu.Lock()
+	/*! defer is missing, mutex is unlocked immediately */
+	x.mu.Unlock()
+	op()
+}
+
+func mismatchingUnlock1(mu *sync.RWMutex, op func()) {
+	mu.Lock()
+	/*! suspicious unlock, maybe Unlock was intended? */
+	defer mu.RUnlock()
+	op()
+}
+
+func mismatchingUnlock2(mu *sync.RWMutex, op func()) {
+	mu.RLock()
+	/*! suspicious unlock, maybe RUnlock was intended? */
+	defer mu.Unlock()
+	op()
+}
+
+func mismatchingUnlock1Struct(x *withMutex, op func()) {
+	x.mu.Lock()
+	/*! suspicious unlock, maybe Unlock was intended? */
+	defer x.mu.RUnlock()
+	op()
+}
+
+func mismatchingUnlock2Struct(x *withMutex, op func()) {
+	x.mu.RLock()
+	/*! suspicious unlock, maybe RUnlock was intended? */
+	defer x.mu.Unlock()
+	op()
+}


### PR DESCRIPTION
Finds mismatching Lock+Unlock sequences.

	Lock+RUnlock -> error
	RLock+Unlock -> error
	Lock+Unlock -> OK
	RLock+RUnlock -> OK

It only checks the 2 adjusted statements.

We don't check for types being sync.Mutex or sync.RWMutex,
let's see how bad it will be for a false positive rates.
People could embed locks or implement custom Lock+Unlock methods.
We won't mark this checker as stable until it's properly tested,
so it shouldn't be a deal breaker.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>