### PR TITLE
checkers: fix setting of Go version for ruleguard

### DIFF
--- a/checkers/embedded_rules.go
+++ b/checkers/embedded_rules.go
@@ -101,6 +101,7 @@ func (c *embeddedRuleguardChecker) WalkFile(f *ast.File) {
 		Pkg:         c.ctx.Pkg,
 		Types:       c.ctx.TypesInfo,
 		Sizes:       c.ctx.SizesInfo,
+		GoVersion:   ruleguard.GoVersion(c.ctx.GoVersion),
 		Fset:        c.ctx.FileSet,
 		TruncateLen: 100,
 	})


### PR DESCRIPTION
This PR fixes a bug when `-go` flag is ignored by `gocritic`.
## Steps to reproduce

Run the following:
```
gocritic check -enable syncMapLoadAndDelete -go 1.14 checkers/testdata/syncMapLoadAndDelete/positive_tests.go
```

### Expected

[sync#Map.LoadAndDelete](https://pkg.go.dev/sync#Map.LoadAndDelete) added in Go 1.15. So, there should not be any warnings for Go 1.14.

### Actual

There is a warning:
```
./checkers/testdata/syncMapLoadAndDelete/positive_tests.go:10:3: syncMapLoadAndDelete: use m.LoadAndDelete to perform load+delete operations atomically
```
---

There should be an integration test for this situation but I don't know where to add it.