### PR TITLE
checkers: turn `init()` for embedded rules into exported func

### DIFF
--- a/checkers/embedded_rules.go
+++ b/checkers/embedded_rules.go
@@ -15,7 +15,7 @@ import (
 
 //go:generate go run ./rules/precompile.go -rules ./rules/rules.go -o ./rulesdata/rulesdata.go
 
-func init() {
+func InitEmbeddedRules() {
 	filename := "rules/rules.go"
 
 	fset := token.NewFileSet()

--- a/cmd/gocritic/main.go
+++ b/cmd/gocritic/main.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	_ "github.com/go-critic/go-critic/checkers" // Register go-critic checkers
+	"github.com/go-critic/go-critic/checkers" // Register go-critic checkers
 	"github.com/go-critic/go-critic/framework/lintmain"
 )
 
 var Version = "v0.0.0-SNAPSHOT"
 
 func main() {
+	checkers.InitEmbeddedRules()
 	lintmain.Run(lintmain.Config{
 		Name:    "gocritic",
 		Version: Version,


### PR DESCRIPTION
The `checkers` package user should use `checkers.InitEmbeddedRules()`
if ruleguard-based rules should be enabled.

Fixes #1218