### PR TITLE
checkers: add empty decl checker

### DIFF
--- a/checkers/rules/rules.go
+++ b/checkers/rules/rules.go
@@ -690,3 +690,13 @@ func externalErrorReassign(m dsl.Matcher) {
 		Where(m["err"].Type.Is(`error`) && m["pkg"].Object.Is(`PkgName`)).
 		Report(`suspicious reassigment of error from another package`)
 }
+
+//doc:summary Detects suspicious empty declarations blocks
+//doc:tags    diagnostic experimental
+//doc:before  var()
+//doc:after   /* nothing */
+func emptyDecl(m dsl.Matcher) {
+	m.Match(`var()`).Report(`empty var() block`)
+	m.Match(`const()`).Report(`empty const() block`)
+	m.Match(`type()`).Report(`empty type() block`)
+}

--- a/checkers/rulesdata/rulesdata.go
+++ b/checkers/rulesdata/rulesdata.go
@@ -2604,6 +2604,41 @@ var PrecompiledRules = &ir.File{
 				},
 			},
 		},
+		ir.RuleGroup{
+			Line:        698,
+			Name:        "emptyDecl",
+			MatcherName: "m",
+			DocTags: []string{
+				"diagnostic",
+				"experimental",
+			},
+			DocSummary: "Detects suspicious empty declarations blocks",
+			DocBefore:  "var()",
+			DocAfter:   "/* nothing */",
+			Rules: []ir.Rule{
+				ir.Rule{
+					Line: 699,
+					SyntaxPatterns: []ir.PatternString{
+						ir.PatternString{Line: 699, Value: "var()"},
+					},
+					ReportTemplate: "empty var() block",
+				},
+				ir.Rule{
+					Line: 700,
+					SyntaxPatterns: []ir.PatternString{
+						ir.PatternString{Line: 700, Value: "const()"},
+					},
+					ReportTemplate: "empty const() block",
+				},
+				ir.Rule{
+					Line: 701,
+					SyntaxPatterns: []ir.PatternString{
+						ir.PatternString{Line: 701, Value: "type()"},
+					},
+					ReportTemplate: "empty type() block",
+				},
+			},
+		},
 	},
 }
 

--- a/checkers/testdata/emptyDecl/negative_tests.go
+++ b/checkers/testdata/emptyDecl/negative_tests.go
@@ -1,0 +1,26 @@
+package checkers
+
+func _() {
+	var (
+		x int
+	)
+	const (
+		y = 2
+	)
+	type (
+		z string
+	)
+	_ = x
+}
+
+var (
+	gx = 0
+)
+
+const (
+	gy = 2
+)
+
+type (
+	gz string
+)

--- a/checkers/testdata/emptyDecl/positive_tests.go
+++ b/checkers/testdata/emptyDecl/positive_tests.go
@@ -1,0 +1,25 @@
+package checkers
+
+func _() {
+	/*! empty var() block */
+	var ()
+	/*! empty const() block */
+	const ()
+	/*! empty type() block */
+	type ()
+}
+
+/*! empty var() block */
+var (
+// Comment
+)
+
+/*! empty const() block */
+const (
+/* Comment one */
+
+// Comment two
+)
+
+/*! empty type() block */
+type ()


### PR DESCRIPTION
Detects `var()`, `const()` and `type()` decls.