### PR TITLE
add rulestest to test our rules.go file

### DIFF
--- a/rulestest/rules_test.go
+++ b/rulestest/rules_test.go
@@ -1,0 +1,15 @@
+package rulestest
+
+import (
+	"testing"
+
+	"github.com/quasilyte/go-ruleguard/analyzer"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestRules(t *testing.T) {
+	if err := analyzer.Analyzer.Flags.Set("rules", "../rules.go"); err != nil {
+		t.Fatalf("set rules flag: %v", err)
+	}
+	analysistest.Run(t, analysistest.TestData(), analyzer.Analyzer, "./...")
+}

--- a/rulestest/testdata/checkers/badChecker.go
+++ b/rulestest/testdata/checkers/badChecker.go
@@ -1,0 +1,13 @@
+package checkers
+
+import (
+	"go/ast"
+)
+
+type BadChecker struct {
+	ctx *contextStub
+}
+
+func (c *BadChecker) VisitExpr(e ast.Expr) {
+	_ = c.ctx.TypesInfo.TypeOf(e) // want `\Quse ctx.TypeOf(e) instead, it's nil-safe`
+}

--- a/rulestest/testdata/checkers/contextStub.go
+++ b/rulestest/testdata/checkers/contextStub.go
@@ -1,0 +1,7 @@
+package checkers
+
+import "go/types"
+
+type contextStub struct {
+	TypesInfo *types.Info
+}


### PR DESCRIPTION
Instead of using a real `framework.Context` I had to use a
stub struct, see https://github.com/golang/go/issues/37054