### PR TITLE
checkers: drop sloppyTestFuncName

### DIFF
--- a/checkers/rules/rules.go
+++ b/checkers/rules/rules.go
@@ -785,30 +785,6 @@ func uncheckedInlineErr(m dsl.Matcher) {
 		At(m["err"])
 }
 
-//doc:summary Detects unsupported test and benchmark funcs
-//doc:tags    diagnostic experimental
-//doc:before  func TessstUnit(t *testing.T)
-//doc:after   func TestUnit(t *testing.T)
-func sloppyTestFuncName(m dsl.Matcher) {
-	m.Match(`func $test($_ *testing.T) { $*_ }`).
-		Where(!m["test"].Text.Matches("Test.*") &&
-			!m["test"].Text.Matches("test.*")).
-		Report("function $test should be of form TestXXX(t *testing.T)")
-
-	m.Match(`func $bench($_ *testing.B) { $*_ }`).
-		Where(!m["bench"].Text.Matches("Benchmark.*") &&
-			!m["bench"].Text.Matches("bench.*")).
-		Report("function $bench should be of form BenchmarkXXX(b *testing.B)")
-
-	m.Match(`func $test($_ *testing.T) { $*_ }`).
-		Where(m["test"].Text.Matches("^test.*")).
-		Report("function $test looks like a test helper, consider to change 1st param to 'tb testing.TB'")
-
-	m.Match(`func $bench($_ *testing.B) { $*_ }`).
-		Where(m["bench"].Text.Matches("^bench(mark)?.*")).
-		Report("function $bench looks like a benchmark helper, consider to change 1st param to 'tb testing.TB'")
-}
-
 //doc:summary Detects bad usage of sync.OnceFunc
 //doc:tags    diagnostic experimental
 //doc:before  sync.OnceFunc(foo)()

--- a/checkers/rulesdata/rulesdata.go
+++ b/checkers/rulesdata/rulesdata.go
@@ -2526,113 +2526,6 @@ var PrecompiledRules = &ir.File{
 		},
 		{
 			Line:        792,
-			Name:        "sloppyTestFuncName",
-			MatcherName: "m",
-			DocTags:     []string{"diagnostic", "experimental"},
-			DocSummary:  "Detects unsupported test and benchmark funcs",
-			DocBefore:   "func TessstUnit(t *testing.T)",
-			DocAfter:    "func TestUnit(t *testing.T)",
-			Rules: []ir.Rule{
-				{
-					Line:           793,
-					SyntaxPatterns: []ir.PatternString{{Line: 793, Value: "func $test($_ *testing.T) { $*_ }"}},
-					ReportTemplate: "function $test should be of form TestXXX(t *testing.T)",
-					WhereExpr: ir.FilterExpr{
-						Line: 794,
-						Op:   ir.FilterAndOp,
-						Src:  "!m[\"test\"].Text.Matches(\"Test.*\") &&\n\t!m[\"test\"].Text.Matches(\"test.*\")",
-						Args: []ir.FilterExpr{
-							{
-								Line: 794,
-								Op:   ir.FilterNotOp,
-								Src:  "!m[\"test\"].Text.Matches(\"Test.*\")",
-								Args: []ir.FilterExpr{{
-									Line:  794,
-									Op:    ir.FilterVarTextMatchesOp,
-									Src:   "m[\"test\"].Text.Matches(\"Test.*\")",
-									Value: "test",
-									Args:  []ir.FilterExpr{{Line: 794, Op: ir.FilterStringOp, Src: "\"Test.*\"", Value: "Test.*"}},
-								}},
-							},
-							{
-								Line: 795,
-								Op:   ir.FilterNotOp,
-								Src:  "!m[\"test\"].Text.Matches(\"test.*\")",
-								Args: []ir.FilterExpr{{
-									Line:  795,
-									Op:    ir.FilterVarTextMatchesOp,
-									Src:   "m[\"test\"].Text.Matches(\"test.*\")",
-									Value: "test",
-									Args:  []ir.FilterExpr{{Line: 795, Op: ir.FilterStringOp, Src: "\"test.*\"", Value: "test.*"}},
-								}},
-							},
-						},
-					},
-				},
-				{
-					Line:           798,
-					SyntaxPatterns: []ir.PatternString{{Line: 798, Value: "func $bench($_ *testing.B) { $*_ }"}},
-					ReportTemplate: "function $bench should be of form BenchmarkXXX(b *testing.B)",
-					WhereExpr: ir.FilterExpr{
-						Line: 799,
-						Op:   ir.FilterAndOp,
-						Src:  "!m[\"bench\"].Text.Matches(\"Benchmark.*\") &&\n\t!m[\"bench\"].Text.Matches(\"bench.*\")",
-						Args: []ir.FilterExpr{
-							{
-								Line: 799,
-								Op:   ir.FilterNotOp,
-								Src:  "!m[\"bench\"].Text.Matches(\"Benchmark.*\")",
-								Args: []ir.FilterExpr{{
-									Line:  799,
-									Op:    ir.FilterVarTextMatchesOp,
-									Src:   "m[\"bench\"].Text.Matches(\"Benchmark.*\")",
-									Value: "bench",
-									Args:  []ir.FilterExpr{{Line: 799, Op: ir.FilterStringOp, Src: "\"Benchmark.*\"", Value: "Benchmark.*"}},
-								}},
-							},
-							{
-								Line: 800,
-								Op:   ir.FilterNotOp,
-								Src:  "!m[\"bench\"].Text.Matches(\"bench.*\")",
-								Args: []ir.FilterExpr{{
-									Line:  800,
-									Op:    ir.FilterVarTextMatchesOp,
-									Src:   "m[\"bench\"].Text.Matches(\"bench.*\")",
-									Value: "bench",
-									Args:  []ir.FilterExpr{{Line: 800, Op: ir.FilterStringOp, Src: "\"bench.*\"", Value: "bench.*"}},
-								}},
-							},
-						},
-					},
-				},
-				{
-					Line:           803,
-					SyntaxPatterns: []ir.PatternString{{Line: 803, Value: "func $test($_ *testing.T) { $*_ }"}},
-					ReportTemplate: "function $test looks like a test helper, consider to change 1st param to 'tb testing.TB'",
-					WhereExpr: ir.FilterExpr{
-						Line:  804,
-						Op:    ir.FilterVarTextMatchesOp,
-						Src:   "m[\"test\"].Text.Matches(\"^test.*\")",
-						Value: "test",
-						Args:  []ir.FilterExpr{{Line: 804, Op: ir.FilterStringOp, Src: "\"^test.*\"", Value: "^test.*"}},
-					},
-				},
-				{
-					Line:           807,
-					SyntaxPatterns: []ir.PatternString{{Line: 807, Value: "func $bench($_ *testing.B) { $*_ }"}},
-					ReportTemplate: "function $bench looks like a benchmark helper, consider to change 1st param to 'tb testing.TB'",
-					WhereExpr: ir.FilterExpr{
-						Line:  808,
-						Op:    ir.FilterVarTextMatchesOp,
-						Src:   "m[\"bench\"].Text.Matches(\"^bench(mark)?.*\")",
-						Value: "bench",
-						Args:  []ir.FilterExpr{{Line: 808, Op: ir.FilterStringOp, Src: "\"^bench(mark)?.*\"", Value: "^bench(mark)?.*"}},
-					},
-				},
-			},
-		},
-		{
-			Line:        816,
 			Name:        "badSyncOnceFunc",
 			MatcherName: "m",
 			DocTags:     []string{"diagnostic", "experimental"},
@@ -2641,22 +2534,22 @@ var PrecompiledRules = &ir.File{
 			DocAfter:    "fooOnce := sync.OnceFunc(foo); ...; fooOnce()",
 			Rules: []ir.Rule{
 				{
-					Line:           817,
-					SyntaxPatterns: []ir.PatternString{{Line: 817, Value: "$*_; sync.OnceFunc($x); $*_;"}},
+					Line:           793,
+					SyntaxPatterns: []ir.PatternString{{Line: 793, Value: "$*_; sync.OnceFunc($x); $*_;"}},
 					ReportTemplate: "possible sync.OnceFunc misuse, sync.OnceFunc($x) result is not used",
 					WhereExpr: ir.FilterExpr{
-						Line:  819,
+						Line:  795,
 						Op:    ir.FilterGoVersionGreaterEqThanOp,
 						Src:   "m.GoVersion().GreaterEqThan(\"1.21\")",
 						Value: "1.21",
 					},
 				},
 				{
-					Line:           821,
-					SyntaxPatterns: []ir.PatternString{{Line: 821, Value: "sync.OnceFunc($x)()"}},
+					Line:           797,
+					SyntaxPatterns: []ir.PatternString{{Line: 797, Value: "sync.OnceFunc($x)()"}},
 					ReportTemplate: "possible sync.OnceFunc misuse, consider to assign sync.OnceFunc($x) to a variable",
 					WhereExpr: ir.FilterExpr{
-						Line:  823,
+						Line:  799,
 						Op:    ir.FilterGoVersionGreaterEqThanOp,
 						Src:   "m.GoVersion().GreaterEqThan(\"1.21\")",
 						Value: "1.21",


### PR DESCRIPTION
Was merged too early and can be better, so better to delete for now (+test doc autogen feature 😉 )

Fixes #1350