### PR TITLE
checkers: use ctx.SizeOf instead of SizesInfo.SizeOf

### DIFF
--- a/checkers/hugeParam_checker.go
+++ b/checkers/hugeParam_checker.go
@@ -53,8 +53,8 @@ func (c *hugeParamChecker) checkParams(params []*ast.Field) {
 			if _, ok := typ.(*typeparams.TypeParam); ok {
 				continue
 			}
-			size := c.ctx.SizesInfo.Sizeof(typ)
-			if size >= c.sizeThreshold {
+			size, ok := c.ctx.SizeOf(typ)
+			if ok && size >= c.sizeThreshold {
 				c.warn(id, size)
 			}
 		}

--- a/checkers/rangeExprCopy_checker.go
+++ b/checkers/rangeExprCopy_checker.go
@@ -69,7 +69,7 @@ func (c *rangeExprCopyChecker) VisitStmt(stmt ast.Stmt) {
 	if _, ok := tv.Type.(*types.Array); !ok {
 		return
 	}
-	if size := c.ctx.SizesInfo.Sizeof(tv.Type); size >= c.sizeThreshold {
+	if size, ok := c.ctx.SizeOf(tv.Type); ok && size >= c.sizeThreshold {
 		c.warn(rng, size)
 	}
 }

--- a/checkers/rangeValCopy_checker.go
+++ b/checkers/rangeValCopy_checker.go
@@ -69,7 +69,7 @@ func (c *rangeValCopyChecker) VisitStmt(stmt ast.Stmt) {
 	if _, ok := typ.(*typeparams.TypeParam); ok {
 		return
 	}
-	if size := c.ctx.SizesInfo.Sizeof(typ); size >= c.sizeThreshold {
+	if size, ok := c.ctx.SizeOf(typ); ok && size >= c.sizeThreshold {
 		c.warn(rng, size)
 	}
 }

--- a/checkers/truncateCmp_checker.go
+++ b/checkers/truncateCmp_checker.go
@@ -96,8 +96,14 @@ func (c *truncateCmpChecker) checkCmp(cmpX, cmpY ast.Expr) {
 		return
 	}
 
-	xsize := c.ctx.SizesInfo.Sizeof(xtyp)
-	ysize := c.ctx.SizesInfo.Sizeof(ytyp)
+	xsize, ok := c.ctx.SizeOf(xtyp)
+	if !ok {
+		return
+	}
+	ysize, ok := c.ctx.SizeOf(ytyp)
+	if !ok {
+		return
+	}
 	if xsize <= ysize {
 		return
 	}

--- a/framework/linter/linter.go
+++ b/framework/linter/linter.go
@@ -6,6 +6,7 @@ import (
 	"go/types"
 
 	"github.com/go-toolsmith/astfmt"
+	"golang.org/x/exp/typeparams"
 )
 
 // CheckerCollection provides additional information for a group of checkers.
@@ -312,6 +313,16 @@ func (ctx *CheckerContext) TypeOf(x ast.Expr) types.Type {
 	// that will fail most type assertions as well as kind checks
 	// (if the call side expects a *types.Basic).
 	return UnknownType
+}
+
+// SizeOf returns the size of the typ in bytes.
+//
+// Unlike SizesInfo.SizeOf, it will not panic on generic types.
+func (ctx *CheckerContext) SizeOf(typ types.Type) (int64, bool) {
+	if _, ok := typ.(*typeparams.TypeParam); ok {
+		return 0, false
+	}
+	return ctx.SizesInfo.Sizeof(typ), true
 }
 
 // FileWalker is an interface every checker should implement.

--- a/rules.go
+++ b/rules.go
@@ -9,3 +9,8 @@ func nilSafeTypeOf(m dsl.Matcher) {
 	m.Match(`$_.ctx.TypesInfo.TypeOf($x)`).
 		Report(`use ctx.TypeOf($x) instead, it's nil-safe`)
 }
+
+func stdSizeof(m dsl.Matcher) {
+	m.Match(`$_.ctx.SizesInfo.Sizeof($_)`).
+		Report(`use ctx.SizeOf instead`)
+}


### PR DESCRIPTION
Also add a ruleguard rule to avoid the unwanted sizeof form
in the future.