### PR TITLE
docs: fix links to Go wiki

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ a typo or missing doc comment. You can also filter issues by using
 
 **s/foo/bar/g** — replace foo with bar throughout your entire change
 
-See [CodeReview](https://github.com/golang/go/wiki/CodeReview).
+See [CodeReview](https://go.dev/wiki/CodeReview).
 
 ### Code review: main rules
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ We're using an optimistic merging strategy most of the time.
 In short, this means that if your contribution has some flaws, we can still merge it and then
 fix them by ourselves. Experimental and work-in-progress checkers are isolated, so nothing bad will happen.
 
-Code style is the same as in Go project, see [CodeReviewComments](https://github.com/golang/go/wiki/codereviewcomments).
+Code style is the same as in Go project, see [CodeReviewComments](https://go.dev/wiki/CodeReviewComments).
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
 It also describes how to develop a new checker for the linter.

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -3,7 +3,7 @@
 
 package critic
 
-// See https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module.
+// See https://go.dev/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module.
 
 import (
 	// Used for CI linting.


### PR DESCRIPTION
The Go wiki on GitHub has migrated to go.dev [#61940](https://go.dev/issues/61940).