### PR TITLE
checkers: dupArg add stdlib-related tests

### DIFF
--- a/checkers/testdata/_importable/strings/strings.go
+++ b/checkers/testdata/_importable/strings/strings.go
@@ -1,3 +1,3 @@
 package strings
 
-func Contains(s string) {}
+func Contains(s ...string) {}

--- a/checkers/testdata/dupArg/negative_tests2.go
+++ b/checkers/testdata/dupArg/negative_tests2.go
@@ -6,4 +6,7 @@ import (
 
 func nonStdPackage() {
 	strings.Contains("")
+
+	var x string
+	strings.Contains(x, x)
 }


### PR DESCRIPTION
Add a test that makes sure that calling a non-stdlib function
that would otherwise match the pattern does not trigger the checker.