### PR TITLE
Recognize methods and third-party packages in exitAfterDefer

### DIFF
--- a/checkers/exitAfterDefer_checker.go
+++ b/checkers/exitAfterDefer_checker.go
@@ -87,6 +87,11 @@ func (c *exitAfterDeferChecker) VisitFuncDecl(fn *ast.FuncDecl) {
 					"(*log.Logger).Fatal",
 					"(*log.Logger).Fatalf",
 					"(*log.Logger).Fatalln",
+					"(*go.uber.org/zap.Logger).Fatal",
+					"(*go.uber.org/zap.SugaredLogger).Fatal",
+					"(*go.uber.org/zap.SugaredLogger).Fatalf",
+					"(*go.uber.org/zap.SugaredLogger).Fatalln",
+					"(*go.uber.org/zap.SugaredLogger).Fatalw",
 					"os.Exit":
 					c.warn(n, deferStmt)
 					return false

--- a/checkers/exitAfterDefer_checker.go
+++ b/checkers/exitAfterDefer_checker.go
@@ -80,7 +80,14 @@ func (c *exitAfterDeferChecker) VisitFuncDecl(fn *ast.FuncDecl) {
 				}
 
 				switch fn.FullName() {
-				case "log.Fatal", "log.Fatalf", "log.Fatalln", "os.Exit":
+				case
+					"log.Fatal",
+					"log.Fatalf",
+					"log.Fatalln",
+					"(*log.Logger).Fatal",
+					"(*log.Logger).Fatalf",
+					"(*log.Logger).Fatalln",
+					"os.Exit":
 					c.warn(n, deferStmt)
 					return false
 				}

--- a/checkers/testdata/exitAfterDefer/negative_tests.go
+++ b/checkers/testdata/exitAfterDefer/negative_tests.go
@@ -61,3 +61,18 @@ func neverOsExitAndCallADefer() {
 		os.Exit(1)
 	}
 }
+
+type exiter struct{}
+
+func (exiter) Exit(code int) {
+
+}
+
+func shadowedOs() {
+	defer println("")
+
+	var os exiter
+
+	// this is not the os.Exit that breaks defers
+	os.Exit(1)
+}

--- a/checkers/testdata/exitAfterDefer/positive_tests.go
+++ b/checkers/testdata/exitAfterDefer/positive_tests.go
@@ -1,6 +1,7 @@
 package checker_test
 
 import (
+	"log"
 	"os"
 )
 
@@ -47,4 +48,11 @@ func deferLambda() {
 
 	/*! os.Exit will exit, and `defer func(x int){...}(...)` will not run */
 	os.Exit(0)
+}
+
+func loggerMethods() {
+	defer println("")
+
+	logger := log.Default()
+	logger.Fatal("goodbye")
 }


### PR DESCRIPTION
Instead of `qualifiedName` which only syntactially concatenated selector's node identifiers, use type checker data to properly resolve fully qualified name.

This allows methods and third-party packages to be unambigiously specified. The folowing names have been added:

* `(*log.Logger).Fatal`,
* `(*log.Logger).Fatalf`,
* `(*log.Logger).Fatalln`,
* `(*go.uber.org/zap.Logger).Fatal`,
* `(*go.uber.org/zap.SugaredLogger).Fatal`,
* `(*go.uber.org/zap.SugaredLogger).Fatalf`,
* `(*go.uber.org/zap.SugaredLogger).Fatalln`,
* `(*go.uber.org/zap.SugaredLogger).Fatalw`,