### PR TITLE
checkers: fix reflect.Value suggestion in redundantSprint

### DIFF
--- a/checkers/checkers_test.go
+++ b/checkers/checkers_test.go
@@ -12,6 +12,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+func init() {
+	if err := InitEmbeddedRules(); err != nil {
+		panic(err) // Should never happen
+	}
+}
+
 func TestCheckers(t *testing.T) {
 	allParams := map[string]map[string]interface{}{
 		"captLocal": {"paramsOnly": false},

--- a/checkers/rules/rules.go
+++ b/checkers/rules/rules.go
@@ -10,7 +10,7 @@ import (
 //doc:after   x.String()
 func redundantSprint(m dsl.Matcher) {
 	m.Match(`fmt.Sprint($x)`, `fmt.Sprintf("%s", $x)`, `fmt.Sprintf("%v", $x)`).
-		Where(m["x"].Type.Implements(`fmt.Stringer`)).
+		Where(!m["x"].Type.Is(`reflect.Value`) && m["x"].Type.Implements(`fmt.Stringer`)).
 		Suggest(`$x.String()`).
 		Report(`use $x.String() instead`)
 

--- a/checkers/rulesdata/rulesdata.go
+++ b/checkers/rulesdata/rulesdata.go
@@ -28,11 +28,30 @@ var PrecompiledRules = &ir.File{
 					ReportTemplate:  "use $x.String() instead",
 					SuggestTemplate: "$x.String()",
 					WhereExpr: ir.FilterExpr{
-						Line:  13,
-						Op:    ir.FilterVarTypeImplementsOp,
-						Src:   "m[\"x\"].Type.Implements(`fmt.Stringer`)",
-						Value: "x",
-						Args:  []ir.FilterExpr{{Line: 13, Op: ir.FilterStringOp, Src: "`fmt.Stringer`", Value: "fmt.Stringer"}},
+						Line: 13,
+						Op:   ir.FilterAndOp,
+						Src:  "!m[\"x\"].Type.Is(`reflect.Value`) && m[\"x\"].Type.Implements(`fmt.Stringer`)",
+						Args: []ir.FilterExpr{
+							{
+								Line: 13,
+								Op:   ir.FilterNotOp,
+								Src:  "!m[\"x\"].Type.Is(`reflect.Value`)",
+								Args: []ir.FilterExpr{{
+									Line:  13,
+									Op:    ir.FilterVarTypeIsOp,
+									Src:   "m[\"x\"].Type.Is(`reflect.Value`)",
+									Value: "x",
+									Args:  []ir.FilterExpr{{Line: 13, Op: ir.FilterStringOp, Src: "`reflect.Value`", Value: "reflect.Value"}},
+								}},
+							},
+							{
+								Line:  13,
+								Op:    ir.FilterVarTypeImplementsOp,
+								Src:   "m[\"x\"].Type.Implements(`fmt.Stringer`)",
+								Value: "x",
+								Args:  []ir.FilterExpr{{Line: 13, Op: ir.FilterStringOp, Src: "`fmt.Stringer`", Value: "fmt.Stringer"}},
+							},
+						},
 					},
 				},
 				{

--- a/checkers/testdata/redundantSprint/negative_tests.go
+++ b/checkers/testdata/redundantSprint/negative_tests.go
@@ -1,5 +1,10 @@
 package checker_test
 
+import (
+	"fmt"
+	"reflect"
+)
+
 func _() {
 	{
 		var foo withStringer
@@ -16,5 +21,12 @@ func _() {
 		_ = s
 
 		_ = "x"
+	}
+
+	{
+		var rv reflect.Value
+		_ = fmt.Sprint(rv)
+		_ = fmt.Sprintf("%s", rv)
+		_ = fmt.Sprintf("%v", rv)
 	}
 }


### PR DESCRIPTION
Also enable embedded rules testing: we need to call
InitEmbeddedRules() somewhere inside the testing code
in order for them to be registered.

Fixes #1255