### PR TITLE
commentFormatting: should allow vertical bars

### DIFF
--- a/checkers/commentFormatting_checker.go
+++ b/checkers/commentFormatting_checker.go
@@ -26,6 +26,7 @@ func init() {
 			`^//nolint\b`,        // e.g.: nolint
 			`^//line /.*:\d+`,    // e.g.: line /path/to/file:123
 			`^//export \w+$`,     // e.g.: export Foo
+			`^//[/+#-]+.*$`,      // e.g.: vertical breaker /////////////
 		}
 		pat := "(?m)" + strings.Join(parts, "|")
 		pragmaRE := regexp.MustCompile(pat)

--- a/checkers/testdata/commentFormatting/negative_tests.go
+++ b/checkers/testdata/commentFormatting/negative_tests.go
@@ -52,3 +52,11 @@ func f2() {
 	//
 	// inside it.
 }
+
+//////////// Vertical ////////////////
+//++++++++++++ bars ++++++++++++++++++
+//############# are ##################
+//---------- permitted ---------------
+
+// Comment in a comment is //OK
+// path */*//with asterisk


### PR DESCRIPTION
This change will allow comments used a vertical line
such as

```
///////////
//--------
//++++++++
//########
```

Fixes: https://github.com/go-critic/go-critic/issues/1065