### PR TITLE
chore: fix CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,17 +22,14 @@
       "unparam",
       "unused",
     ],
+    "disable": [
+      "depguard",
+      "dupl",
+      "gocyclo",
+      "lll",
+      "prealloc",
+    ],
   },
-  "disable": [
-    "depguard",
-    "dupl",
-    "gocyclo",
-    "interfacer",
-    "lll",
-    "maligned",
-    "prealloc",
-    "typecheck",
-  ],
   "linters-settings": {
     "gocritic": {
       "enabled-checks": [
@@ -44,6 +41,9 @@
         },
       },
     },
+    "gosec": {
+      "excludes": ["G115"]
+    }
   },
   "issues": {
     "exclude-dirs": ["checkers/rules"],

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ ci-generate:
 	@git diff --exit-code --quiet || (echo "Please run 'go generate ./...' to update precompiled rules."; false)
 
 ci-linter:
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH_DIR)/bin v1.59.1
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH_DIR)/bin v1.60.2
 	@$(GOPATH_DIR)/bin/golangci-lint run
 	# cd tools && go install github.com/quasilyte/go-consistent
 	# @$(GOPATH_DIR)/bin/go-consistent ./...


### PR DESCRIPTION
- update golangci-lint to v1.60.2 (go1.23 support)
- fix golangci-lint configuration

You will maybe need this update of ruleguard: https://github.com/quasilyte/go-ruleguard/pull/479