### PR TITLE
checkers/sloppyLen: make it diagnostic check

### DIFF
--- a/checkers/rules/rules.go
+++ b/checkers/rules/rules.go
@@ -108,7 +108,7 @@ func preferDecodeRune(m dsl.Matcher) {
 }
 
 //doc:summary Detects usage of `len` when result is obvious or doesn't make sense
-//doc:tags    style
+//doc:tags    diagnostic
 //doc:before  len(arr) <= 0
 //doc:after   len(arr) == 0
 func sloppyLen(m dsl.Matcher) {

--- a/checkers/rulesdata/rulesdata.go
+++ b/checkers/rulesdata/rulesdata.go
@@ -363,7 +363,7 @@ var PrecompiledRules = &ir.File{
 			Line:        114,
 			Name:        "sloppyLen",
 			MatcherName: "m",
-			DocTags:     []string{"style"},
+			DocTags:     []string{"diagnostic"},
 			DocSummary:  "Detects usage of `len` when result is obvious or doesn't make sense",
 			DocBefore:   "len(arr) <= 0",
 			DocAfter:    "len(arr) == 0",


### PR DESCRIPTION
It's more a diagnostic check rather than style. First to cases are always const and 3rd is always non-zero which sounds like a diagnostic thing.

Touches `emptyStringTest` a bit.