### PR TITLE
checkers/octalLiteral: should warn only for Go >= 1.13

### DIFF
--- a/checkers/octalLiteral_checker.go
+++ b/checkers/octalLiteral_checker.go
@@ -31,6 +31,9 @@ type octalLiteralChecker struct {
 }
 
 func (c *octalLiteralChecker) VisitExpr(expr ast.Expr) {
+	if !c.ctx.GoVersion.GreaterOrEqual(linter.GoVersion{Major: 1, Minor: 13}) {
+		return
+	}
 	lit := astcast.ToBasicLit(expr)
 	if lit.Kind != token.INT {
 		return


### PR DESCRIPTION
This PR changes the `octalLiteral` check to show a warning only if the Go version is greater than 1.13. Because prefixes `0o` or `0O` are available since [Go 1.13](https://go.dev/doc/go1.13).

## How to test

- Clone https://github.com/golang/dl. This repo targets [Go 1.11.](https://github.com/golang/dl/blob/c7dbe52702e1669c6f0ad1f36e68d6e0864a1c5d/go.mod#L3)
- Run `gocritic check -go 1.11 -enable octalLiteral ./...`

### Expected

No warnings.

### Actual

There are warnings:

```
./internal/genv/main.go:60:45: octalLiteral: use new octal literal style, 0o755
./internal/genv/main.go:63:49: octalLiteral: use new octal literal style, 0o666
./internal/version/gotip.go:71:31: octalLiteral: use new octal literal style, 0o755
./internal/version/version.go:109:35: octalLiteral: use new octal literal style, 0o755
./internal/version/version.go:152:74: octalLiteral: use new octal literal style, 0o644
./internal/version/version.go:209:46: octalLiteral: use new octal literal style, 0o755
./internal/version/version.go:239:31: octalLiteral: use new octal literal style, 0o755
./internal/version/version.go:263:35: octalLiteral: use new octal literal style, 0o755
./internal/version/version.go:275:48: octalLiteral: use new octal literal style, 0o755
```

With the changes in this PR `gocritic` doesn't show any `octalLiteral` warnings for `golang/dl` repo.