### PR TITLE
checkers: fix equalFold rules autofix templates

### DIFF
--- a/checkers/rules/rules.go
+++ b/checkers/rules/rules.go
@@ -569,7 +569,7 @@ func equalFold(m dsl.Matcher) {
 		`strings.ToUpper($x) == strings.ToUpper($y)`,
 		`$x == strings.ToUpper($y)`).
 		Where(m["x"].Pure && m["y"].Pure && m["x"].Text != m["y"].Text).
-		Suggest(`strings.EqualFold($x, $y)]`).
+		Suggest(`strings.EqualFold($x, $y)`).
 		Report(`consider replacing with strings.EqualFold($x, $y)`)
 
 	// string != patterns
@@ -581,7 +581,7 @@ func equalFold(m dsl.Matcher) {
 		`strings.ToUpper($x) != strings.ToUpper($y)`,
 		`$x != strings.ToUpper($y)`).
 		Where(m["x"].Pure && m["y"].Pure && m["x"].Text != m["y"].Text).
-		Suggest(`!strings.EqualFold($x, $y)]`).
+		Suggest(`!strings.EqualFold($x, $y)`).
 		Report(`consider replacing with !strings.EqualFold($x, $y)`)
 
 	// bytes.Equal patterns
@@ -593,7 +593,7 @@ func equalFold(m dsl.Matcher) {
 		`bytes.Equal(bytes.ToUpper($x), bytes.ToUpper($y))`,
 		`bytes.Equal($x, bytes.ToUpper($y))`).
 		Where(m["x"].Pure && m["y"].Pure && m["x"].Text != m["y"].Text).
-		Suggest(`bytes.EqualFold($x, $y)]`).
+		Suggest(`bytes.EqualFold($x, $y)`).
 		Report(`consider replacing with bytes.EqualFold($x, $y)`)
 }
 

--- a/checkers/rulesdata/rulesdata.go
+++ b/checkers/rulesdata/rulesdata.go
@@ -2099,7 +2099,7 @@ var PrecompiledRules = &ir.File{
 						ir.PatternString{Line: 570, Value: "$x == strings.ToUpper($y)"},
 					},
 					ReportTemplate:  "consider replacing with strings.EqualFold($x, $y)",
-					SuggestTemplate: "strings.EqualFold($x, $y)]",
+					SuggestTemplate: "strings.EqualFold($x, $y)",
 					WhereExpr: ir.FilterExpr{
 						Line: 571,
 						Op:   ir.FilterAndOp,
@@ -2137,7 +2137,7 @@ var PrecompiledRules = &ir.File{
 						ir.PatternString{Line: 582, Value: "$x != strings.ToUpper($y)"},
 					},
 					ReportTemplate:  "consider replacing with !strings.EqualFold($x, $y)",
-					SuggestTemplate: "!strings.EqualFold($x, $y)]",
+					SuggestTemplate: "!strings.EqualFold($x, $y)",
 					WhereExpr: ir.FilterExpr{
 						Line: 583,
 						Op:   ir.FilterAndOp,
@@ -2175,7 +2175,7 @@ var PrecompiledRules = &ir.File{
 						ir.PatternString{Line: 594, Value: "bytes.Equal($x, bytes.ToUpper($y))"},
 					},
 					ReportTemplate:  "consider replacing with bytes.EqualFold($x, $y)",
-					SuggestTemplate: "bytes.EqualFold($x, $y)]",
+					SuggestTemplate: "bytes.EqualFold($x, $y)",
 					WhereExpr: ir.FilterExpr{
 						Line: 595,
 						Op:   ir.FilterAndOp,


### PR DESCRIPTION
Removed a typo from a `Suggest()` string.