### PR TITLE
checkers: fix precompile.go imports

### DIFF
--- a/checkers/rules/precompile.go
+++ b/checkers/rules/precompile.go
@@ -12,8 +12,8 @@ import (
 	"go/parser"
 	"go/token"
 	"go/types"
-	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 	"text/template"
 


### PR DESCRIPTION
Updates #1126 (https://github.com/go-critic/go-critic/issues/1126#issuecomment-945824769)