### PR TITLE
[checkers/deprecatedComment] Check that deprecated convention appears in a separate paragraph

### DIFF
--- a/checkers/deprecatedComment_checker.go
+++ b/checkers/deprecatedComment_checker.go
@@ -8,6 +8,8 @@ import (
 	"github.com/go-critic/go-critic/linter"
 )
 
+const DeprecatedPrefix = "Deprecated: "
+
 func init() {
 	var info linter.CheckerInfo
 	info.Name = "deprecatedComment"
@@ -97,14 +99,14 @@ func (c *deprecatedCommentChecker) VisitDocComment(doc *ast.CommentGroup) {
 			continue
 		}
 		l := comment.Text[len("//"):]
-		if len(l) < len("Deprecated: ") {
+		if len(l) < len(DeprecatedPrefix) {
 			continue
 		}
 		l = strings.TrimSpace(l)
 
 		// Check whether someone messed up with a prefix casing.
 		upcase := strings.ToUpper(l)
-		if strings.HasPrefix(upcase, "DEPRECATED: ") && !strings.HasPrefix(l, "Deprecated: ") {
+		if strings.HasPrefix(upcase, "DEPRECATED: ") && !strings.HasPrefix(l, DeprecatedPrefix) {
 			c.warnCasing(comment, l)
 			return
 		}

--- a/checkers/deprecatedComment_checker.go
+++ b/checkers/deprecatedComment_checker.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-critic/go-critic/linter"
 )
 
-const DeprecatedPrefix = "Deprecated: "
+const deprecatedPrefix = "Deprecated: "
 
 func init() {
 	var info linter.CheckerInfo
@@ -103,7 +103,7 @@ func (c *deprecatedCommentChecker) VisitDocComment(doc *ast.CommentGroup) {
 			// TODO(quasilyte): handle multi-line doc comments.
 			continue
 		}
-		rawLine := comment.Text[len("//"):]
+		rawLine := strings.TrimPrefix(comment.Text, "//")
 		l := strings.TrimSpace(rawLine)
 		if len(rawLine) < len(DeprecatedPrefix) {
 			prev = &l
@@ -143,11 +143,11 @@ func (c *deprecatedCommentChecker) VisitDocComment(doc *ast.CommentGroup) {
 			}
 		}
 
-		if strings.HasPrefix(l, DeprecatedPrefix) && prev != nil && *prev != "" {
+		if strings.HasPrefix(l, DeprecatedPrefix) && prev != "" {
 			c.warnParagraph(comment)
 			return
 		}
-		prev = &rawLine
+		prev = rawLine
 	}
 }
 

--- a/checkers/deprecatedComment_checker.go
+++ b/checkers/deprecatedComment_checker.go
@@ -95,8 +95,7 @@ func (c *deprecatedCommentChecker) VisitDocComment(doc *ast.CommentGroup) {
 
 	// prev stores the previous line after it was trimmed.
 	// It's used to check whether the deprecation prefix is at the beginning of a new paragraph.
-	// It's nil on the first iteration.
-	var prev *string
+	var prev string
 
 	for _, comment := range doc.List {
 		if strings.HasPrefix(comment.Text, "/*") {
@@ -105,14 +104,14 @@ func (c *deprecatedCommentChecker) VisitDocComment(doc *ast.CommentGroup) {
 		}
 		rawLine := strings.TrimPrefix(comment.Text, "//")
 		l := strings.TrimSpace(rawLine)
-		if len(rawLine) < len(DeprecatedPrefix) {
-			prev = &l
+		if len(rawLine) < len(deprecatedPrefix) {
+			prev = l
 			continue
 		}
 
 		// Check whether someone messed up with a prefix casing.
 		upcase := strings.ToUpper(l)
-		if strings.HasPrefix(upcase, "DEPRECATED: ") && !strings.HasPrefix(l, DeprecatedPrefix) {
+		if strings.HasPrefix(upcase, "DEPRECATED: ") && !strings.HasPrefix(l, deprecatedPrefix) {
 			c.warnCasing(comment, l)
 			return
 		}
@@ -143,11 +142,11 @@ func (c *deprecatedCommentChecker) VisitDocComment(doc *ast.CommentGroup) {
 			}
 		}
 
-		if strings.HasPrefix(l, DeprecatedPrefix) && prev != "" {
+		if strings.HasPrefix(l, deprecatedPrefix) && prev != "" {
 			c.warnParagraph(comment)
 			return
 		}
-		prev = rawLine
+		prev = l
 	}
 }
 
@@ -170,5 +169,5 @@ func (c *deprecatedCommentChecker) warnTypo(cause ast.Node, line string) {
 }
 
 func (c *deprecatedCommentChecker) warnParagraph(cause ast.Node) {
-	c.ctx.Warn(cause, "`Deprecated: ` prefix should be at the beginning of a new paragraph")
+	c.ctx.Warn(cause, "`Deprecated: ` notices should be in a dedicated paragraph, separated from the rest")
 }

--- a/checkers/testdata/deprecatedComment/negative_tests.go
+++ b/checkers/testdata/deprecatedComment/negative_tests.go
@@ -56,3 +56,15 @@ type ComponentStatusList struct {
 
 	Items []ComponentStatus
 }
+
+// SomethingOlder is old
+//
+// Deprecated: This API is deprecated in v1.19+
+//
+// and these are information that are in another paragraph, but not part of the deprecation one
+type SomethingOlder struct{}
+
+// Deprecated: This API is deprecated in v1.19+
+//
+// SomethingLegacy is also old
+type SomethingLegacy struct{}

--- a/checkers/testdata/deprecatedComment/negative_tests.go
+++ b/checkers/testdata/deprecatedComment/negative_tests.go
@@ -35,6 +35,7 @@ var (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ComponentStatus (and ComponentStatus) holds the cluster validation info.
+//
 // Deprecated: This API is deprecated in v1.19+
 type ComponentStatus struct {
 	foo string
@@ -46,6 +47,7 @@ type ComponentStatus struct {
 }
 
 // ComponentStatusList represents the list of component statuses
+//
 // Deprecated: This API is deprecated in v1.19+
 type ComponentStatusList struct {
 	string

--- a/checkers/testdata/deprecatedComment/positive_tests.go
+++ b/checkers/testdata/deprecatedComment/positive_tests.go
@@ -208,6 +208,6 @@ type ComponentStatusListBad struct {
 }
 
 // This is a sentence.
-/*! `Deprecated: ` prefix should be at the beginning of a new paragraph */
+/*! `Deprecated: ` notices should be in a dedicated paragraph, separated from the rest */
 // Deprecated: use something else.
 func InSameParagraphAsPreviousSentence() {}

--- a/checkers/testdata/deprecatedComment/positive_tests.go
+++ b/checkers/testdata/deprecatedComment/positive_tests.go
@@ -206,3 +206,8 @@ type ComponentStatusListBad struct {
 
 	Items []int
 }
+
+// This is a sentence.
+/*! `Deprecated: ` prefix should be at the beginning of a new paragraph */
+// Deprecated: use something else.
+func InSameParagraphAsPreviousSentence() {}


### PR DESCRIPTION
Deprecation comments need to [be on their own paragraph](https://go.dev/wiki/Deprecated):

> To signal that an identifier should not be used, **add a paragraph** to its doc comment that begins with Deprecated: followed by some information about the deprecation, and a recommendation on what to use instead, if applicable.

Tools like the `go doc` generator and `staticcheck` explicitly [check for `Deprecated: ` only at the beginning of new paragraphs](https://github.com/dominikh/go-tools/blob/a2bad015c062e0d4ffabc65eb948e76acc395f0d/analysis/facts/deprecated/deprecated.go#L39), and it is a common mistake to write code like this (incorrect!):

```go
// Foo does something.
// Deprecated: use Bar instead.
func Foo() {}
```

Instead of the correct:

```go
// Foo does something.
//
// Deprecated: use Bar instead.
func Foo() {}
```

To check for this, this PR updates the `deprecatedComment` checker to error out if all of the following hold:
1. A comment line starts with 'Deprecated: ' (case sensitive),
2. This is not the first line of the comment group and
3. The previous line contains characters other than whitespace.

Note that some 'negative tests' were actually instances of this issue.

Fixes #1453
