### PR TITLE
update go-ruleguard

### DIFF
--- a/checkers/checkers.go
+++ b/checkers/checkers.go
@@ -4,6 +4,7 @@ package checkers
 import (
 	"fmt"
 	"go/ast"
+	"go/build"
 	"go/token"
 	"os"
 
@@ -31,6 +32,8 @@ func init() {
 	fset := token.NewFileSet()
 	var groups []ruleguard.GoRuleGroup
 
+	var buildContext *build.Context
+
 	// First we create an Engine to parse all rules.
 	// We need it to get the structured info about our rules
 	// that will be used to generate checkers.
@@ -39,6 +42,8 @@ func init() {
 	// LoadedGroups() returns a slice copy and that's all what we need.
 	{
 		rootEngine := ruleguard.NewEngine()
+		rootEngine.InferBuildContext()
+		buildContext = rootEngine.BuildContext
 
 		loadContext := &ruleguard.LoadContext{
 			Fset: fset,
@@ -71,6 +76,7 @@ func init() {
 				},
 			}
 			engine := ruleguard.NewEngine()
+			engine.BuildContext = buildContext
 			err := engine.LoadFromIR(parseContext, filename, rulesdata.PrecompiledRules)
 			if err != nil {
 				return nil, err

--- a/checkers/ruleguard_checker.go
+++ b/checkers/ruleguard_checker.go
@@ -110,6 +110,7 @@ func newRuleguardChecker(info *linter.CheckerInfo, ctx *linter.CheckerContext) (
 	}
 
 	engine := ruleguard.NewEngine()
+	engine.InferBuildContext()
 	fset := token.NewFileSet()
 	filePatterns := strings.Split(rulesFlag, ",")
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/mattn/goveralls v0.0.2
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c
-	github.com/quasilyte/go-ruleguard v0.3.11
+	github.com/quasilyte/go-ruleguard v0.3.12
 	github.com/quasilyte/go-ruleguard/dsl v0.3.10
 	github.com/quasilyte/regex/syntax v0.0.0-20200407221936-30656e2c4a95
 	golang.org/x/tools v0.0.0-20201230224404-63754364767c

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtP
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c h1:JoUA0uz9U0FVFq5p4LjEq4C0VgQ0El320s3Ms0V4eww=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/quasilyte/go-ruleguard v0.3.1-0.20210203134552-1b5a410e1cc8/go.mod h1:KsAh3x0e7Fkpgs+Q9pNLS5XpFSvYCEVl5gP9Pp1xp30=
-github.com/quasilyte/go-ruleguard v0.3.11 h1:jKRk50wIigmwKzWpNoqECdbT9tXD8YeEN1ygVvL11kA=
-github.com/quasilyte/go-ruleguard v0.3.11/go.mod h1:Ul8wwdqR6kBVOCt2dipDBkE+T6vAV/iixkrKuRTN1oQ=
+github.com/quasilyte/go-ruleguard v0.3.12 h1:h+T+fqHji24GHid17en0+Jue2jWQEM8wtqqtGZUBHaA=
+github.com/quasilyte/go-ruleguard v0.3.12/go.mod h1:Ul8wwdqR6kBVOCt2dipDBkE+T6vAV/iixkrKuRTN1oQ=
 github.com/quasilyte/go-ruleguard/dsl v0.3.0/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/quasilyte/go-ruleguard/dsl v0.3.10 h1:4tVlVVcBT+nNWoF+t/zrAMO13sHAqYotX1K12Gc8f8A=
 github.com/quasilyte/go-ruleguard/dsl v0.3.10/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=


### PR DESCRIPTION
The newer version uses a fix for srcimporter that tries
to use incorrect GOROOT and then fails to locate stdlib packages.

Updates #1126