### PR TITLE
Fixed deferUnlambda `After` docs `f()`->`defer f()`

### DIFF
--- a/checkers/deferUnlambda_checker.go
+++ b/checkers/deferUnlambda_checker.go
@@ -15,7 +15,7 @@ func init() {
 	info.Tags = []string{"style", "experimental"}
 	info.Summary = "Detects deferred function literals that can be simplified"
 	info.Before = `defer func() { f() }()`
-	info.After = `f()`
+	info.After = `defer f()`
 
 	collection.AddChecker(&info, func(ctx *linter.CheckerContext) (linter.FileWalker, error) {
 		return astwalk.WalkerForStmt(&deferUnlambdaChecker{ctx: ctx}), nil


### PR DESCRIPTION
Fixed the `deferUnlambda` checker's `After` documentation string `f()`->`defer f()`, to indicate the checker doesn't expect the removal of the defer statement, only expects to transform the lambda wrapped function call into a simple function call.

This is in line with the current functionality which [expects](https://github.com/go-critic/go-critic/blob/6090d88757f445be96d2e507d7b17e2abcb40c4b/checkers/deferUnlambda_checker.go#L93) the corrected code to look like `defer f()`.