### PR TITLE
checkers: add dupOption

### DIFF
--- a/checkers/dupOption_checker.go
+++ b/checkers/dupOption_checker.go
@@ -1,0 +1,113 @@
+package checkers
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+
+	"github.com/go-critic/go-critic/checkers/internal/astwalk"
+	"github.com/go-critic/go-critic/linter"
+	"github.com/go-toolsmith/astcast"
+	"github.com/go-toolsmith/astfmt"
+)
+
+func init() {
+	var info linter.CheckerInfo
+	info.Name = "dupOption"
+	info.Tags = []string{linter.DiagnosticTag, linter.ExperimentalTag}
+	info.Summary = "Detects duplicated option func arg"
+	info.Before = `doSomething(name,
+		withWidth(w),
+		withHeight(h),
+		withWidth(w),
+)`
+	info.After = `doSomething(name,
+		withWidth(w),
+		withHeight(h),
+)`
+
+	collection.AddChecker(&info, func(ctx *linter.CheckerContext) (linter.FileWalker, error) {
+		c := &dupOptionChecker{ctx: ctx}
+		return astwalk.WalkerForExpr(c), nil
+	})
+}
+
+type dupOptionChecker struct {
+	astwalk.WalkHandler
+	ctx *linter.CheckerContext
+}
+
+func (c *dupOptionChecker) VisitExpr(expr ast.Expr) {
+	call := astcast.ToCallExpr(expr)
+	variadicArgs, argType := c.getVariadicArgs(call)
+	if len(variadicArgs) == 0 {
+		return
+	}
+
+	if !c.isOptionType(argType) {
+		return
+	}
+
+	dupArgs := c.findDupArgs(variadicArgs)
+	for _, arg := range dupArgs {
+		c.warn(arg)
+	}
+}
+
+func (c *dupOptionChecker) getVariadicArgs(call *ast.CallExpr) ([]ast.Expr, types.Type) {
+	if len(call.Args) == 0 {
+		return nil, nil
+	}
+
+	// skip for someFunc(a, b ...)
+	if call.Ellipsis != token.NoPos {
+		return nil, nil
+	}
+
+	funType := c.ctx.TypesInfo.TypeOf(call.Fun)
+	sign, ok := funType.(*types.Signature)
+	if !ok || !sign.Variadic() {
+		return nil, nil
+	}
+
+	last := sign.Params().Len() - 1
+	sliceType, ok := sign.Params().At(last).Type().(*types.Slice)
+	if !ok {
+		return nil, nil
+	}
+	argType := sliceType.Elem()
+	return call.Args[last:], argType
+}
+
+func (a *dupOptionChecker) isOptionType(typeInfo types.Type) bool {
+	typeInfo = typeInfo.Underlying()
+
+	sign, ok := typeInfo.(*types.Signature)
+	if !ok {
+		return false
+	}
+
+	if sign.Params().Len() == 0 {
+		return false
+	}
+
+	return true
+}
+
+func (a *dupOptionChecker) findDupArgs(args []ast.Expr) []ast.Expr {
+	codeMap := make(map[string]bool)
+	dupArgs := make([]ast.Expr, 0)
+	for _, arg := range args {
+		code := astfmt.Sprint(arg)
+		if !codeMap[code] {
+			codeMap[code] = true
+			continue
+		}
+		dupArgs = append(dupArgs, arg)
+	}
+	return dupArgs
+}
+
+func (c *dupOptionChecker) warn(arg ast.Node) {
+	c.ctx.Warn(arg, "func arg `%s` is duplicated", arg)
+}

--- a/checkers/dupOption_checker.go
+++ b/checkers/dupOption_checker.go
@@ -15,7 +15,7 @@ func init() {
 	var info linter.CheckerInfo
 	info.Name = "dupOption"
 	info.Tags = []string{linter.DiagnosticTag, linter.ExperimentalTag}
-	info.Summary = "Detects duplicated option func arg"
+	info.Summary = "Detects duplicated option function arguments in variadic function calls"
 	info.Before = `doSomething(name,
 		withWidth(w),
 		withHeight(h),

--- a/checkers/dupOption_checker.go
+++ b/checkers/dupOption_checker.go
@@ -99,11 +99,11 @@ func (c *dupOptionChecker) findDupArgs(args []ast.Expr) []ast.Expr {
 	dupArgs := make([]ast.Expr, 0)
 	for _, arg := range args {
 		code := astfmt.Sprint(arg)
-		if !codeMap[code] {
-			codeMap[code] = true
+		if codeMap[code] {
+			dupArgs = append(dupArgs, arg)
 			continue
 		}
-		dupArgs = append(dupArgs, arg)
+		codeMap[code] = true
 	}
 	return dupArgs
 }

--- a/checkers/dupOption_checker.go
+++ b/checkers/dupOption_checker.go
@@ -79,7 +79,7 @@ func (c *dupOptionChecker) getVariadicArgs(call *ast.CallExpr) ([]ast.Expr, type
 	return call.Args[last:], argType
 }
 
-func (a *dupOptionChecker) isOptionType(typeInfo types.Type) bool {
+func (c *dupOptionChecker) isOptionType(typeInfo types.Type) bool {
 	typeInfo = typeInfo.Underlying()
 
 	sign, ok := typeInfo.(*types.Signature)
@@ -94,7 +94,7 @@ func (a *dupOptionChecker) isOptionType(typeInfo types.Type) bool {
 	return true
 }
 
-func (a *dupOptionChecker) findDupArgs(args []ast.Expr) []ast.Expr {
+func (c *dupOptionChecker) findDupArgs(args []ast.Expr) []ast.Expr {
 	codeMap := make(map[string]bool)
 	dupArgs := make([]ast.Expr, 0)
 	for _, arg := range args {

--- a/checkers/dupOption_checker.go
+++ b/checkers/dupOption_checker.go
@@ -109,5 +109,5 @@ func (c *dupOptionChecker) findDupArgs(args []ast.Expr) []ast.Expr {
 }
 
 func (c *dupOptionChecker) warn(arg ast.Node) {
-	c.ctx.Warn(arg, "func arg `%s` is duplicated", arg)
+	c.ctx.Warn(arg, "function argument `%s` is duplicated", arg)
 }

--- a/checkers/dupOption_checker.go
+++ b/checkers/dupOption_checker.go
@@ -64,7 +64,7 @@ func (c *dupOptionChecker) getVariadicArgs(call *ast.CallExpr) ([]ast.Expr, type
 		return nil, nil
 	}
 
-	funType := c.ctx.TypesInfo.TypeOf(call.Fun)
+	funType := c.ctx.TypeOf(call.Fun)
 	sign, ok := funType.(*types.Signature)
 	if !ok || !sign.Variadic() {
 		return nil, nil

--- a/checkers/testdata/dupOption/negative_tests.go
+++ b/checkers/testdata/dupOption/negative_tests.go
@@ -1,0 +1,12 @@
+package checker_test
+
+func doSome2(w, h int) {
+	_ = newPanel("hello",
+		withWidth(w),
+		withHeight(h),
+	)
+
+	export(nil,
+		withImage(nil, ""),
+	)
+}

--- a/checkers/testdata/dupOption/positive_tests.go
+++ b/checkers/testdata/dupOption/positive_tests.go
@@ -88,30 +88,30 @@ func doSome1(w, h int) {
 	_ = newPanel("hello",
 		withWidth(w),
 		withHeight(h),
-		/*! func arg `withWidth(w)` is duplicated */
+		/*! function argument `withWidth(w)` is duplicated */
 		withWidth(w),
 	)
 
 	export(nil,
 		withImage(nil, ""),
-		/*! func arg `withImage(nil, "")` is duplicated */
+		/*! function argument `withImage(nil, "")` is duplicated */
 		withImage(nil, ""),
 	)
 
 	_ = newPanel("case2",
 		withHeight(h),
 		withDefaultWidth(),
-		/*! func arg `withDefaultWidth()` is duplicated */
+		/*! function argument `withDefaultWidth()` is duplicated */
 		withDefaultWidth(),
 		defaultWidth,
-		/*! func arg `defaultWidth` is duplicated */
+		/*! function argument `defaultWidth` is duplicated */
 		defaultWidth,
 	)
 
 	_ = newPanel("case3",
 		withHeight(h),
 		defaultWidth,
-		/*! func arg `defaultWidth` is duplicated */
+		/*! function argument `defaultWidth` is duplicated */
 		defaultWidth,
 	)
 
@@ -119,7 +119,7 @@ func doSome1(w, h int) {
 		withGroup(""),
 		withKey("key"),
 		defaultOpt,
-		/*! func arg `defaultOpt` is duplicated */
+		/*! function argument `defaultOpt` is duplicated */
 		defaultOpt,
 	)
 }

--- a/checkers/testdata/dupOption/positive_tests.go
+++ b/checkers/testdata/dupOption/positive_tests.go
@@ -27,6 +27,12 @@ func withWidth(w int) func(c *panel) {
 	}
 }
 
+func withDefaultWidth() func(c *panel) {
+	return withWidth(100)
+}
+
+var defaultWidth = withDefaultWidth()
+
 func withHeight(h int) func(c *panel) {
 	return func(c *panel) {
 		c.height = h
@@ -46,6 +52,38 @@ func withImage(_ any, _ string) exportOpt {
 func export(_ any, _ ...exportOpt) {
 }
 
+type sourceOptions struct{}
+
+type sourceOpt = func(context.Context, *sourceOptions) error
+
+func withGroup(_ string) sourceOpt {
+	return func(_ context.Context, _ *sourceOptions) error {
+		return nil
+	}
+}
+
+func withKey(_ string) sourceOpt {
+	return func(_ context.Context, _ *sourceOptions) error {
+		return nil
+	}
+}
+
+func defaultOpt(_ context.Context, _ *sourceOptions) error {
+	return nil
+}
+
+func newSource(_ any, opts ...sourceOpt) (any, error) {
+	ctx := context.Background()
+	o := &sourceOptions{}
+	for _, opt := range opts {
+		err := opt(ctx, o)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return nil, nil
+}
+
 func doSome1(w, h int) {
 	_ = newPanel("hello",
 		withWidth(w),
@@ -58,5 +96,30 @@ func doSome1(w, h int) {
 		withImage(nil, ""),
 		/*! func arg `withImage(nil, "")` is duplicated */
 		withImage(nil, ""),
+	)
+
+	_ = newPanel("case2",
+		withHeight(h),
+		withDefaultWidth(),
+		/*! func arg `withDefaultWidth()` is duplicated */
+		withDefaultWidth(),
+		defaultWidth,
+		/*! func arg `defaultWidth` is duplicated */
+		defaultWidth,
+	)
+
+	_ = newPanel("case3",
+		withHeight(h),
+		defaultWidth,
+		/*! func arg `defaultWidth` is duplicated */
+		defaultWidth,
+	)
+
+	_, _ = newSource("case4",
+		withGroup(""),
+		withKey("key"),
+		defaultOpt,
+		/*! func arg `defaultOpt` is duplicated */
+		defaultOpt,
 	)
 }

--- a/checkers/testdata/dupOption/positive_tests.go
+++ b/checkers/testdata/dupOption/positive_tests.go
@@ -1,0 +1,62 @@
+package checker_test
+
+import "context"
+
+type panel struct {
+	name   string
+	width  int
+	height int
+}
+
+func newPanel(name string, opts ...func(c *panel)) *panel {
+	cfg := &panel{
+		name:   name,
+		width:  0,
+		height: 0,
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	return cfg
+}
+
+func withWidth(w int) func(c *panel) {
+	return func(c *panel) {
+		c.width = w
+	}
+}
+
+func withHeight(h int) func(c *panel) {
+	return func(c *panel) {
+		c.height = h
+	}
+}
+
+type exportOptions struct{}
+
+type exportOpt func(context.Context, *exportOptions) error
+
+func withImage(_ any, _ string) exportOpt {
+	return func(_ context.Context, _ *exportOptions) error {
+		return nil
+	}
+}
+
+func export(_ any, _ ...exportOpt) {
+}
+
+func doSome1(w, h int) {
+	_ = newPanel("hello",
+		withWidth(w),
+		withHeight(h),
+		/*! func arg `withWidth(w)` is duplicated */
+		withWidth(w),
+	)
+
+	export(nil,
+		withImage(nil, ""),
+		/*! func arg `withImage(nil, "")` is duplicated */
+		withImage(nil, ""),
+	)
+}


### PR DESCRIPTION
I first implement it in another copyandpaste linter, i found that the `repeat arg` like `math.Max(a, a)` has already added in go-critic,

so i move the left part `repeat option` here, I have check the open golang github repos, the result can be found here https://github.com/alingse/copyandpaste/issues/7 

of cause, this may report some false-positive case like [docker/compose/blob/main/cmd/compose/compose.go#L399-L407](https://github.com/docker/compose/blob/main/cmd/compose/compose.go#L399-L407)