### PR TITLE
checkers: ignore `else { if <init> {...} }` in elseif checker

### DIFF
--- a/checkers/elseif_checker.go
+++ b/checkers/elseif_checker.go
@@ -59,7 +59,7 @@ func (c *elseifChecker) VisitStmt(stmt ast.Stmt) {
 		if balanced && c.skipBalanced {
 			return // Configured to skip balanced statements
 		}
-		if innerIfStmt.Else != nil {
+		if innerIfStmt.Else != nil || innerIfStmt.Init != nil {
 			return
 		}
 		c.warn(stmt.Else)

--- a/checkers/testdata/elseif/negative_tests.go
+++ b/checkers/testdata/elseif/negative_tests.go
@@ -52,3 +52,13 @@ func elseElse() {
 		}
 	}
 }
+
+func withInitClause() {
+	if true {
+
+	} else {
+		if x := 0; x == 5 {
+
+		}
+	}
+}


### PR DESCRIPTION
Don't report cases when there is an init clause in the inner
if statement. This makes this checker more conservative and
its reports more likely to be accepted by the users.