### PR TITLE
Add built-in min and max functions

### DIFF
--- a/checkers/utils.go
+++ b/checkers/utils.go
@@ -223,6 +223,8 @@ var goBuiltins = map[string]bool{
 	"imag":    true,
 	"len":     true,
 	"make":    true,
+	"min":     true,
+	"max":     true,
 	"new":     true,
 	"panic":   true,
 	"print":   true,


### PR DESCRIPTION
Go 1.21 added min and max built-in functions.

This fixes #762 for min, max built-ins and more.