### PR TITLE
checkers/octalLiteral: skip check for fs package

### DIFF
--- a/checkers/octalLiteral_checker.go
+++ b/checkers/octalLiteral_checker.go
@@ -22,8 +22,8 @@ func init() {
 		c := &octalLiteralChecker{
 			ctx: ctx,
 			octFriendlyPkg: map[string]bool{
-				"fs":        true,
 				"os":        true,
+				"io/fs":     true,
 				"io/ioutil": true,
 			},
 		}

--- a/checkers/octalLiteral_checker.go
+++ b/checkers/octalLiteral_checker.go
@@ -22,6 +22,7 @@ func init() {
 		c := &octalLiteralChecker{
 			ctx: ctx,
 			octFriendlyPkg: map[string]bool{
+				"fs":        true,
 				"os":        true,
 				"io/ioutil": true,
 			},

--- a/checkers/testdata/octalLiteral/negative_tests.go
+++ b/checkers/testdata/octalLiteral/negative_tests.go
@@ -59,7 +59,7 @@ func NoWarningsCalc() {
 }
 
 func NoWarningsFs() {
-	_ = fs.FileMode(0999)
+	_ = fs.FileMode(0555)
 }
 
 func NoWarningsOs() {

--- a/checkers/testdata/octalLiteral/negative_tests.go
+++ b/checkers/testdata/octalLiteral/negative_tests.go
@@ -1,6 +1,7 @@
 package checker_test
 
 import (
+	"io/fs"
 	"io/ioutil"
 	"log"
 	"math"
@@ -55,6 +56,10 @@ func NoWarningsCalc() {
 	_ = math.Exp(0x12)
 	_ = math.Max(12, 0xd)
 	_ = math.Min(0, 1)
+}
+
+func NoWarningsFs() {
+	_ = fs.FileMode(0999)
 }
 
 func NoWarningsOs() {


### PR DESCRIPTION
Fixes #1061 