### PR TITLE
update go-toolsmith/pkgload

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-toolsmith/astequal v1.0.1
 	github.com/go-toolsmith/astfmt v1.0.0
 	github.com/go-toolsmith/astp v1.0.0
-	github.com/go-toolsmith/pkgload v1.0.0
+	github.com/go-toolsmith/pkgload v1.0.1
 	github.com/go-toolsmith/strparse v1.0.0
 	github.com/go-toolsmith/typep v1.0.2
 	github.com/google/go-cmp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/go-toolsmith/astp v1.0.0 h1:alXE75TXgcmupDsMK1fRAy0YUzLzqPVvBKoyWV+KP
 github.com/go-toolsmith/astp v1.0.0/go.mod h1:RSyrtpVlfTFGDYRbrjyWP1pYu//tSFcvdYrA8meBmLI=
 github.com/go-toolsmith/pkgload v1.0.0 h1:4DFWWMXVfbcN5So1sBNW9+yeiMqLFGl1wFLTL5R0Tgg=
 github.com/go-toolsmith/pkgload v1.0.0/go.mod h1:5eFArkbO80v7Z0kdngIxsRXRMTaX4Ilcwuh3clNrQJc=
+github.com/go-toolsmith/pkgload v1.0.1 h1:olBaNnuEUQAqyv4M6gN16Yw3YEMs+nlo4ZwLVfZvpNA=
+github.com/go-toolsmith/pkgload v1.0.1/go.mod h1:5eFArkbO80v7Z0kdngIxsRXRMTaX4Ilcwuh3clNrQJc=
 github.com/go-toolsmith/strparse v1.0.0 h1:Vcw78DnpCAKlM20kSbAyO4mPfJn/lyYA4BJUDxe2Jb4=
 github.com/go-toolsmith/strparse v1.0.0/go.mod h1:YI2nUKP9YGZnL/L1/DLFBfixrcjslWct4wyljWhSRy8=
 github.com/go-toolsmith/typep v1.0.0/go.mod h1:JSQCQMUPdRlMZFswiq3TGpNp1GMktqkR2Ns5AIQkATU=


### PR DESCRIPTION
This avoids a nil deref in some modules.