### PR TITLE
checkers/commentedOutCode: add minimum length of comment parameter.

### DIFF
--- a/checkers/checkers_test.go
+++ b/checkers/checkers_test.go
@@ -21,7 +21,8 @@ func init() {
 
 func TestCheckers(t *testing.T) {
 	allParams := map[string]map[string]interface{}{
-		"captLocal": {"paramsOnly": false},
+		"captLocal":        {"paramsOnly": false},
+		"commentedOutCode": {"minLength": 9},
 	}
 
 	for _, info := range linter.GetCheckersInfo() {

--- a/checkers/testdata/commentedOutCode/negative_tests.go
+++ b/checkers/testdata/commentedOutCode/negative_tests.go
@@ -77,4 +77,6 @@ func permittedComments() {
 	// //line directives with omitted filenames lead to empty filenames
 
 	/* CINC/CINV/CNEG */
+
+	// v := 世界
 }

--- a/checkers/testdata/commentedOutCode/positive_tests.go
+++ b/checkers/testdata/commentedOutCode/positive_tests.go
@@ -38,4 +38,7 @@ func multiLineCode() {
 	//rulebases.POST("/", postRsHandler)                                //create a rulebase
 	//rulebases.DELETE("/:id", deleteRsHandler)                         //delete a rulebase
 	//rulebases.PUT("/:setid", putRsHandler)                            //update a rulebase
+
+	/*! may want to remove commented-out code */
+	// v := 781
 }

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -582,6 +582,16 @@ foo(1, 2)
 ```
 
 
+Checker parameters:
+<ul>
+<li>
+
+  `@commentedOutCode.minLength` min length of the comment that triggers a warning (default 15)
+
+</li>
+
+</ul>
+
 ## commentedOutImport
 
 [


### PR DESCRIPTION
Implements go-critic#1244.