### PR TITLE
checkers: make yodaStyleExpr more conservative

### DIFF
--- a/checkers/rules/rules.go
+++ b/checkers/rules/rules.go
@@ -471,22 +471,13 @@ func unslice(m dsl.Matcher) {
 //doc:before  return nil != ptr
 //doc:after   return ptr != nil
 func yodaStyleExpr(m dsl.Matcher) {
-	m.Match(`$constval != $x`).Where(m["constval"].Const && !m["x"].Const).
+	m.Match(`$constval != $x`).Where(m["constval"].Node.Is(`BasicLit`) && !m["x"].Node.Is(`BasicLit`)).
 		Report(`consider to change order in expression to $x != $constval`)
-	m.Match(`$constval == $x`).Where(m["constval"].Const && !m["x"].Const).
+	m.Match(`$constval == $x`).Where(m["constval"].Node.Is(`BasicLit`) && !m["x"].Node.Is(`BasicLit`)).
 		Report(`consider to change order in expression to $x == $constval`)
 
-	m.Match(`nil != $x`).Where(!m["x"].Const).
+	m.Match(`nil != $x`).Where(!m["x"].Node.Is(`BasicLit`)).
 		Report(`consider to change order in expression to $x != nil`)
-	m.Match(`nil == $x`).Where(!m["x"].Const).
+	m.Match(`nil == $x`).Where(!m["x"].Node.Is(`BasicLit`)).
 		Report(`consider to change order in expression to $x == nil`)
-
-	m.Match(`$constval < $x`).Where(m["constval"].Const && !m["x"].Const).
-		Report(`consider to change order in expression to $x >= $constval`)
-	m.Match(`$constval <= $x`).Where(m["constval"].Const && !m["x"].Const).
-		Report(`consider to change order in expression to $x > $constval`)
-	m.Match(`$constval > $x`).Where(m["constval"].Const && !m["x"].Const).
-		Report(`consider to change order in expression to $x <= $constval`)
-	m.Match(`$constval >= $x`).Where(m["constval"].Const && !m["x"].Const).
-		Report(`consider to change order in expression to $x < $constval`)
 }

--- a/checkers/rulesdata/rulesdata.go
+++ b/checkers/rulesdata/rulesdata.go
@@ -2274,24 +2274,40 @@ var PrecompiledRules = &ir.File{
 					WhereExpr: ir.FilterExpr{
 						Line: 474,
 						Op:   ir.FilterAndOp,
-						Src:  "m[\"constval\"].Const && !m[\"x\"].Const",
+						Src:  "m[\"constval\"].Node.Is(`BasicLit`) && !m[\"x\"].Node.Is(`BasicLit`)",
 						Args: []ir.FilterExpr{
 							ir.FilterExpr{
 								Line:  474,
-								Op:    ir.FilterVarConstOp,
-								Src:   "m[\"constval\"].Const",
+								Op:    ir.FilterVarNodeIsOp,
+								Src:   "m[\"constval\"].Node.Is(`BasicLit`)",
 								Value: "constval",
+								Args: []ir.FilterExpr{
+									ir.FilterExpr{
+										Line:  474,
+										Op:    ir.FilterStringOp,
+										Src:   "`BasicLit`",
+										Value: "BasicLit",
+									},
+								},
 							},
 							ir.FilterExpr{
 								Line: 474,
 								Op:   ir.FilterNotOp,
-								Src:  "!m[\"x\"].Const",
+								Src:  "!m[\"x\"].Node.Is(`BasicLit`)",
 								Args: []ir.FilterExpr{
 									ir.FilterExpr{
 										Line:  474,
-										Op:    ir.FilterVarConstOp,
-										Src:   "m[\"x\"].Const",
+										Op:    ir.FilterVarNodeIsOp,
+										Src:   "m[\"x\"].Node.Is(`BasicLit`)",
 										Value: "x",
+										Args: []ir.FilterExpr{
+											ir.FilterExpr{
+												Line:  474,
+												Op:    ir.FilterStringOp,
+												Src:   "`BasicLit`",
+												Value: "BasicLit",
+											},
+										},
 									},
 								},
 							},
@@ -2305,24 +2321,40 @@ var PrecompiledRules = &ir.File{
 					WhereExpr: ir.FilterExpr{
 						Line: 476,
 						Op:   ir.FilterAndOp,
-						Src:  "m[\"constval\"].Const && !m[\"x\"].Const",
+						Src:  "m[\"constval\"].Node.Is(`BasicLit`) && !m[\"x\"].Node.Is(`BasicLit`)",
 						Args: []ir.FilterExpr{
 							ir.FilterExpr{
 								Line:  476,
-								Op:    ir.FilterVarConstOp,
-								Src:   "m[\"constval\"].Const",
+								Op:    ir.FilterVarNodeIsOp,
+								Src:   "m[\"constval\"].Node.Is(`BasicLit`)",
 								Value: "constval",
+								Args: []ir.FilterExpr{
+									ir.FilterExpr{
+										Line:  476,
+										Op:    ir.FilterStringOp,
+										Src:   "`BasicLit`",
+										Value: "BasicLit",
+									},
+								},
 							},
 							ir.FilterExpr{
 								Line: 476,
 								Op:   ir.FilterNotOp,
-								Src:  "!m[\"x\"].Const",
+								Src:  "!m[\"x\"].Node.Is(`BasicLit`)",
 								Args: []ir.FilterExpr{
 									ir.FilterExpr{
 										Line:  476,
-										Op:    ir.FilterVarConstOp,
-										Src:   "m[\"x\"].Const",
+										Op:    ir.FilterVarNodeIsOp,
+										Src:   "m[\"x\"].Node.Is(`BasicLit`)",
 										Value: "x",
+										Args: []ir.FilterExpr{
+											ir.FilterExpr{
+												Line:  476,
+												Op:    ir.FilterStringOp,
+												Src:   "`BasicLit`",
+												Value: "BasicLit",
+											},
+										},
 									},
 								},
 							},
@@ -2336,13 +2368,21 @@ var PrecompiledRules = &ir.File{
 					WhereExpr: ir.FilterExpr{
 						Line: 479,
 						Op:   ir.FilterNotOp,
-						Src:  "!m[\"x\"].Const",
+						Src:  "!m[\"x\"].Node.Is(`BasicLit`)",
 						Args: []ir.FilterExpr{
 							ir.FilterExpr{
 								Line:  479,
-								Op:    ir.FilterVarConstOp,
-								Src:   "m[\"x\"].Const",
+								Op:    ir.FilterVarNodeIsOp,
+								Src:   "m[\"x\"].Node.Is(`BasicLit`)",
 								Value: "x",
+								Args: []ir.FilterExpr{
+									ir.FilterExpr{
+										Line:  479,
+										Op:    ir.FilterStringOp,
+										Src:   "`BasicLit`",
+										Value: "BasicLit",
+									},
+								},
 							},
 						},
 					},
@@ -2354,135 +2394,19 @@ var PrecompiledRules = &ir.File{
 					WhereExpr: ir.FilterExpr{
 						Line: 481,
 						Op:   ir.FilterNotOp,
-						Src:  "!m[\"x\"].Const",
+						Src:  "!m[\"x\"].Node.Is(`BasicLit`)",
 						Args: []ir.FilterExpr{
 							ir.FilterExpr{
 								Line:  481,
-								Op:    ir.FilterVarConstOp,
-								Src:   "m[\"x\"].Const",
+								Op:    ir.FilterVarNodeIsOp,
+								Src:   "m[\"x\"].Node.Is(`BasicLit`)",
 								Value: "x",
-							},
-						},
-					},
-				},
-				ir.Rule{
-					Line:           484,
-					SyntaxPattern:  "$constval < $x",
-					ReportTemplate: "consider to change order in expression to $x >= $constval",
-					WhereExpr: ir.FilterExpr{
-						Line: 484,
-						Op:   ir.FilterAndOp,
-						Src:  "m[\"constval\"].Const && !m[\"x\"].Const",
-						Args: []ir.FilterExpr{
-							ir.FilterExpr{
-								Line:  484,
-								Op:    ir.FilterVarConstOp,
-								Src:   "m[\"constval\"].Const",
-								Value: "constval",
-							},
-							ir.FilterExpr{
-								Line: 484,
-								Op:   ir.FilterNotOp,
-								Src:  "!m[\"x\"].Const",
 								Args: []ir.FilterExpr{
 									ir.FilterExpr{
-										Line:  484,
-										Op:    ir.FilterVarConstOp,
-										Src:   "m[\"x\"].Const",
-										Value: "x",
-									},
-								},
-							},
-						},
-					},
-				},
-				ir.Rule{
-					Line:           486,
-					SyntaxPattern:  "$constval <= $x",
-					ReportTemplate: "consider to change order in expression to $x > $constval",
-					WhereExpr: ir.FilterExpr{
-						Line: 486,
-						Op:   ir.FilterAndOp,
-						Src:  "m[\"constval\"].Const && !m[\"x\"].Const",
-						Args: []ir.FilterExpr{
-							ir.FilterExpr{
-								Line:  486,
-								Op:    ir.FilterVarConstOp,
-								Src:   "m[\"constval\"].Const",
-								Value: "constval",
-							},
-							ir.FilterExpr{
-								Line: 486,
-								Op:   ir.FilterNotOp,
-								Src:  "!m[\"x\"].Const",
-								Args: []ir.FilterExpr{
-									ir.FilterExpr{
-										Line:  486,
-										Op:    ir.FilterVarConstOp,
-										Src:   "m[\"x\"].Const",
-										Value: "x",
-									},
-								},
-							},
-						},
-					},
-				},
-				ir.Rule{
-					Line:           488,
-					SyntaxPattern:  "$constval > $x",
-					ReportTemplate: "consider to change order in expression to $x <= $constval",
-					WhereExpr: ir.FilterExpr{
-						Line: 488,
-						Op:   ir.FilterAndOp,
-						Src:  "m[\"constval\"].Const && !m[\"x\"].Const",
-						Args: []ir.FilterExpr{
-							ir.FilterExpr{
-								Line:  488,
-								Op:    ir.FilterVarConstOp,
-								Src:   "m[\"constval\"].Const",
-								Value: "constval",
-							},
-							ir.FilterExpr{
-								Line: 488,
-								Op:   ir.FilterNotOp,
-								Src:  "!m[\"x\"].Const",
-								Args: []ir.FilterExpr{
-									ir.FilterExpr{
-										Line:  488,
-										Op:    ir.FilterVarConstOp,
-										Src:   "m[\"x\"].Const",
-										Value: "x",
-									},
-								},
-							},
-						},
-					},
-				},
-				ir.Rule{
-					Line:           490,
-					SyntaxPattern:  "$constval >= $x",
-					ReportTemplate: "consider to change order in expression to $x < $constval",
-					WhereExpr: ir.FilterExpr{
-						Line: 490,
-						Op:   ir.FilterAndOp,
-						Src:  "m[\"constval\"].Const && !m[\"x\"].Const",
-						Args: []ir.FilterExpr{
-							ir.FilterExpr{
-								Line:  490,
-								Op:    ir.FilterVarConstOp,
-								Src:   "m[\"constval\"].Const",
-								Value: "constval",
-							},
-							ir.FilterExpr{
-								Line: 490,
-								Op:   ir.FilterNotOp,
-								Src:  "!m[\"x\"].Const",
-								Args: []ir.FilterExpr{
-									ir.FilterExpr{
-										Line:  490,
-										Op:    ir.FilterVarConstOp,
-										Src:   "m[\"x\"].Const",
-										Value: "x",
+										Line:  481,
+										Op:    ir.FilterStringOp,
+										Src:   "`BasicLit`",
+										Value: "BasicLit",
 									},
 								},
 							},

--- a/checkers/testdata/yodaStyleExpr/negative_tests.go
+++ b/checkers/testdata/yodaStyleExpr/negative_tests.go
@@ -1,5 +1,7 @@
 package checker_test
 
+import "unsafe"
+
 func g1() {
 	var a int
 	if a == 10 {
@@ -15,5 +17,22 @@ func _() {
 	const foo = 10
 	_ = 10 != 15
 	_ = foo == 15
-	_ = 15 == foo
+
+	type myArray struct {
+		data [10]int
+	}
+	var arr myArray
+	var i int
+	_ = len(arr.data) == i
+	_ = i == len(arr.data)
+
+	_ = unsafe.Sizeof(0) == 0
+
+	var c byte
+	if '0' <= c && c <= '9' {
+		// character range ok
+	}
+	if c >= '0' && c <= '9' {
+		// character range ok
+	}
 }

--- a/checkers/testdata/yodaStyleExpr/positive_tests.go
+++ b/checkers/testdata/yodaStyleExpr/positive_tests.go
@@ -1,16 +1,6 @@
 package checker_test
 
-func yodaComparisons() {
-	var x int
-	/*! consider to change order in expression to x <= 0 */
-	_ = 0 > x
-	/*! consider to change order in expression to x >= 0 */
-	_ = 0 < x
-	/*! consider to change order in expression to x < 0 */
-	_ = 0 >= x
-	/*! consider to change order in expression to x > 0 */
-	_ = 0 <= x
-}
+import "unsafe"
 
 func f1() {
 	var m map[int]int
@@ -27,6 +17,9 @@ func f1() {
 	/*! consider to change order in expression to s == "" */
 	if "" == s {
 	}
+
+	/*! consider to change order in expression to unsafe.Sizeof(0) == 0 */
+	_ = 0 == unsafe.Sizeof(0)
 }
 
 func f2() bool {


### PR DESCRIPTION
Don't warn on `<`, `<=`, `>`, `>=`.

Fixes #905
Fixes #1103