### PR TITLE
checkers: add rangeAppendAll

### DIFF
--- a/checkers/rangeAppendAll_checker.go
+++ b/checkers/rangeAppendAll_checker.go
@@ -1,0 +1,102 @@
+package checkers
+
+import (
+	"go/ast"
+	"go/token"
+
+	"github.com/go-critic/go-critic/checkers/internal/astwalk"
+	"github.com/go-critic/go-critic/linter"
+	"github.com/go-toolsmith/astcast"
+	"golang.org/x/tools/go/ast/astutil"
+)
+
+func init() {
+	var info linter.CheckerInfo
+	info.Name = "rangeAppendAll"
+	info.Tags = []string{linter.DiagnosticTag, linter.ExperimentalTag}
+	info.Summary = "Detects append all its data while range it"
+	info.Summary = "Detects suspicious sort.Slice calls"
+	info.Before = `for _, n := range ns {
+	...
+		rs = append(rs, ns...) // append all slice data
+	}
+}`
+	info.After = `for _, n := range ns {
+	...
+		rs = append(rs, n)
+	}
+}`
+
+	collection.AddChecker(&info, func(ctx *linter.CheckerContext) (linter.FileWalker, error) {
+		c := &rangeAppendAllChecker{ctx: ctx}
+		return astwalk.WalkerForStmt(c), nil
+	})
+}
+
+type rangeAppendAllChecker struct {
+	astwalk.WalkHandler
+	ctx *linter.CheckerContext
+}
+
+func (c *rangeAppendAllChecker) VisitStmt(stmt ast.Stmt) {
+	rangeStmt, ok := stmt.(*ast.RangeStmt)
+	if !ok || len(rangeStmt.Body.List) == 0 {
+		return
+	}
+	rangeIdent, ok := rangeStmt.X.(*ast.Ident)
+	if !ok {
+		return
+	}
+	rangeObj := c.ctx.TypesInfo.ObjectOf(rangeIdent)
+
+	astutil.Apply(rangeStmt.Body, nil, func(cur *astutil.Cursor) bool {
+		appendFrom := c.getValidAppendFrom(cur.Node())
+		if appendFrom != nil {
+			appendFromObj := c.ctx.TypesInfo.ObjectOf(appendFrom)
+			if appendFromObj == rangeObj {
+				c.warn(appendFrom)
+			}
+		}
+		return true
+	})
+}
+
+func (c *rangeAppendAllChecker) getValidAppendFrom(expr ast.Node) *ast.Ident {
+	call := astcast.ToCallExpr(expr)
+	if len(call.Args) != 2 || call.Ellipsis == token.NoPos {
+		return nil
+	}
+	if qualifiedName(call.Fun) != "append" {
+		return nil
+	}
+	if c.isFirstArgInitSlice(call.Args[0]) {
+		return nil
+	}
+	appendFrom, ok := call.Args[1].(*ast.Ident)
+	if !ok {
+		return nil
+	}
+	return appendFrom
+}
+
+func (c *rangeAppendAllChecker) isFirstArgInitSlice(arg ast.Expr) bool {
+	switch v := arg.(type) {
+	// []T{}, []T{n}
+	case *ast.CompositeLit:
+		return true
+	// []T(nil)
+	case *ast.CallExpr:
+		if astcast.ToArrayType(v.Fun) != astcast.NilArrayType && len(v.Args) == 1 {
+			id := astcast.ToIdent(v.Args[0])
+			if id.Name == "nil" && id.Obj == nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (c *rangeAppendAllChecker) warn(appendFrom *ast.Ident) {
+	c.ctx.Warn(appendFrom, "append all `%s` data while range it",
+		appendFrom)
+}

--- a/checkers/rangeAppendAll_checker.go
+++ b/checkers/rangeAppendAll_checker.go
@@ -90,8 +90,10 @@ func (c *rangeAppendAllChecker) isFirstArgInitSlice(arg ast.Expr) bool {
 			id := astcast.ToIdent(v.Args[0])
 			return id.Name == "nil" && id.Obj == nil
 		}
+		return false
+	default:
+		return false
 	}
-	return false
 }
 
 func (c *rangeAppendAllChecker) warn(appendFrom *ast.Ident) {

--- a/checkers/rangeAppendAll_checker.go
+++ b/checkers/rangeAppendAll_checker.go
@@ -15,7 +15,6 @@ func init() {
 	info.Name = "rangeAppendAll"
 	info.Tags = []string{linter.DiagnosticTag, linter.ExperimentalTag}
 	info.Summary = "Detects append all its data while range it"
-	info.Summary = "Detects suspicious sort.Slice calls"
 	info.Before = `for _, n := range ns {
 	...
 		rs = append(rs, ns...) // append all slice data

--- a/checkers/rangeAppendAll_checker.go
+++ b/checkers/rangeAppendAll_checker.go
@@ -68,7 +68,7 @@ func (c *rangeAppendAllChecker) getValidAppendFrom(expr ast.Node) *ast.Ident {
 	if qualifiedName(call.Fun) != "append" {
 		return nil
 	}
-	if c.isFirstArgInitSlice(call.Args[0]) {
+	if c.isSliceLiteral(call.Args[0]) {
 		return nil
 	}
 	appendFrom, ok := call.Args[1].(*ast.Ident)
@@ -78,7 +78,7 @@ func (c *rangeAppendAllChecker) getValidAppendFrom(expr ast.Node) *ast.Ident {
 	return appendFrom
 }
 
-func (c *rangeAppendAllChecker) isFirstArgInitSlice(arg ast.Expr) bool {
+func (c *rangeAppendAllChecker) isSliceLiteral(arg ast.Expr) bool {
 	switch v := arg.(type) {
 	// []T{}, []T{n}
 	case *ast.CompositeLit:

--- a/checkers/rangeAppendAll_checker.go
+++ b/checkers/rangeAppendAll_checker.go
@@ -88,9 +88,7 @@ func (c *rangeAppendAllChecker) isFirstArgInitSlice(arg ast.Expr) bool {
 	case *ast.CallExpr:
 		if astcast.ToArrayType(v.Fun) != astcast.NilArrayType && len(v.Args) == 1 {
 			id := astcast.ToIdent(v.Args[0])
-			if id.Name == "nil" && id.Obj == nil {
-				return true
-			}
+			return id.Name == "nil" && id.Obj == nil
 		}
 	}
 	return false

--- a/checkers/rangeAppendAll_checker.go
+++ b/checkers/rangeAppendAll_checker.go
@@ -95,6 +95,5 @@ func (c *rangeAppendAllChecker) isFirstArgInitSlice(arg ast.Expr) bool {
 }
 
 func (c *rangeAppendAllChecker) warn(appendFrom *ast.Ident) {
-	c.ctx.Warn(appendFrom, "append all `%s` data while range it",
-		appendFrom)
+	c.ctx.Warn(appendFrom, "append all `%s` data while range it", appendFrom)
 }

--- a/checkers/testdata/rangeAppendAll/negative_tests.go
+++ b/checkers/testdata/rangeAppendAll/negative_tests.go
@@ -1,0 +1,18 @@
+package checker_test
+
+func collectWithNil(ns []string, k int) bool {
+	rs := make([]string, 0)
+	rs2 := make([]string, 0)
+	rs3 := make([]string, 0)
+	for _, n := range ns {
+		if len(n) > k {
+			rs = append([]string{n}, ns...)
+			rs2 = append([]string{}, ns...)
+			rs3 = append([]string(nil), ns...)
+		}
+	}
+	if len(rs) > 0 || len(rs2) > 0 || len(rs3) > 0 {
+		return true
+	}
+	return false
+}

--- a/checkers/testdata/rangeAppendAll/positive_tests.go
+++ b/checkers/testdata/rangeAppendAll/positive_tests.go
@@ -22,6 +22,19 @@ func collectLong(ns []string, k int) []string {
 	return rs
 }
 
+func someFuncCall(n int) {
+}
+
+func collectBasic(ns []int, k int) []int {
+	rs := make([]int, 0)
+	for _, n := range ns {
+		someFuncCall(n)
+		/*! append all `ns` data while range it */
+		rs = append(rs, ns...)
+	}
+	return rs
+}
+
 func collectLongCorrect(ns []string, k int) []string {
 	rs := make([]string, 0)
 	n := ns[0]

--- a/checkers/testdata/rangeAppendAll/positive_tests.go
+++ b/checkers/testdata/rangeAppendAll/positive_tests.go
@@ -1,0 +1,36 @@
+package checker_test
+
+func collectBigger(ns []int, k int) []int {
+	rs := make([]int, 0)
+	for _, n := range ns {
+		if n > k {
+			/*! append all `ns` data while range it */
+			rs = append(rs, ns...)
+		}
+	}
+	return rs
+}
+
+func collectLong(ns []string, k int) []string {
+	rs := make([]string, 0)
+	for _, n := range ns {
+		if len(n) > k {
+			/*! append all `ns` data while range it */
+			rs = append(rs, ns...)
+		}
+	}
+	return rs
+}
+
+func collectLongCorrect(ns []string, k int) []string {
+	rs := make([]string, 0)
+	n := ns[0]
+	rs = append(rs, n)
+	for _, n := range ns {
+		if len(n) > k {
+			rs = append(rs, n)
+		}
+	}
+	rs = append(rs, ns...)
+	return rs
+}


### PR DESCRIPTION
This is a bug I discovered during work.

append all its data while range over it is generally not the intended behavior and can lead to duplicate data.

```go
for _, n := range ns {
    ...
    rs = append(rs, n)     // OK
    rs = append(rs, ns...) // Bug
    ...
}
```

I implemented the checker firstly in my repo and use the [go-linter-runner](https://github.com/alingse/go-linter-runner) github  action to scan top 10k Go repos.  This found real bugs, documented in https://github.com/alingse/sundrylint/issues/1 

