### PR TITLE
checkers: rethink octalLiteral checker

### DIFF
--- a/checkers/octalLiteral_checker.go
+++ b/checkers/octalLiteral_checker.go
@@ -3,7 +3,8 @@ package checkers
 import (
 	"go/ast"
 	"go/token"
-	"go/types"
+	"strings"
+	"unicode"
 
 	"github.com/go-critic/go-critic/checkers/internal/astwalk"
 	"github.com/go-critic/go-critic/framework/linter"
@@ -13,71 +14,34 @@ import (
 func init() {
 	var info linter.CheckerInfo
 	info.Name = "octalLiteral"
-	info.Tags = []string{"diagnostic", "experimental"}
-	info.Summary = "Detects octal literals passed to functions"
+	info.Tags = []string{"style", "experimental", "opinionated"}
+	info.Summary = "Detects old-style octal literals"
 	info.Before = `foo(02)`
-	info.After = `foo(2)`
+	info.After = `foo(0o2)`
 
 	collection.AddChecker(&info, func(ctx *linter.CheckerContext) (linter.FileWalker, error) {
-		c := &octalLiteralChecker{
-			ctx: ctx,
-			octFriendlyPkg: map[string]bool{
-				"os":        true,
-				"io/fs":     true,
-				"io/ioutil": true,
-			},
-		}
-		return astwalk.WalkerForExpr(c), nil
+		return astwalk.WalkerForExpr(&octalLiteralChecker{ctx: ctx}), nil
 	})
 }
 
 type octalLiteralChecker struct {
 	astwalk.WalkHandler
 	ctx *linter.CheckerContext
-
-	octFriendlyPkg map[string]bool
 }
 
 func (c *octalLiteralChecker) VisitExpr(expr ast.Expr) {
-	call := astcast.ToCallExpr(expr)
-	calledExpr := astcast.ToSelectorExpr(call.Fun)
-	ident := astcast.ToIdent(calledExpr.X)
-
-	if obj, ok := c.ctx.TypesInfo.ObjectOf(ident).(*types.PkgName); ok {
-		pkg := obj.Imported()
-		if c.octFriendlyPkg[pkg.Path()] {
-			return
-		}
+	lit := astcast.ToBasicLit(expr)
+	if lit.Kind != token.INT {
+		return
 	}
-
-	for _, arg := range call.Args {
-		if lit := astcast.ToBasicLit(c.unsign(arg)); len(lit.Value) > 1 &&
-			c.isIntLiteral(lit) &&
-			c.isOctalLiteral(lit) {
-			c.warn(call)
-			return
-		}
+	if !strings.HasPrefix(lit.Value, "0") || len(lit.Value) == 1 {
+		return
+	}
+	if unicode.IsDigit(rune(lit.Value[1])) {
+		c.warn(lit)
 	}
 }
 
-func (c *octalLiteralChecker) unsign(e ast.Expr) ast.Expr {
-	u, ok := e.(*ast.UnaryExpr)
-	if !ok {
-		return e
-	}
-	return u.X
-}
-
-func (c *octalLiteralChecker) isIntLiteral(lit *ast.BasicLit) bool {
-	return lit.Kind == token.INT
-}
-
-func (c *octalLiteralChecker) isOctalLiteral(lit *ast.BasicLit) bool {
-	return lit.Value[0] == '0' &&
-		lit.Value[1] != 'x' &&
-		lit.Value[1] != 'X'
-}
-
-func (c *octalLiteralChecker) warn(expr ast.Expr) {
-	c.ctx.Warn(expr, "suspicious octal args in `%s`", expr)
+func (c *octalLiteralChecker) warn(lit *ast.BasicLit) {
+	c.ctx.Warn(lit, "use new octal literal style, 0o%s", lit.Value[len("0"):])
 }

--- a/checkers/testdata/octalLiteral/negative_tests.go
+++ b/checkers/testdata/octalLiteral/negative_tests.go
@@ -32,7 +32,7 @@ func NoWarningsCalc() {
 	_ = calculateInt(12)
 	_ = calculateInt(1 + 2)
 
-	var x = 03
+	var x = 0x3
 	_ = calculateInt(x)
 
 	_ = calculateHex(0x0)
@@ -59,11 +59,11 @@ func NoWarningsCalc() {
 }
 
 func NoWarningsFs() {
-	_ = fs.FileMode(0555)
+	_ = fs.FileMode(0o555)
 }
 
 func NoWarningsOs() {
-	f, err := os.OpenFile("notes.txt", os.O_RDWR|os.O_CREATE, 0755)
+	f, err := os.OpenFile("notes.txt", os.O_RDWR|os.O_CREATE, 0o755)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -73,5 +73,5 @@ func NoWarningsOs() {
 }
 
 func NoWarningsIoutil() {
-	_ = ioutil.WriteFile("notes.txt", nil, 0666)
+	_ = ioutil.WriteFile("notes.txt", nil, 0o666)
 }

--- a/checkers/testdata/octalLiteral/positive_tests.go
+++ b/checkers/testdata/octalLiteral/positive_tests.go
@@ -1,7 +1,11 @@
 package checker_test
 
 import (
+	"io/fs"
+	"io/ioutil"
+	"log"
 	"math"
+	"os"
 )
 
 func calculateIntPair(x, y int) (int, int) {
@@ -13,48 +17,54 @@ func calculateManyArgs(x int, s string, y int) (int, string, int) {
 }
 
 func warningsCalc() {
-	/*! suspicious octal args in `calculateInt(00)` */
+	/*! use new octal literal style, 0o3 */
+	var x = 03
+	_ = calculateInt(x)
+
+	/*! use new octal literal style, 0o0 */
 	_ = calculateInt(00)
 
-	/*! suspicious octal args in `calculateInt(+01)` */
+	/*! use new octal literal style, 0o1 */
 	_ = calculateInt(+01)
 
-	/*! suspicious octal args in `calculateInt(-01)` */
+	/*! use new octal literal style, 0o1 */
 	_ = calculateInt(-01)
 
-	/*! suspicious octal args in `calculateInt(012)` */
+	/*! use new octal literal style, 0o12 */
 	_ = calculateInt(calculateInt(012))
 
-	/*! suspicious octal args in `calculateIntPair(01, 2)` */
+	/*! use new octal literal style, 0o1 */
 	_, _ = calculateIntPair(01, 2)
 
-	/*! suspicious octal args in `calculateIntPair(-1, -012)` */
+	/*! use new octal literal style, 0o12 */
 	_, _ = calculateIntPair(-1, -012)
 
-	/*! suspicious octal args in `calculateIntPair(01, 02)` */
+	/*! use new octal literal style, 0o1 */
+	/*! use new octal literal style, 0o2 */
 	_, _ = calculateIntPair(01, 02)
 
-	/*! suspicious octal args in `calculateInt(01)` */
-	/*! suspicious octal args in `calculateInt(02)` */
+	/*! use new octal literal style, 0o1 */
+	/*! use new octal literal style, 0o2 */
 	_, _ = calculateIntPair(calculateInt(01), calculateInt(02))
 
-	/*! suspicious octal args in `calculateIntPair(01, calculateInt(02))` */
-	/*! suspicious octal args in `calculateInt(02)` */
+	/*! use new octal literal style, 0o1 */
+	/*! use new octal literal style, 0o2 */
 	_, _ = calculateIntPair(01, calculateInt(02))
 
-	/*! suspicious octal args in `calculateManyArgs(11, "12", 013)` */
+	/*! use new octal literal style, 0o13 */
 	_, _, _ = calculateManyArgs(11, "12", 013)
 
-	/*! suspicious octal args in `calculateManyArgs(-02, "3", -04)` */
+	/*! use new octal literal style, 0o2 */
+	/*! use new octal literal style, 0o4 */
 	_, _, _ = calculateManyArgs(-02, "3", -04)
 
-	/*! suspicious octal args in `math.Exp(012)` */
+	/*! use new octal literal style, 0o12 */
 	_ = math.Exp(012)
 
-	/*! suspicious octal args in `math.Max(12, 01)` */
+	/*! use new octal literal style, 0o1 */
 	_ = math.Max(12, 01)
 
-	/*! suspicious octal args in `math.Max(1, 01)` */
+	/*! use new octal literal style, 0o1 */
 	_ = math.Max(1, math.Max(1, 01))
 }
 
@@ -67,7 +77,22 @@ func (os *OpenServer) Init(x int) {
 }
 
 func warningsOs() {
-	var os OpenServer
-	/*! suspicious octal args in `os.Init(02)` */
-	os.Init(02)
+	/*! use new octal literal style, 0o755 */
+	f, err := os.OpenFile("notes.txt", os.O_RDWR|os.O_CREATE, 0755)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func warningsFs() {
+	/*! use new octal literal style, 0o555 */
+	_ = fs.FileMode(0555)
+}
+
+func warningsIoutil() {
+	/*! use new octal literal style, 0o666 */
+	_ = ioutil.WriteFile("notes.txt", nil, 0666)
 }

--- a/cmd/makedocs/main.go
+++ b/cmd/makedocs/main.go
@@ -30,7 +30,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("render template: %v", err)
 	}
-	if err := ioutil.WriteFile(docsPath+"overview.md", buf.Bytes(), 0600); err != nil {
+	if err := ioutil.WriteFile(docsPath+"overview.md", buf.Bytes(), 0o600); err != nil {
 		log.Fatalf("write output file: %v", err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-critic/go-critic
 
-go 1.12
+go 1.13
 
 require (
 	github.com/go-toolsmith/astcast v1.0.0


### PR DESCRIPTION
Instead of trying to be smart, report ALL old-syntax octal literals.
Even in os function calls.

The fix is simple: use newer octal literal syntax.

This check is marked as opinionated.