### PR TITLE
checkers: fix typos

### DIFF
--- a/checkers/analyzer/run.go
+++ b/checkers/analyzer/run.go
@@ -103,7 +103,7 @@ func asDiag(c *linter.Checker, warning linter.Warning) analysis.Diagnostic {
 	return diag
 }
 
-// prepareGocritic initializes a new gocririt object,
+// prepareGocritic initializes a new gocritic object,
 // but unlike newGocritic() it could use a cached version.
 func prepareGocritic() (*gocritic, error) {
 	if DisableCache {

--- a/checkers/internal/lintutil/astflow.go
+++ b/checkers/internal/lintutil/astflow.go
@@ -18,7 +18,7 @@ import (
 //
 // If proven really useful, can be moved to go-toolsmith library.
 
-// IsImmutable reports whether n can be midified through any operation.
+// IsImmutable reports whether n can be modified through any operation.
 func IsImmutable(info *types.Info, n ast.Expr) bool {
 	if astp.IsBasicLit(n) {
 		return true

--- a/checkers/mapKey_checker.go
+++ b/checkers/mapKey_checker.go
@@ -117,7 +117,7 @@ func (c *mapKeyChecker) checkWhitespace(lit *ast.CompositeLit) {
 }
 
 func (c *mapKeyChecker) warnWhitespace(key ast.Node) {
-	c.ctx.Warn(key, "suspucious whitespace in %s key", key)
+	c.ctx.Warn(key, "suspicious whitespace in %s key", key)
 }
 
 func (c *mapKeyChecker) warnDupKey(key ast.Node) {

--- a/checkers/testdata/builtinShadow/negative_tests.go
+++ b/checkers/testdata/builtinShadow/negative_tests.go
@@ -1,6 +1,6 @@
 package checker_test
 
-func noWarnigs() {
+func noWarnings() {
 	var foo struct {
 		len int
 		cap int

--- a/checkers/testdata/commentFormatting/positive_tests.go
+++ b/checkers/testdata/commentFormatting/positive_tests.go
@@ -15,7 +15,7 @@ package checker_test
 func f1() {
 	/*! put a space between `//` and comment text */
 	//block with
-	//sevaral lines
+	//several lines
 	//without leading space
 }
 

--- a/checkers/testdata/dynamicFmtString/positive_tests.go
+++ b/checkers/testdata/dynamicFmtString/positive_tests.go
@@ -5,7 +5,7 @@ import (
 )
 
 func fmtUndefinedFormatting() {
-	foo := "foo happend"
+	foo := "foo happened"
 	fooFunc := func(k string) (string, string) { return "", "123" }
 	var barFunc = func() string { return "123" }
 	/*! use errors.New(foo) or fmt.Errorf("%s", foo) instead */

--- a/checkers/testdata/evalOrder/positive_tests.go
+++ b/checkers/testdata/evalOrder/positive_tests.go
@@ -22,7 +22,7 @@ func (o object) cantMutate() int {
 	return o.val
 }
 
-func returnDepencency() {
+func returnDependency() {
 	var x int
 	var y int
 

--- a/checkers/testdata/mapKey/positive_tests.go
+++ b/checkers/testdata/mapKey/positive_tests.go
@@ -2,7 +2,7 @@ package checker_test
 
 func suspiciousWhitespace() {
 	_ = map[string]int{
-		/*! suspucious whitespace in `foo ` key */
+		/*! suspicious whitespace in `foo ` key */
 		`foo `: 1,
 		`bar`:  2,
 		`baz`:  3,
@@ -11,7 +11,7 @@ func suspiciousWhitespace() {
 	_ = map[string]int{
 		"foo": 1,
 		"bar": 2,
-		/*! suspucious whitespace in " baz" key */
+		/*! suspicious whitespace in " baz" key */
 		" baz": 3,
 	}
 
@@ -19,7 +19,7 @@ func suspiciousWhitespace() {
 
 	_ = myMap{
 		"foo": 1,
-		/*! suspucious whitespace in "bar " key */
+		/*! suspicious whitespace in "bar " key */
 		"bar ": 2,
 		"baz":  3,
 	}

--- a/checkers/testdata/rangeValCopy/positive_tests.go
+++ b/checkers/testdata/rangeValCopy/positive_tests.go
@@ -5,7 +5,7 @@ import (
 )
 
 type bigObject struct {
-	// Fields are carefuly selected to get equal struct size
+	// Fields are carefully selected to get equal struct size
 	// for both AMD64 and 386.
 
 	body [1024]byte

--- a/checkers/utils.go
+++ b/checkers/utils.go
@@ -260,7 +260,7 @@ func isUnitTestFunc(ctx *linter.CheckerContext, fn *ast.FuncDecl) bool {
 	return false
 }
 
-// qualifiedName returns called expr fully-quallified name.
+// qualifiedName returns called expr fully-qualified name.
 //
 // It works for simple identifiers like f => "f" and identifiers
 // from other package like pkg.f => "pkg.f".


### PR DESCRIPTION
This PR fixes typos in the warning message, comments, and testdata function names.