### PR TITLE
Remove the `experimental` tag from the `ioutil` check so that it's enabled by default

### DIFF
--- a/checkers/rules/rules.go
+++ b/checkers/rules/rules.go
@@ -40,7 +40,7 @@ func deferUnlambda(m dsl.Matcher) {
 }
 
 //doc:summary Detects deprecated io/ioutil package usages
-//doc:tags    style experimental
+//doc:tags    style
 //doc:before  ioutil.ReadAll(r)
 //doc:after   io.ReadAll(r)
 func ioutilDeprecated(m dsl.Matcher) {

--- a/checkers/rulesdata/rulesdata.go
+++ b/checkers/rulesdata/rulesdata.go
@@ -206,7 +206,6 @@ var PrecompiledRules = &ir.File{
 			MatcherName: "m",
 			DocTags: []string{
 				"style",
-				"experimental",
 			},
 			DocSummary: "Detects deprecated io/ioutil package usages",
 			DocBefore:  "ioutil.ReadAll(r)",
@@ -2787,4 +2786,3 @@ var PrecompiledRules = &ir.File{
 		},
 	},
 }
-

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -87,7 +87,7 @@ with another one that is considered more idiomatic or simple.
 |:heavy_check_mark:[ifElseChain](#ifelsechain)|Detects repeated if-else statements and suggests to replace them with switch statement|
 |:white_check_mark:[importShadow](#importshadow)|Detects when imported package names shadowed in the assignments|
 |:white_check_mark:[initClause](#initclause)|Detects non-assignment statements inside if/switch init clause|
-|:white_check_mark:[ioutilDeprecated](#ioutildeprecated)|Detects deprecated io/ioutil package usages|
+|:heavy_check_mark:[ioutilDeprecated](#ioutildeprecated)|Detects deprecated io/ioutil package usages|
 |:white_check_mark:[methodExprCall](#methodexprcall)|Detects method expression call that can be replaced with a method call|
 |:white_check_mark:[nestingReduce](#nestingreduce)|Finds where nesting level could be reduced|
 |:heavy_check_mark:[newDeref](#newderef)|Detects immediate dereferencing of `new` expressions|
@@ -1363,8 +1363,7 @@ if cond {
 ## ioutilDeprecated
 
 [
-  **style**
-  **experimental** ]
+  **style** ]
 
 Detects deprecated io/ioutil package usages.
 
@@ -2802,5 +2801,3 @@ return nil != ptr
 ```go
 return ptr != nil
 ```
-
-


### PR DESCRIPTION
The `ioutil` package was [deprecated as part of `go` `1.16`](https://go.dev/doc/go1.16#ioutil).

Now that `go` `1.18` has dropped, the core `go` team no longer supports
`1.16`.

So it should be safe to remove the `experimental` tag. This will switch
the check from disabled by default to enabled by default.

Note that the check still has internal `if` statements to only fire on code
running `1.16` or newer, so even though it's enabled by default, it won't
start complaining on code running older versions of `go`.