### PR TITLE
checkers/unlambda: correct calculation amount args.

### DIFF
--- a/checkers/testdata/unlambda/negative_tests.go
+++ b/checkers/testdata/unlambda/negative_tests.go
@@ -128,3 +128,13 @@ func varFunc() {
 	var varfunc func(x int) int
 	_ = func(x int) int { return varfunc(x) }
 }
+
+func wrap(options ...string) error { return nil }
+
+var _ = func(options ...string) error {
+	return wrap(append(options, "timeout")...)
+}
+
+var _ = func(options ...string) error {
+	return wrap(append(append(append(options, "timeout")))...)
+}

--- a/checkers/testdata/unlambda/positive_tests.go
+++ b/checkers/testdata/unlambda/positive_tests.go
@@ -48,6 +48,9 @@ func variadicTest() {
 
 	_ = func(x int, ys ...int) int { return variadicInt(1, 2) }
 	_ = func(x int, y int, _ ...int) int { return variadicInt(x, y) }
+
+	/*! replace `func(options ...string) error { return wrap(append(append(append(options)))...) }` with `wrap` */
+	_ = func(options ...string) error { return wrap(append(append(append(options)))...) }
 }
 
 func variadicInterfaces(x int, y interface{}, ys ...interface{}) int { return 0 }

--- a/checkers/unlambda_checker.go
+++ b/checkers/unlambda_checker.go
@@ -91,11 +91,28 @@ func (c *unlambdaChecker) VisitExpr(x ast.Expr) {
 		}
 	}
 
-	if len(result.Args) == n {
+	if c.lenArgs(result.Args) == n {
 		c.warn(fn, callable)
 	}
 }
 
 func (c *unlambdaChecker) warn(cause ast.Node, suggestion string) {
 	c.ctx.Warn(cause, "replace `%s` with `%s`", cause, suggestion)
+}
+
+func (c *unlambdaChecker) lenArgs(args []ast.Expr) int {
+	lenArgs := len(args)
+
+	for _, arg := range args {
+		callExp, ok := arg.(*ast.CallExpr)
+		if !ok {
+			continue
+		}
+
+		// Don't count function call. only args.
+		lenArgs--
+		lenArgs += c.lenArgs(callExp.Args)
+	}
+
+	return lenArgs
 }


### PR DESCRIPTION
Count args of CallExpr.

Example: `a(b(1,2))` will be 2, not 1.

fixes #1362