### PR TITLE
checkers/commentFormatting: exclude GoLand and VSCode custom folding regions

### DIFF
--- a/checkers/commentFormatting_checker.go
+++ b/checkers/commentFormatting_checker.go
@@ -27,12 +27,16 @@ func init() {
 			"//nolint",
 		}
 		parts := []string{
-			"//go:generate ",  // e.g.: go:generate value
-			"//line /",        // e.g.: line /path/to/file:123
-			"//nolint ",       // e.g.: nolint
-			"//noinspection ", // e.g.: noinspection ALL, some GoLand and friends versions
-			"//export ",       // e.g.: export Foo
-			"///",             // e.g.: vertical breaker /////////////
+			"//go:generate ",   // e.g.: go:generate value
+			"//line /",         // e.g.: line /path/to/file:123
+			"//nolint ",        // e.g.: nolint
+			"//noinspection ",  // e.g.: noinspection ALL, some GoLand and friends versions
+			"//region",         // e.g.: region awawa, used by GoLand and friends for custom folding
+			"//endregion",      // e.g.: endregion awawa or endregion, closes GoLand regions
+			"//<editor-fold",   // e.g.: <editor-fold desc="awawa"> or <editor-fold>, used by VSCode for custom folding
+			"//</editor-fold>", // e.g.: </editor-fold>, closes VSCode regions
+			"//export ",        // e.g.: export Foo
+			"///",              // e.g.: vertical breaker /////////////
 			"//+",
 			"//#",
 			"//-",

--- a/checkers/testdata/commentFormatting/negative_tests.go
+++ b/checkers/testdata/commentFormatting/negative_tests.go
@@ -63,3 +63,13 @@ func f2() {
 
 // Comment in a comment is //OK
 // path */*//with asterisk
+
+//region GoLand custom folding region
+func goland() {
+}
+//endregion
+
+//<editor-fold desc="VSCode custom folding region">
+func vscode() {
+}
+//</editor-fold>


### PR DESCRIPTION
For editor documentation, see:
- https://www.jetbrains.com/help/go/code-folding-settings.html#fold-by-default-section
- https://code.visualstudio.com/docs/editor/codebasics#_folding