### PR TITLE
 checkers/rules/rules.go:dynamicFmtString: fix advice doc string for issue 1381

### DIFF
--- a/checkers/rules/rules.go
+++ b/checkers/rules/rules.go
@@ -728,7 +728,7 @@ func emptyDecl(m dsl.Matcher) {
 //doc:summary Detects suspicious formatting strings usage
 //doc:tags    diagnostic experimental
 //doc:before  fmt.Errorf(msg)
-//doc:after   fmt.Errorf("%s", msg)
+//doc:after   errors.New(mesg) or fmt.Errorf("%s", msg)
 func dynamicFmtString(m dsl.Matcher) {
 	m.Match(`fmt.Errorf($f)`).
 		Where(!m["f"].Const).

--- a/checkers/rulesdata/rulesdata.go
+++ b/checkers/rulesdata/rulesdata.go
@@ -2364,7 +2364,7 @@ var PrecompiledRules = &ir.File{
 			DocTags:     []string{"diagnostic", "experimental"},
 			DocSummary:  "Detects suspicious formatting strings usage",
 			DocBefore:   "fmt.Errorf(msg)",
-			DocAfter:    "fmt.Errorf(\"%s\", msg)",
+			DocAfter:    "errors.New(mesg) or fmt.Errorf(\"%s\", msg)",
 			Rules: []ir.Rule{
 				{
 					Line:            733,

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -917,7 +917,7 @@ fmt.Errorf(msg)
 
 **After:**
 ```go
-fmt.Errorf("%s", msg)
+errors.New(mesg) or fmt.Errorf("%s", msg)
 ```
 
 


### PR DESCRIPTION
Hello,
If this PR is requested I believe it will fix the issue reported [here](https://github.com/go-critic/go-critic/issues/1381).

Please let me know if there is anything else I can update (e.g. alter .github/workflow/doc.yaml to fail if go generate wasn't ran and a diff is detected).