### PR TITLE
framework/linter: allow target Go version constraint

### DIFF
--- a/framework/linter/go_version.go
+++ b/framework/linter/go_version.go
@@ -1,0 +1,51 @@
+package linter
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type GoVersion struct {
+	Major int
+	Minor int
+}
+
+// GreaterOrEqual performs $v >= $other operation.
+//
+// In other words, it reports whether $v version constraint can use
+// a feature from the $other Go version.
+//
+// As a special case, Major=0 covers all versions.
+func (v GoVersion) GreaterOrEqual(other GoVersion) bool {
+	if v.Major == 0 {
+		return true
+	}
+	if v.Major == other.Major {
+		return v.Minor >= other.Minor
+	}
+	return v.Major >= other.Major
+}
+
+func parseGoVersion(version string) GoVersion {
+	version = strings.TrimPrefix(version, "go")
+	if version == "" {
+		return GoVersion{}
+	}
+	parts := strings.Split(version, ".")
+	if len(parts) != 2 {
+		panic(fmt.Sprintf("invalid Go version format: %s", version))
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		panic(fmt.Sprintf("invalid major version part: %s: %s", parts[0], err))
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		panic(fmt.Sprintf("invalid minor version part: %s: %s", parts[1], err))
+	}
+	return GoVersion{
+		Major: major,
+		Minor: minor,
+	}
+}

--- a/framework/linter/go_version_test.go
+++ b/framework/linter/go_version_test.go
@@ -1,0 +1,75 @@
+package linter
+
+import (
+	"testing"
+)
+
+func TestGoVersionParse(t *testing.T) {
+	tests := []struct {
+		s     string
+		major int
+		minor int
+	}{
+		{"", 0, 0},
+		{"1.5", 1, 5},
+		{"1.10", 1, 10},
+		{"2.0", 2, 0},
+		{"2.1", 2, 1},
+	}
+
+	runTest := func(x string, wantMajor, wantMinor int) {
+		have := parseGoVersion(x)
+		if have.Major != wantMajor {
+			t.Errorf("parseGoVersion(%s); major: want %d, have %d", x, wantMajor, have.Major)
+		}
+		if have.Minor != wantMinor {
+			t.Errorf("parseGoVersion(%s); minor: want %d, have %d", x, wantMinor, have.Minor)
+		}
+	}
+
+	for _, test := range tests {
+		runTest(test.s, test.major, test.minor)
+		runTest("go"+test.s, test.major, test.minor)
+	}
+}
+
+func TestGoVersionCompare(t *testing.T) {
+	tests := []struct {
+		version string
+		other   string
+		want    bool
+	}{
+		{"", "1.5", true},
+		{"", "2.0", true},
+
+		{"1.0", "1.0", true},
+		{"1.0", "1.1", false},
+		{"1.0", "2.0", false},
+
+		{"1.16", "1.15", true},
+		{"1.16", "1.16", true},
+		{"1.16", "1.17", false},
+		{"1.16", "2.0", false},
+		{"1.16", "2.1", false},
+
+		{"2.0", "1.0", true},
+		{"2.0", "1.15", true},
+		{"2.0", "1.254", true},
+		{"2.0", "2.0", true},
+		{"2.0", "2.1", false},
+	}
+
+	runTest := func(x, y string, want bool) {
+		have := parseGoVersion(x).GreaterOrEqual(parseGoVersion(y))
+		if have != want {
+			t.Errorf("%s >= %s: incorrect result (want %v)", x, y, want)
+		}
+	}
+
+	for _, test := range tests {
+		runTest(test.version, test.other, test.want)
+		runTest(test.version, "go"+test.other, test.want)
+		runTest("go"+test.version, test.other, test.want)
+		runTest("go"+test.version, "go"+test.other, test.want)
+	}
+}

--- a/framework/linter/lintpack.go
+++ b/framework/linter/lintpack.go
@@ -157,6 +157,9 @@ type Context struct {
 	// Arch-dependent.
 	SizesInfo types.Sizes
 
+	// GoVersion is a target Go version.
+	GoVersion GoVersion
+
 	// FileSet is a file set that was used during the program loading.
 	FileSet *token.FileSet
 
@@ -196,6 +199,19 @@ func NewContext(fset *token.FileSet, sizes types.Sizes) *Context {
 		SizesInfo: sizes,
 		TypesInfo: &types.Info{},
 	}
+}
+
+// SetGoVersion adjust the target Go language version.
+//
+// The format is like "1.5", "1.8", etc.
+// It's permitted to have "go" prefix (e.g. "go1.5").
+//
+// Empty string (the default) means that we make no
+// Go version assumptions and (like gocritic does) behave
+// like all features are available. To make gocritic
+// more conservative, the upper Go version level should be adjusted.
+func (c *Context) SetGoVersion(version string) {
+	c.GoVersion = parseGoVersion(version)
 }
 
 // SetPackageInfo sets package-related metadata.

--- a/framework/lintmain/internal/check/check.go
+++ b/framework/lintmain/internal/check/check.go
@@ -79,6 +79,7 @@ type program struct {
 	gopath  string
 	goroot  string
 
+	goVersion          string
 	exitCode           int
 	checkTests         bool
 	checkGenerated     bool
@@ -272,6 +273,7 @@ func (p *program) loadProgram() error {
 
 	p.loadedPackages = pkgs
 	p.ctx = linter.NewContext(p.fset, sizes)
+	p.ctx.SetGoVersion(p.goVersion)
 
 	return nil
 }
@@ -358,6 +360,8 @@ func (p *program) parseArgs() error {
 		`whether to use colored output`)
 	flag.BoolVar(&p.verbose, "v", false,
 		`whether to print output useful during linter debugging`)
+	flag.StringVar(&p.goVersion, "go", "",
+		`select the Go version to target. Leave as string for the latest`)
 
 	flag.Parse()
 


### PR DESCRIPTION
When set, gocritic checkers will try to avoid suggesting and linting
something that is not available in the specified Go version constraint.

By default, we assume no constraints and treat all Go features as available.

There are 2 configuration points:

1. Public (`$target`) -- target go version option (`--go`)
2. Private (`$required`) -- per-checker go version requirement

When checker is executed, it checks whether its report satisfies the
target Go version constraint (if any).
This is done like: `$target >= $required`.

New `--go` command-line option can be used to set go-critic target version.
We're expecting `golangci-lint` to catch up later and allow setting
that option via the config.