### PR TITLE
README.md: Doc sec tag disabled, fails if enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Tags:
 * `#performance` - kind of checks that detect potential performance issues in code
 * `#experimental` - check is under testing and development. Disabled by default
 * `#opinionated` - check can be unwanted for some people. Disabled by default
-* `#security` -  kind of checks that find security issues in code
+* `#security` -  kind of checks that find security issues in code. Disabled by default and empty, so will fail if enabled.
 
 ## Contributing
 


### PR DESCRIPTION
Document that the security tag is disabled by default. Also document
that there are currently no checks in the security tag, so enabling it
will fail.

$ ./gocritic check -v -enable='#security
init checkers: empty checkers set selected
$ echo $?
1

When trying to enable the tag through golangci-lint, this is the error:

ERRO Invalid gocritic settings: gocritic [enabled]tag "security" doesn't
exist

The tag was added in #989.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>