### PR TITLE
ci,docs: autogenerate docs (#1016)

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -1,0 +1,44 @@
+name: Doc
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  generate_doc:
+    name: generate_doc
+    runs-on: ubuntu-latest
+    env:
+      PATH_OVERVIEW: './docs/overview.md'
+    permissions:
+      contents: write
+
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v4
+        with:
+          ref: ${{ github.head_ref }}
+          go-version: stable
+          check-latest: true
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+
+      - name: Generate docs
+        run: |
+          make docs
+
+      - name: Commit into master
+        uses: stefanzweifel/git-auto-commit-action@v5
+        id: auto-commit-action
+        with:
+          commit_message: auto generate doc [bot]
+          file_pattern: ${{ env.PATH_OVERVIEW }}
+
+      - name: Dispatches if doc changed
+        if: steps.auto-commit-action.outputs.changes_detected == 'true'
+        run: |
+          gh auth login --with-token <<< "${{ secrets.PUSH_DOCS_TOKEN }}"
+          gh api repos/go-critic/go-critic.github.io/dispatches \
+            --field event_type='update_doc' \
+            --field client_payload[content]="$(xz -z --stdout ${{ env.PATH_OVERVIEW }} | base64)"


### PR DESCRIPTION
Autogenerate of doc into ci/cd

<details>
  <summary>Simple diagram</summary>
<img width="1404" alt="image" src="https://github.com/go-critic/go-critic/assets/31652715/bb526311-a9b3-4c90-acc2-99ae29e8df5e">
</details>

Need to add token into secrets.

In my case, tested on fine-grained personal access token with perms:
1. Read access to administration and metadata.
2. Read and Write access to code.


Close #1016
Related: https://github.com/go-critic/go-critic.github.io/pull/20