### PR TITLE
docs: fix ruleguard parameters description

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2031,7 +2031,7 @@ Checker parameters:
 </li>
 <li>
 
-  `@ruleguard.enable` comma-separated list of enabled groups or skip empty to enable everything (default <all>)
+  `@ruleguard.enable` comma-separated list of enabled groups or skip empty to enable everything (default &lt;all&gt;)
 
 </li>
 <li>


### PR DESCRIPTION
This PR escapes `<all>` to fix the broken ruleguard's description on the [site](https://go-critic.com/overview.html#ruleguard):

<img width="600" alt="image" src="https://github.com/go-critic/go-critic/assets/3228886/1003f4bc-4071-4e6c-98ed-c8766d6262f4">
