### PR TITLE
checkers(commentFormatting): treat //noinspection as pragma

### DIFF
--- a/checkers/commentFormatting_checker.go
+++ b/checkers/commentFormatting_checker.go
@@ -27,6 +27,7 @@ func init() {
 			`^//line /.*:\d+`,    // e.g.: line /path/to/file:123
 			`^//export \w+$`,     // e.g.: export Foo
 			`^//[/+#-]+.*$`,      // e.g.: vertical breaker /////////////
+			`^//noinspection `,   // e.g.: noinspection ALL, some GoLand and friends versions
 		}
 		pat := "(?m)" + strings.Join(parts, "|")
 		pragmaRE := regexp.MustCompile(pat)


### PR DESCRIPTION
Used by some versions of GoLand and friends IDE's.