### PR TITLE
Fix appendAssign checker to also warn on short decl

### DIFF
--- a/checkers/appendAssign_checker.go
+++ b/checkers/appendAssign_checker.go
@@ -36,7 +36,7 @@ type appendAssignChecker struct {
 
 func (c *appendAssignChecker) VisitStmt(stmt ast.Stmt) {
 	assign, ok := stmt.(*ast.AssignStmt)
-	if !ok || assign.Tok != token.ASSIGN || len(assign.Lhs) != len(assign.Rhs) {
+	if !ok || (assign.Tok != token.ASSIGN && assign.Tok != token.DEFINE) || len(assign.Lhs) != len(assign.Rhs) {
 		return
 	}
 	for i, rhs := range assign.Rhs {

--- a/checkers/testdata/appendAssign/negative_tests.go
+++ b/checkers/testdata/appendAssign/negative_tests.go
@@ -15,9 +15,15 @@ func permittedAppends() {
 	// where y is used instead of x by mistake, so lines below
 	// do not trigger a warning.
 
-	xs0 := append(xs, 1)
-	xs1 := append(xs, 1)
-	ys0 := append(ys, 1)
+	xs = append(xs, 1)
+	xs0 := xs
+	xs = append(xs, 1)
+	xs1 := xs
+	ys = append(ys, 1)
+	ys0 := ys
+
+	ts := append([]int{1}, 1)
+	_ = ts
 
 	// Also permit to assign to "_".
 	_ = append(xs, xs0[0], xs1[1], ys0[0])
@@ -76,9 +82,9 @@ func appendNotInAssignment() {
 		v2 = append(xs, v1[0])
 		v3 = append(v2[:], ys[0])
 	)
-	v4 := append(v3, xs[0])
+	v3 = append(v3, xs[0])
 	{
-		v3 := append(v4, 1)
+		v3 = append(v3, 1)
 		_ = v3
 	}
 }

--- a/checkers/testdata/appendAssign/positive_tests.go
+++ b/checkers/testdata/appendAssign/positive_tests.go
@@ -35,7 +35,8 @@ func suspiciousAppends() {
 		xs2 = append(xs, 1)
 	}
 
-	/* append result short assigned to a new slice */
+	/*! append result not assigned to the same slice */
 	zs := append(xs, 1)
+
 	_ = zs
 }

--- a/checkers/testdata/appendAssign/positive_tests.go
+++ b/checkers/testdata/appendAssign/positive_tests.go
@@ -1,6 +1,6 @@
 package checker_test
 
-func suspeciousAppends() {
+func suspiciousAppends() {
 	var xs []int
 	var ys []int
 

--- a/checkers/testdata/appendAssign/positive_tests.go
+++ b/checkers/testdata/appendAssign/positive_tests.go
@@ -37,4 +37,5 @@ func suspeciousAppends() {
 
 	/* append result short assigned to a new slice */
 	zs := append(xs, 1)
+	_ = zs
 }

--- a/checkers/testdata/appendAssign/positive_tests.go
+++ b/checkers/testdata/appendAssign/positive_tests.go
@@ -34,4 +34,7 @@ func suspeciousAppends() {
 		/*! append result not assigned to the same slice */
 		xs2 = append(xs, 1)
 	}
+
+	/* append result short assigned to a new slice */
+	zs := append(xs, 1)
 }


### PR DESCRIPTION
Makes the `appendAssign` checker also warn on a short declaration, not just on assignments, e.g.

```go
x := []int{}
y := append(x, 1) // <- bad!
```

The motivation for this restriction is that allowing short declarations is error prone: https://blog.allegro.tech/2017/07/golang-slices-gotcha.html

Additional context: https://stackoverflow.com/a/35276346