### PR TITLE
dev: enable back golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,21 +1,19 @@
 {
   "run": {
     # timeout for analysis, e.g. 30s, 5m, default is 1m
-    "deadline": "3m",
-    "skip-dirs": ["checkers/rules"],
+    "timeout": "3m",
   },
-  "fast": false,
   "linters": {
+    "fast": false,
     "enable": [
       "errcheck",
-      "gas",
+      "gosec",
       "gocritic",
       "gofmt",
       "goimports",
       "gosimple",
       "govet",
       "ineffassign",
-      "megacheck",
       "misspell",
       "nakedret",
       "revive",
@@ -47,4 +45,7 @@
       },
     },
   },
+  "issues": {
+    "exclude-dirs": ["checkers/rules"],
+  }
 }

--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,8 @@ ci-generate:
 	@git diff --exit-code --quiet || (echo "Please run 'go generate ./...' to update precompiled rules."; false)
 
 ci-linter:
-	# TODO(cristaloleg): enable back
-	# @curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH_DIR)/bin v1.54.0
-	# @$(GOPATH_DIR)/bin/golangci-lint run
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH_DIR)/bin v1.59.1
+	@$(GOPATH_DIR)/bin/golangci-lint run
 	# cd tools && go install github.com/quasilyte/go-consistent
 	# @$(GOPATH_DIR)/bin/go-consistent ./...
 	go build -o gocritic ./cmd/gocritic

--- a/checkers/caseOrder_checker.go
+++ b/checkers/caseOrder_checker.go
@@ -82,7 +82,7 @@ func (c *caseOrderChecker) warnUnknownType(cause, concrete ast.Node) {
 	c.ctx.Warn(cause, "type is not defined %s", concrete)
 }
 
-func (c *caseOrderChecker) checkSwitch(s *ast.SwitchStmt) {
+func (c *caseOrderChecker) checkSwitch(_ *ast.SwitchStmt) {
 	// TODO(quasilyte): can handle expression cases that overlap.
 	// Cases that have narrower value range should go before wider ones.
 }

--- a/checkers/internal/astwalk/walk_handler.go
+++ b/checkers/internal/astwalk/walk_handler.go
@@ -17,7 +17,7 @@ type WalkHandler struct {
 
 // EnterFile is a default walkerEvents.EnterFile implementation
 // that reports every file as accepted candidate for checking.
-func (w *WalkHandler) EnterFile(f *ast.File) bool {
+func (w *WalkHandler) EnterFile(_ *ast.File) bool {
 	return true
 }
 

--- a/checkers/ruleguard_checker.go
+++ b/checkers/ruleguard_checker.go
@@ -87,7 +87,7 @@ func newErrorHandler(failOnErrorFlag string) (*parseErrorHandler, error) {
 	failOnErrorPredicates := map[string]func(error) bool{
 		"dsl":    func(err error) bool { var e *ruleguard.ImportError; return !errors.As(err, &e) },
 		"import": func(err error) bool { var e *ruleguard.ImportError; return errors.As(err, &e) },
-		"all":    func(err error) bool { return true },
+		"all":    func(_ error) bool { return true },
 	}
 	for _, k := range strings.Split(failOnErrorFlag, ",") {
 		if k == "" {

--- a/cmd/gocritic/check.go
+++ b/cmd/gocritic/check.go
@@ -162,11 +162,10 @@ func (p *program) checkFile(f *ast.File) {
 				if err, ok := r.(error); ok {
 					log.Printf("%s: error: %v\n", c.Info.Name, err)
 					panic(err)
-				} else {
-					// Some other kind of run-time panic.
-					// Undo the recover and resume panic.
-					panic(r)
 				}
+				// Some other kind of run-time panic.
+				// Undo the recover and resume panic.
+				panic(r)
 			}()
 
 			warnings[i] = append(warnings[i], c.Check(f)...)

--- a/cmd/makedocs/main.go
+++ b/cmd/makedocs/main.go
@@ -35,7 +35,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("render template: %v", err)
 	}
-	
+
 	// A bit hacky but works, see https://github.com/go-critic/go-critic/pull/1403.
 	buff := bytes.ReplaceAll(buf.Bytes(), []byte("<all>"), []byte("&lt;all&gt;"))
 

--- a/linter/helpers.go
+++ b/linter/helpers.go
@@ -116,7 +116,7 @@ func validateCheckerName(info *CheckerInfo) error {
 	return nil
 }
 
-func validateCheckerDocumentation(info *CheckerInfo) error {
+func validateCheckerDocumentation(_ *CheckerInfo) error {
 	// TODO(quasilyte): validate documentation.
 	return nil
 }


### PR DESCRIPTION
The PR enables linting via golangci-lint. It was previously disabled in #1360.

Also, this PR upgrades golangci-lint to the latest version v1.59.1, fixes configuration warnings and appeared lint issues.