### PR TITLE
supported generics for typeDefFirst and paramTypeCombine

### DIFF
--- a/checkers/paramTypeCombine_checker.go
+++ b/checkers/paramTypeCombine_checker.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-critic/go-critic/checkers/internal/astwalk"
 	"github.com/go-critic/go-critic/framework/linter"
+	"github.com/go-toolsmith/astcopy"
 	"github.com/go-toolsmith/astequal"
 )
 
@@ -38,10 +39,12 @@ func (c *paramTypeCombineChecker) VisitFuncDecl(decl *ast.FuncDecl) {
 }
 
 func (c *paramTypeCombineChecker) optimizeFuncType(f *ast.FuncType) *ast.FuncType {
-	return &ast.FuncType{
-		Params:  c.optimizeParams(f.Params),
-		Results: c.optimizeParams(f.Results),
-	}
+	optimizedParamFunc := astcopy.FuncType(f)
+
+	optimizedParamFunc.Params = c.optimizeParams(f.Params)
+	optimizedParamFunc.Results = c.optimizeParams(f.Results)
+
+	return optimizedParamFunc
 }
 func (c *paramTypeCombineChecker) optimizeParams(params *ast.FieldList) *ast.FieldList {
 	// To avoid false positives, skip unnamed param lists.

--- a/checkers/testdata/paramTypeCombine/negative_tests_go118.go
+++ b/checkers/testdata/paramTypeCombine/negative_tests_go118.go
@@ -1,0 +1,17 @@
+//go:build go1.18
+// +build go1.18
+
+package checker_test
+
+func genericGood1[T any](a T, b, c int)                {}
+func genericGood2[T any](a, b T, c int)                {}
+func genericGood3[T any](a T)                          {}
+func genericGood4[T any]()                             {}
+func genericGood5[T any, Y any](a, b T, c int, d, e Y) {}
+
+func genericUnnamed[T any](T, T) {}
+
+func genericUnnamedResults[T any]() (T, T) {
+	var t T
+	return t, t
+}

--- a/checkers/testdata/paramTypeCombine/positive_tests_go118.go
+++ b/checkers/testdata/paramTypeCombine/positive_tests_go118.go
@@ -1,0 +1,21 @@
+//go:build go1.18
+// +build go1.18
+
+package checker_test
+
+/*! func[T any]() (a T, b T, c T) could be replaced with func[T any]() (a, b, c T) */
+func genericSimple1[T any]() (a T, b T, c T) { return a, b, c }
+
+/*! func[T any](a T, b T, c T) could be replaced with func[T any](a, b, c T) */
+func genericSimple2[T any](a T, b T, c T) {}
+
+/*! func[T any, Y any](a T, b T, c int, d Y, e Y) could be replaced with func[T any, Y any](a, b T, c int, d, e Y) */
+func genericMixed1[T any, Y any](a T, b T, c int, d Y, e Y) {}
+
+/*! func[T any, Y any]() (a T, b T, c int, d Y, e Y) could be replaced with func[T any, Y any]() (a, b T, c int, d, e Y) */
+func genericMixed2[T any, Y any]() (a T, b T, c int, d Y, e Y) { return a, b, c, d, e }
+
+/*! func[T any](a T, b T, c int, d int32, e int32) (f int64, g int64, h T, k T) could be replaced with func[T any](a, b T, c int, d, e int32) (f, g int64, h, k T) */
+func genericMixed3[T any](a T, b T, c int, d int32, e int32) (f int64, g int64, h T, k T) {
+	return f, g, h, k
+}

--- a/checkers/testdata/typeDefFirst/negative_tests_go118.go
+++ b/checkers/testdata/typeDefFirst/negative_tests_go118.go
@@ -1,0 +1,14 @@
+//go:build go1.18
+// +build go1.18
+
+package checker_test
+
+type genericNegativeStruct[T any] struct{ _ []T }
+
+func (_ genericNegativeStruct[T]) Method()         {}
+func (_ *genericNegativeStruct[T]) MethodWithRef() {}
+
+type multiGenericNegativeStruct[T any, X any] struct{ _ []T }
+
+func (_ multiGenericNegativeStruct[T, X]) Method()         {}
+func (_ *multiGenericNegativeStruct[T, X]) MethodWithRef() {}

--- a/checkers/testdata/typeDefFirst/positive_tests_go118.go
+++ b/checkers/testdata/typeDefFirst/positive_tests_go118.go
@@ -1,0 +1,14 @@
+//go:build go1.18
+// +build go1.18
+
+package checker_test
+
+func (_ genericPositiveStruct[T]) Method() {}
+
+/*! definition of type 'genericPositiveStruct' should appear before its methods */
+type genericPositiveStruct[T any] struct{ _ []T }
+
+func (_ *multiGenericPositiveStruct[T, X]) MethodWithRef() {}
+
+/*! definition of type 'multiGenericPositiveStruct' should appear before its methods */
+type multiGenericPositiveStruct[T any, X any] struct{ _ []T }

--- a/checkers/typeDefFirst_checker.go
+++ b/checkers/typeDefFirst_checker.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-critic/go-critic/checkers/internal/astwalk"
 	"github.com/go-critic/go-critic/framework/linter"
+	"golang.org/x/exp/typeparams"
 )
 
 func init() {
@@ -78,6 +79,10 @@ func (c *typeDefFirstChecker) receiverType(e ast.Expr) string {
 		return c.receiverType(e.X)
 	case *ast.Ident:
 		return e.Name
+	case *ast.IndexExpr:
+		return c.receiverType(e.X)
+	case *typeparams.IndexListExpr:
+		return c.receiverType(e.X)
 	default:
 		panic("unreachable")
 	}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/quasilyte/go-ruleguard v0.3.16-0.20220213074421-6aa060fab41a
 	github.com/quasilyte/go-ruleguard/dsl v0.3.21
 	github.com/quasilyte/regex/syntax v0.0.0-20200407221936-30656e2c4a95
+	golang.org/x/exp/typeparams v0.0.0-20220428152302-39d4317da171
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 	golang.org/x/tools v0.1.9-0.20211228192929-ee1ca4ffc4da
 )


### PR DESCRIPTION
Fixes go-critic/go-critic#1193