### PR TITLE
deps: bump x/tools to 0.30.0 to support Go 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-critic/go-critic
 
-go 1.18
+go 1.22.0
 
 require (
 	github.com/cristalhq/acmd v0.12.0
@@ -16,13 +16,13 @@ require (
 	github.com/quasilyte/go-ruleguard v0.4.2
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22
 	github.com/quasilyte/regex/syntax v0.0.0-20210819130434-b3f0c404a727
-	golang.org/x/tools v0.23.0
+	golang.org/x/tools v0.30.0
 )
 
 require (
 	github.com/quasilyte/gogrep v0.5.0 // indirect
 	github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20240213143201-ec583247a57a // indirect
-	golang.org/x/mod v0.19.0 // indirect
-	golang.org/x/sync v0.7.0 // indirect
+	golang.org/x/mod v0.23.0 // indirect
+	golang.org/x/sync v0.11.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -36,9 +36,9 @@ golang.org/x/exp/typeparams v0.0.0-20220428152302-39d4317da171/go.mod h1:AbB0pIl
 golang.org/x/exp/typeparams v0.0.0-20230203172020-98cc5a0785f9/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/exp/typeparams v0.0.0-20240213143201-ec583247a57a h1:rrd/FiSCWtI24jk057yBSfEfHrzzjXva1VkDNWRXMag=
 golang.org/x/exp/typeparams v0.0.0-20240213143201-ec583247a57a/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
-golang.org/x/mod v0.19.0 h1:fEdghXQSo20giMthA7cd28ZC+jts4amQ3YMXiP5oMQ8=
-golang.org/x/mod v0.19.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
-golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
-golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
-golang.org/x/tools v0.23.0 h1:SGsXPZ+2l4JsgaCKkx+FQ9YZ5XEtA1GZYuoDjenLjvg=
-golang.org/x/tools v0.23.0/go.mod h1:pnu6ufv6vQkll6szChhK3C3L/ruaIv5eBeztNG8wtsI=
+golang.org/x/mod v0.23.0 h1:Zb7khfcRGKk+kqfxFaP5tZqCnDZMjC5VtUBs87Hr6QM=
+golang.org/x/mod v0.23.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
+golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/tools v0.30.0 h1:BgcpHewrV5AUp2G9MebG4XPFI1E2W41zU1SaqVA9vJY=
+golang.org/x/tools v0.30.0/go.mod h1:c347cR/OJfw5TI+GfX7RUPNMdDRRbjvYTS0jPyvsVtY=


### PR DESCRIPTION
This PR fixes the problem with building go-critic on Homebrew/homebrew-core#201070 with Go 1.24. Also, it fixes failing tests.

> go-critic: [test failure](https://github.com/Homebrew/homebrew-core/actions/runs/12321762564/job/34395107957?pr=201070#step:4:392): Minitest::Assertion: Expected /sloppyLen:\ len\(str\)\ <=\ 0\ can\ be\ len\(str\)\ ==\ 0/ to match "internal error: package \"fmt\" without types was imported from \"command-line-arguments\"\n".

```sh
$ go version
go version go1.24.0 darwin/arm64
$ go test ./...
?       github.com/go-critic/go-critic  [no test files]
2025/02/12 14:55:19 internal error: package "bytes" without types was imported from "github.com/go-critic/go-critic/checkers/testdata/argOrder"
FAIL    github.com/go-critic/go-critic/checkers 4.654s
?       github.com/go-critic/go-critic/checkers/analyzer        [no test files]
?       github.com/go-critic/go-critic/checkers/internal/astwalk        [no test files]
?       github.com/go-critic/go-critic/checkers/internal/linttest       [no test files]
?       github.com/go-critic/go-critic/checkers/internal/lintutil       [no test files]
?       github.com/go-critic/go-critic/checkers/rules   [no test files]
?       github.com/go-critic/go-critic/checkers/rulesdata       [no test files]
ok      github.com/go-critic/go-critic/cmd/gocritic     (cached)
?       github.com/go-critic/go-critic/cmd/gocritic-analysis    [no test files]
?       github.com/go-critic/go-critic/cmd/makedocs     [no test files]
ok      github.com/go-critic/go-critic/linter   (cached)
ok      github.com/go-critic/go-critic/rulestest        1.303s
FAIL
```

This update is done by hand because @dependabot can't update the Go version in `go.mod`.

Diff: https://github.com/golang/tools/compare/v0.23.0...v0.30.0

Closes #1436