### PR TITLE
dev: enable copyloopvar and usetesting linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@
   "linters": {
     "fast": false,
     "enable": [
+      "copyloopvar",
       "errcheck",
       "gosec",
       "gocritic",
@@ -21,6 +22,7 @@
       "unconvert",
       "unparam",
       "unused",
+      "usetesting",
     ],
     "disable": [
       "depguard",
@@ -43,7 +45,10 @@
     },
     "gosec": {
       "excludes": ["G115"]
-    }
+    },
+    "usetesting": {
+      "os-temp-dir": true,
+    },
   },
   "issues": {
     "exclude-dirs": ["checkers/rules"],

--- a/checkers/analyzer/run.go
+++ b/checkers/analyzer/run.go
@@ -40,7 +40,6 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	for _, f := range pass.Files {
-		f := f
 		filename := filepath.Base(pass.Fset.Position(f.Pos()).Filename)
 		ctx.SetFileInfo(filename, f)
 

--- a/checkers/checkers_test.go
+++ b/checkers/checkers_test.go
@@ -170,21 +170,19 @@ func TestExternal(t *testing.T) {
 	}
 
 	// Build the linter.
-	tmpDir := os.TempDir()
+	tmpDir := t.TempDir()
 	gocriticBin := filepath.Join(tmpDir, "gocritic_external_test.exe")
 	args := []string{"build", "-race", "-o", gocriticBin, "github.com/go-critic/go-critic/cmd/gocritic"}
 	out, err := exec.Command("go", args...).CombinedOutput()
 	if err != nil {
 		t.Fatalf("%v: %s", err, out)
 	}
-	defer os.Remove(gocriticBin)
 
 	externalTests := filepath.Join(tmpDir, "extern-testdata")
 	out, err = exec.Command("git", "clone", "https://github.com/go-critic/extern-testdata.git", externalTests).CombinedOutput()
 	if err != nil {
 		t.Fatalf("%v: %s", err, out)
 	}
-	defer os.RemoveAll(externalTests)
 
 	projects, err := os.ReadDir(filepath.Join(externalTests, "projects"))
 	if err != nil {

--- a/cmd/gocritic/check.go
+++ b/cmd/gocritic/check.go
@@ -142,7 +142,6 @@ func (p *program) checkFile(f *ast.File) {
 	wg.Add(len(p.checkers))
 
 	for i := range p.checkers {
-		i := i
 		c := p.checkers[i]
 
 		// All checkers are expected to use *lint.Context


### PR DESCRIPTION
The PR enables [`copyloopvar`](https://golangci-lint.run/usage/linters/#copyloopvar) and [`usetesting`](https://golangci-lint.run/usage/linters/#usetesting) linters.