### PR TITLE
checkers/hugeParam: fix: ast.FuncDecl.Type.Results could be nil when checking for String()

### DIFF
--- a/checkers/hugeParam_checker.go
+++ b/checkers/hugeParam_checker.go
@@ -56,6 +56,7 @@ func (*hugeParamChecker) isImplementStringer(decl *ast.FuncDecl) bool {
 	if decl.Recv != nil &&
 		decl.Name.Name == "String" &&
 		decl.Type != nil &&
+		decl.Type.Params.List != nil && decl.Type.Results.List != nil &&
 		len(decl.Type.Params.List) == 0 &&
 		len(decl.Type.Results.List) == 1 &&
 		astcast.ToIdent(decl.Type.Results.List[0].Type).Name == "string" {

--- a/checkers/hugeParam_checker.go
+++ b/checkers/hugeParam_checker.go
@@ -56,9 +56,8 @@ func (*hugeParamChecker) isImplementStringer(decl *ast.FuncDecl) bool {
 	if decl.Recv != nil &&
 		decl.Name.Name == "String" &&
 		decl.Type != nil &&
-		decl.Type.Params.List != nil && decl.Type.Results.List != nil &&
 		len(decl.Type.Params.List) == 0 &&
-		decl.Type.Results.List != nil && //
+		decl.Type.Results != nil &&
 		len(decl.Type.Results.List) == 1 &&
 		astcast.ToIdent(decl.Type.Results.List[0].Type).Name == "string" {
 		return true
@@ -66,7 +65,6 @@ func (*hugeParamChecker) isImplementStringer(decl *ast.FuncDecl) bool {
 
 	return false
 }
-
 func (c *hugeParamChecker) checkParams(params []*ast.Field) {
 	for _, p := range params {
 		for _, id := range p.Names {

--- a/checkers/hugeParam_checker.go
+++ b/checkers/hugeParam_checker.go
@@ -65,6 +65,7 @@ func (*hugeParamChecker) isImplementStringer(decl *ast.FuncDecl) bool {
 
 	return false
 }
+
 func (c *hugeParamChecker) checkParams(params []*ast.Field) {
 	for _, p := range params {
 		for _, id := range p.Names {

--- a/checkers/hugeParam_checker.go
+++ b/checkers/hugeParam_checker.go
@@ -58,6 +58,7 @@ func (*hugeParamChecker) isImplementStringer(decl *ast.FuncDecl) bool {
 		decl.Type != nil &&
 		decl.Type.Params.List != nil && decl.Type.Results.List != nil &&
 		len(decl.Type.Params.List) == 0 &&
+		decl.Type.Results.List != nil && //
 		len(decl.Type.Results.List) == 1 &&
 		astcast.ToIdent(decl.Type.Results.List[0].Type).Name == "string" {
 		return true

--- a/checkers/rulesdata/rulesdata.go
+++ b/checkers/rulesdata/rulesdata.go
@@ -2518,3 +2518,4 @@ var PrecompiledRules = &ir.File{
 		},
 	},
 }
+

--- a/checkers/rulesdata/rulesdata.go
+++ b/checkers/rulesdata/rulesdata.go
@@ -2518,4 +2518,3 @@ var PrecompiledRules = &ir.File{
 		},
 	},
 }
-


### PR DESCRIPTION
Hello,
This will fix a panic when you run go critic with hugeParam and scan a function that is named String, but does not return any value.

The document state the Results could be nil, this change will check for the nil before checking the length.
https://pkg.go.dev/go/ast#FuncType

Please let me know if you need me to write a test or fix anything else.

Thank you again for writing this tool!

example code that when ran with `./gocritic check -enable=hugeParam` will panic
```go
package main

type foo struct {}

func (foo) String() {
  // Empty
}

func main() {
  f := foo{}
  f.String()
}
```