### PR TITLE
checkers: fix typo in externalErrorReassign description

### DIFF
--- a/checkers/rules/rules.go
+++ b/checkers/rules/rules.go
@@ -717,14 +717,14 @@ func badSorting(m dsl.Matcher) {
 		Report(`suspicious sort.StringSlice usage, maybe sort.Strings was intended?`)
 }
 
-//doc:summary Detects suspicious reassigment of error from another package
+//doc:summary Detects suspicious reassignment of error from another package
 //doc:tags    diagnostic experimental
 //doc:before  io.EOF = nil
 //doc:after   /* don't do it */
 func externalErrorReassign(m dsl.Matcher) {
 	m.Match(`$pkg.$err = $x`).
 		Where(m["err"].Type.Is(`error`) && m["pkg"].Object.Is(`PkgName`)).
-		Report(`suspicious reassigment of error from another package`)
+		Report(`suspicious reassignment of error from another package`)
 }
 
 //doc:summary Detects suspicious empty declarations blocks

--- a/checkers/rulesdata/rulesdata.go
+++ b/checkers/rulesdata/rulesdata.go
@@ -2342,13 +2342,13 @@ var PrecompiledRules = &ir.File{
 			Name:        "externalErrorReassign",
 			MatcherName: "m",
 			DocTags:     []string{"diagnostic", "experimental"},
-			DocSummary:  "Detects suspicious reassigment of error from another package",
+			DocSummary:  "Detects suspicious reassignment of error from another package",
 			DocBefore:   "io.EOF = nil",
 			DocAfter:    "/* don't do it */",
 			Rules: []ir.Rule{{
 				Line:           725,
 				SyntaxPatterns: []ir.PatternString{{Line: 725, Value: "$pkg.$err = $x"}},
-				ReportTemplate: "suspicious reassigment of error from another package",
+				ReportTemplate: "suspicious reassignment of error from another package",
 				WhereExpr: ir.FilterExpr{
 					Line: 726,
 					Op:   ir.FilterAndOp,

--- a/checkers/testdata/externalErrorReassign/positive_tests.go
+++ b/checkers/testdata/externalErrorReassign/positive_tests.go
@@ -8,9 +8,9 @@ import (
 )
 
 func _() {
-	/*! suspicious reassigment of error from another package */
+	/*! suspicious reassignment of error from another package */
 	examplepkg.FooError = nil
 
-	/*! suspicious reassigment of error from another package */
+	/*! suspicious reassignment of error from another package */
 	examplepkg.FooError = fmt.Errorf("your error is: %w", io.EOF)
 }

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -42,7 +42,7 @@ They also detect code that may be correct, but looks suspicious.
 |:white_check_mark:[emptyDecl](#emptydecl)|Detects suspicious empty declarations blocks|
 |:white_check_mark:[evalOrder](#evalorder)|Detects unwanted dependencies on the evaluation order|
 |:heavy_check_mark:[exitAfterDefer](#exitafterdefer)|Detects calls to exit/fatal inside functions that use defer|
-|:white_check_mark:[externalErrorReassign](#externalerrorreassign)|Detects suspicious reassigment of error from another package|
+|:white_check_mark:[externalErrorReassign](#externalerrorreassign)|Detects suspicious reassignment of error from another package|
 |:white_check_mark:[filepathJoin](#filepathjoin)|Detects problems in filepath.Join() function calls|
 |:heavy_check_mark:[flagDeref](#flagderef)|Detects immediate dereferencing of `flag` package pointers|
 |:heavy_check_mark:[flagName](#flagname)|Detects suspicious flag names|
@@ -1132,7 +1132,7 @@ type Foo struct{ ...; mu sync.Mutex; ... }
   **diagnostic**
   **experimental** ]
 
-Detects suspicious reassigment of error from another package.
+Detects suspicious reassignment of error from another package.
 
 
 


### PR DESCRIPTION
This PR corrects a typo in the description of the checker `externalErrorReassign`.