### PR TITLE
feat(InitEmbeddedRules): return an error instead of panic

### DIFF
--- a/checkers/embedded_rules.go
+++ b/checkers/embedded_rules.go
@@ -15,7 +15,7 @@ import (
 
 //go:generate go run ./rules/precompile.go -rules ./rules/rules.go -o ./rulesdata/rulesdata.go
 
-func InitEmbeddedRules() {
+func InitEmbeddedRules() error {
 	filename := "rules/rules.go"
 
 	fset := token.NewFileSet()
@@ -44,7 +44,7 @@ func InitEmbeddedRules() {
 			},
 		}
 		if err := rootEngine.LoadFromIR(loadContext, filename, rulesdata.PrecompiledRules); err != nil {
-			panic(fmt.Sprintf("load embedded ruleguard rules: %v", err))
+			return fmt.Errorf("load embedded ruleguard rules: %w", err)
 		}
 		groups = rootEngine.LoadedGroups()
 	}
@@ -87,6 +87,8 @@ func InitEmbeddedRules() {
 			return c, nil
 		})
 	}
+
+	return nil
 }
 
 type embeddedRuleguardChecker struct {

--- a/cmd/gocritic/main.go
+++ b/cmd/gocritic/main.go
@@ -8,7 +8,11 @@ import (
 var Version = "v0.0.0-SNAPSHOT"
 
 func main() {
-	checkers.InitEmbeddedRules()
+	err := checkers.InitEmbeddedRules()
+	if err != nil {
+		panic(err)
+	}
+
 	lintmain.Run(lintmain.Config{
 		Name:    "gocritic",
 		Version: Version,


### PR DESCRIPTION
Related to #1246 and #1218.

Inside golangci-lint, we have to catch the panic with a `recover`.
It's more API friendly if the function `InitEmbeddedRules` returns an error.