### PR TITLE
Add support for glob pattern in ruleguard/rules configuration

### DIFF
--- a/checkers/ruleguard_checker.go
+++ b/checkers/ruleguard_checker.go
@@ -86,7 +86,7 @@ func newRuleguardChecker(info *linter.CheckerInfo, ctx *linter.CheckerContext) *
 					log.Panicf("ruleguard init error: %+v", err)
 				}
 				log.Printf("ruleguard init error: %+v", err)
-				return c
+				continue
 			}
 			ruleSets = append(ruleSets, rset)
 		}

--- a/checkers/ruleguard_checker.go
+++ b/checkers/ruleguard_checker.go
@@ -22,7 +22,7 @@ func init() {
 	info.Params = linter.CheckerParams{
 		"rules": {
 			Value: "",
-			Usage: "comma-separated list of gorule file paths. Patterns such as 'rules-*.go' may be specified",
+			Usage: "comma-separated list of gorule file paths. Glob patterns such as 'rules-*.go' may be specified",
 		},
 		"debug": {
 			Value: "",

--- a/checkers/ruleguard_checker.go
+++ b/checkers/ruleguard_checker.go
@@ -22,7 +22,7 @@ func init() {
 	info.Params = linter.CheckerParams{
 		"rules": {
 			Value: "",
-			Usage: "comma-separated list of gorule file paths",
+			Usage: "comma-separated list of gorule file paths. Patterns such as 'rules-*.go' may be specified",
 		},
 		"debug": {
 			Value: "",

--- a/checkers/testdata/_integration/ruleguard-glob/file.go
+++ b/checkers/testdata/_integration/ruleguard-glob/file.go
@@ -1,0 +1,23 @@
+package example
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+func separator() string {
+	return string(os.PathSeparator)
+}
+
+func join(p ...string) string {
+	return filepath.Join(p...)
+}
+
+var mu sync.RWMutex
+
+func badlock() {
+	mu.Lock()
+	defer mu.RUnlock()
+	println("foo")
+}

--- a/checkers/testdata/_integration/ruleguard-glob/linttest.golden
+++ b/checkers/testdata/_integration/ruleguard-glob/linttest.golden
@@ -1,0 +1,3 @@
+exit status 1
+./file.go:20:2: ruleguard: maybe mu.RLock() was intended?
+./file.go:10:16: ruleguard: suggestion: filepath.Separator

--- a/checkers/testdata/_integration/ruleguard-glob/linttest.params
+++ b/checkers/testdata/_integration/ruleguard-glob/linttest.params
@@ -1,0 +1,1 @@
+check -@ruleguard.rules rules*.go -enable ruleguard ./... | linttest.golden

--- a/checkers/testdata/_integration/ruleguard-glob/rules1.go
+++ b/checkers/testdata/_integration/ruleguard-glob/rules1.go
@@ -1,0 +1,10 @@
+// +build ignore
+
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl/fluent"
+
+func badLock(m fluent.Matcher) {
+	m.Match(`$mu.Lock(); defer $mu.RUnlock()`).Report(`maybe $mu.RLock() was intended?`)
+	m.Match(`$mu.RLock(); defer $mu.Unlock()`).Report(`maybe $mu.Lock() was intended?`)
+}

--- a/checkers/testdata/_integration/ruleguard-glob/rules2.go
+++ b/checkers/testdata/_integration/ruleguard-glob/rules2.go
@@ -1,0 +1,20 @@
+// +build ignore
+
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl/fluent"
+
+func osFilepath(m fluent.Matcher) {
+	// path/filepath package forwards path separators so if
+	// the file already uses filepath-related API it might be
+	// a good idea to reduce the direct os package dependency.
+	// In some cases it helps to remove the "os" package import completely.
+
+	m.Match(`os.PathSeparator`).
+		Where(m.File().Imports("path/filepath")).
+		Suggest(`filepath.Separator`)
+
+	m.Match(`os.PathListSeparator`).
+		Where(m.File().Imports("path/filepath")).
+		Suggest(`filepath.ListSeparator`)
+}


### PR DESCRIPTION
Currently the list of ruleguard files is specified as a comma-separated list.
This PR allows to specify a pattern (using filepath.Glob).

Is there a way to add unit tests for this?

Also, not sure how to document the Match pattern: https://golang.org/pkg/path/filepath/#Match