### PR TITLE
framework/linter: refactor go version handling

### DIFF
--- a/framework/linter/go_version.go
+++ b/framework/linter/go_version.go
@@ -27,25 +27,25 @@ func (v GoVersion) GreaterOrEqual(other GoVersion) bool {
 	return v.Major >= other.Major
 }
 
-func parseGoVersion(version string) GoVersion {
+func ParseGoVersion(version string) (GoVersion, error) {
+	var result GoVersion
 	version = strings.TrimPrefix(version, "go")
 	if version == "" {
-		return GoVersion{}
+		return result, nil
 	}
 	parts := strings.Split(version, ".")
 	if len(parts) != 2 {
-		panic(fmt.Sprintf("invalid Go version format: %s", version))
+		return result, fmt.Errorf("invalid Go version format: %s", version)
 	}
 	major, err := strconv.Atoi(parts[0])
 	if err != nil {
-		panic(fmt.Sprintf("invalid major version part: %s: %s", parts[0], err))
+		return result, fmt.Errorf("invalid major version part: %s: %w", parts[0], err)
 	}
 	minor, err := strconv.Atoi(parts[1])
 	if err != nil {
-		panic(fmt.Sprintf("invalid minor version part: %s: %s", parts[1], err))
+		return result, fmt.Errorf("invalid minor version part: %s: %w", parts[1], err)
 	}
-	return GoVersion{
-		Major: major,
-		Minor: minor,
-	}
+	result.Major = major
+	result.Minor = minor
+	return result, nil
 }

--- a/framework/linter/go_version_test.go
+++ b/framework/linter/go_version_test.go
@@ -18,7 +18,10 @@ func TestGoVersionParse(t *testing.T) {
 	}
 
 	runTest := func(x string, wantMajor, wantMinor int) {
-		have := parseGoVersion(x)
+		have, err := ParseGoVersion(x)
+		if err != nil {
+			t.Fatalf("parse %q: %v", x, err)
+		}
 		if have.Major != wantMajor {
 			t.Errorf("parseGoVersion(%s); major: want %d, have %d", x, wantMajor, have.Major)
 		}
@@ -57,6 +60,14 @@ func TestGoVersionCompare(t *testing.T) {
 		{"2.0", "1.254", true},
 		{"2.0", "2.0", true},
 		{"2.0", "2.1", false},
+	}
+
+	parseGoVersion := func(s string) GoVersion {
+		v, err := ParseGoVersion(s)
+		if err != nil {
+			t.Fatalf("parse %q: %v", s, err)
+		}
+		return v
 	}
 
 	runTest := func(x, y string, want bool) {

--- a/framework/linter/linter.go
+++ b/framework/linter/linter.go
@@ -232,7 +232,11 @@ func NewContext(fset *token.FileSet, sizes types.Sizes) *Context {
 // like all features are available. To make gocritic
 // more conservative, the upper Go version level should be adjusted.
 func (c *Context) SetGoVersion(version string) {
-	c.GoVersion = parseGoVersion(version)
+	v, err := ParseGoVersion(version)
+	if err != nil {
+		panic(err)
+	}
+	c.GoVersion = v
 }
 
 // SetPackageInfo sets package-related metadata.


### PR DESCRIPTION
Make version parsing api more idiomatic.