### PR TITLE
docs: update README install instruction for go 1.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ Instructions below show how to build `go-critic` from sources.
 GO111MODULE=on go get -v -u github.com/go-critic/go-critic/cmd/gocritic
 ```
 
+as of go 1.18, use go install instead
+```bash
+go install -v github.com/go-critic/go-critic/cmd/gocritic@latest
+```
+
 If the command above does not work, you can try cloning this repository
 under your `GOPATH` and run `make gocritic`.
 


### PR DESCRIPTION
As of go 1.18 `go get` outside of a module is deprecated, we should use `go install` instead. 
This PR adds a small note on this for new users who wish to download go-critic