### PR TITLE
checkers: extend flagName diagnostics

### DIFF
--- a/checkers/flagName_checker.go
+++ b/checkers/flagName_checker.go
@@ -15,9 +15,10 @@ func init() {
 	var info linter.CheckerInfo
 	info.Name = "flagName"
 	info.Tags = []string{"diagnostic"}
-	info.Summary = "Detects flag names with whitespace"
+	info.Summary = "Detects suspicious flag names"
 	info.Before = `b := flag.Bool(" foo ", false, "description")`
 	info.After = `b := flag.Bool("foo", false, "description")`
+	info.Note = "https://github.com/golang/go/issues/41792"
 
 	collection.AddChecker(&info, func(ctx *linter.CheckerContext) linter.FileWalker {
 		return astwalk.WalkerForExpr(&flagNameChecker{ctx: ctx})
@@ -58,9 +59,28 @@ func (c *flagNameChecker) checkFlagName(call *ast.CallExpr, arg ast.Expr) {
 		return // Non-constant name
 	}
 	name := constant.StringVal(cv)
-	if strings.Contains(name, " ") {
+	switch {
+	case name == "":
+		c.warnEmpty(call)
+	case strings.HasPrefix(name, "-"):
+		c.warnHypenPrefix(call, name)
+	case strings.Contains(name, "="):
+		c.warnEq(call, name)
+	case strings.Contains(name, " "):
 		c.warnWhitespace(call, name)
 	}
+}
+
+func (c *flagNameChecker) warnEmpty(cause ast.Node) {
+	c.ctx.Warn(cause, "empty flag name")
+}
+
+func (c *flagNameChecker) warnHypenPrefix(cause ast.Node, name string) {
+	c.ctx.Warn(cause, "flag name %q should not start with a hypen", name)
+}
+
+func (c *flagNameChecker) warnEq(cause ast.Node, name string) {
+	c.ctx.Warn(cause, "flag name %q should not contain '='", name)
 }
 
 func (c *flagNameChecker) warnWhitespace(cause ast.Node, name string) {

--- a/checkers/testdata/flagName/negative_tests.go
+++ b/checkers/testdata/flagName/negative_tests.go
@@ -4,6 +4,10 @@ import (
 	"flag"
 )
 
+func dynamicFlagName(flagName string) {
+	_ = flag.String(flagName, "", "") // can't analyze
+}
+
 func methodCall() {
 	// See #784.
 	var getter flag.Getter

--- a/checkers/testdata/flagName/positive_tests.go
+++ b/checkers/testdata/flagName/positive_tests.go
@@ -4,6 +4,28 @@ import (
 	"flag"
 )
 
+func flagsWithEmptyName() {
+	/*! empty flag name */
+	_ = flag.Bool("", false, "")
+}
+
+func flagsWithHypenPrefix() {
+	/*! flag name "-name" should not start with a hypen */
+	_ = flag.Bool("-name", false, "")
+	/*! flag name "--name" should not start with a hypen */
+	_ = flag.Bool("--name", false, "")
+}
+
+func flagsWithEqSign() {
+	/*! flag name "foo=bar" should not contain '=' */
+	_ = flag.Bool("foo=bar", false, "")
+
+	const flagName = "foo="
+
+	/*! flag name "foo=" should not contain '=' */
+	_ = flag.Bool(flagName, false, "")
+}
+
 func flagsWithWhitespace() {
 	/*! flag name " name" contains whitespace */
 	_ = flag.Bool(" name", false, "")


### PR DESCRIPTION
From the https://github.com/golang/go/issues/41792

    And these are invalid flag names:

        * Empty String:

          * If the flag name is an empty string and is used in the `-flag x` form, the flag starting with hyphen('-''') can be the non-flag argument and the flag starting with double hyphen('--''') can be the terminator.
          * > Flag parsing stops just before the first non-flag argument("-" is a non-flag argument) or after the terminator "--".

        * Starting with hyphen:

          * According to the document the flag should start with '-' or '--'. But, if the flag name starts with hyphen, this package can’t distinguish between '-''-flag' and '--''flag'.

        * Containing equal sign:

          * This package uses equal sign to split the flag into a name-value pair. So, if the flag name contains equal sign, this package can't split it properly.
          * e.g. If the flag name is 'foo=bar' and the flag is '-foo=bar=value', this package can't find out the actual value.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>