### PR TITLE
checkers: remove outdated build constraint

### DIFF
--- a/checkers/rules/precompile.go
+++ b/checkers/rules/precompile.go
@@ -1,5 +1,4 @@
 //go:build generate
-// +build generate
 
 package main
 

--- a/checkers/testdata/_integration/ruleguard-glob/rules1.go
+++ b/checkers/testdata/_integration/ruleguard-glob/rules1.go
@@ -1,4 +1,4 @@
-// +build ignore
+//go:build ignore
 
 package gorules
 

--- a/checkers/testdata/_integration/ruleguard-glob/rules2.go
+++ b/checkers/testdata/_integration/ruleguard-glob/rules2.go
@@ -1,4 +1,4 @@
-// +build ignore
+//go:build ignore
 
 package gorules
 

--- a/checkers/testdata/_integration/ruleguard-multi/rules1.go
+++ b/checkers/testdata/_integration/ruleguard-multi/rules1.go
@@ -1,4 +1,4 @@
-// +build ignore
+//go:build ignore
 
 package gorules
 

--- a/checkers/testdata/_integration/ruleguard-multi/rules2.go
+++ b/checkers/testdata/_integration/ruleguard-multi/rules2.go
@@ -1,4 +1,4 @@
-// +build ignore
+//go:build ignore
 
 package gorules
 

--- a/checkers/testdata/_integration/ruleguard/rules.go
+++ b/checkers/testdata/_integration/ruleguard/rules.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package gorules
 

--- a/checkers/testdata/hugeParam/negative_tests_go118.go
+++ b/checkers/testdata/hugeParam/negative_tests_go118.go
@@ -1,5 +1,4 @@
 //go:build go1.18
-// +build go1.18
 
 package checker_test
 

--- a/checkers/testdata/newDeref/negative_tests118.go
+++ b/checkers/testdata/newDeref/negative_tests118.go
@@ -1,5 +1,4 @@
 //go:build go1.18
-// +build go1.18
 
 package checker_test
 

--- a/checkers/testdata/paramTypeCombine/negative_tests_go118.go
+++ b/checkers/testdata/paramTypeCombine/negative_tests_go118.go
@@ -1,5 +1,4 @@
 //go:build go1.18
-// +build go1.18
 
 package checker_test
 

--- a/checkers/testdata/paramTypeCombine/positive_tests_go118.go
+++ b/checkers/testdata/paramTypeCombine/positive_tests_go118.go
@@ -1,5 +1,4 @@
 //go:build go1.18
-// +build go1.18
 
 package checker_test
 

--- a/checkers/testdata/typeDefFirst/negative_tests_go118.go
+++ b/checkers/testdata/typeDefFirst/negative_tests_go118.go
@@ -1,5 +1,4 @@
 //go:build go1.18
-// +build go1.18
 
 package checker_test
 

--- a/checkers/testdata/typeDefFirst/positive_tests_go118.go
+++ b/checkers/testdata/typeDefFirst/positive_tests_go118.go
@@ -1,5 +1,4 @@
 //go:build go1.18
-// +build go1.18
 
 package checker_test
 

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,5 +1,4 @@
 //go:build tools
-// +build tools
 
 package critic
 


### PR DESCRIPTION
This PR removes outdated in Go 1.18 `// +build` comments. According to the https://pkg.go.dev/cmd/go#hdr-Build_constraints:

> Go versions 1.16 and earlier used a different syntax for build constraints, with a "// +build" prefix. The gofmt command will add an equivalent //go:build constraint when encountering the older syntax.