### PR TITLE
perf: cache ruleguard engines for embedded rules

### DIFF
--- a/checkers/embedded_rules.go
+++ b/checkers/embedded_rules.go
@@ -6,6 +6,7 @@ import (
 	"go/build"
 	"go/token"
 	"os"
+	"sync"
 
 	"github.com/go-critic/go-critic/checkers/rulesdata"
 	"github.com/go-critic/go-critic/linter"
@@ -14,6 +15,42 @@ import (
 )
 
 //go:generate go run ./rules/precompile.go -rules ./rules/rules.go -o ./rulesdata/rulesdata.go
+
+// cachedEngine holds a pre-initialized ruleguard engine for a specific rule group.
+// The engine is created once and reused for all checker instances.
+type cachedEngine struct {
+	engine *ruleguard.Engine
+	once   sync.Once
+	err    error
+
+	// Configuration needed to create the engine
+	fset         *token.FileSet
+	buildContext *build.Context
+	groupName    string
+	debug        bool
+}
+
+func (ce *cachedEngine) get() (*ruleguard.Engine, error) {
+	ce.once.Do(func() {
+		parseContext := &ruleguard.LoadContext{
+			Fset: ce.fset,
+			GroupFilter: func(gr *ruleguard.GoRuleGroup) bool {
+				return gr.Name == ce.groupName
+			},
+			DebugImports: ce.debug,
+			DebugPrint: func(s string) {
+				fmt.Println("debug:", s)
+			},
+		}
+		engine := ruleguard.NewEngine()
+		engine.BuildContext = ce.buildContext
+		ce.err = engine.LoadFromIR(parseContext, "rules/rules.go", rulesdata.PrecompiledRules)
+		if ce.err == nil {
+			ce.engine = engine
+		}
+	})
+	return ce.engine, ce.err
+}
 
 func InitEmbeddedRules() error {
 	filename := "rules/rules.go"
@@ -49,8 +86,8 @@ func InitEmbeddedRules() error {
 		groups = rootEngine.LoadedGroups()
 	}
 
-	// For every rules group we create a new checker and a separate engine.
-	// That dedicated ruleguard engine will contain rules only from one group.
+	// For every rules group we create a cached engine holder.
+	// The engine will be created lazily on first use and then reused.
 	for i := range groups {
 		g := groups[i]
 		info := &linter.CheckerInfo{
@@ -63,20 +100,17 @@ func InitEmbeddedRules() error {
 
 			EmbeddedRuleguard: true,
 		}
+
+		// Create a cached engine for this rule group
+		cache := &cachedEngine{
+			fset:         fset,
+			buildContext: buildContext,
+			groupName:    g.Name,
+			debug:        ruleguardDebug,
+		}
+
 		collection.AddChecker(info, func(ctx *linter.CheckerContext) (linter.FileWalker, error) {
-			parseContext := &ruleguard.LoadContext{
-				Fset: fset,
-				GroupFilter: func(gr *ruleguard.GoRuleGroup) bool {
-					return gr.Name == g.Name
-				},
-				DebugImports: ruleguardDebug,
-				DebugPrint: func(s string) {
-					fmt.Println("debug:", s)
-				},
-			}
-			engine := ruleguard.NewEngine()
-			engine.BuildContext = buildContext
-			err := engine.LoadFromIR(parseContext, filename, rulesdata.PrecompiledRules)
+			engine, err := cache.get()
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Previously, each call to NewChecker for an embedded ruleguard rule would create a new ruleguard.Engine and call LoadFromIR, which performs expensive type imports via go/internal/srcimporter. When golangci-lint runs go-critic on a large codebase, this happens repeatedly for every package being analyzed, causing significant performance degradation.

This change introduces a cachedEngine struct that lazily initializes each rule group's engine on first use (via sync.Once) and reuses it for all subsequent checker instances. The engine itself is stateless with respect to the files being analyzed - only the RunContext passed to WalkFile contains package-specific information.

Benchmark results on a medium-sized Go project (~100 packages):
- Before: 24.46s wall clock, 216.90s total CPU time
- After:  6.74s wall clock, ~59s total CPU time
- Improvement: 72% reduction in wall clock time

The bottleneck was identified via CPU profiling, which showed findTypeNoCache and srcimporter operations consuming ~50% of CPU time due to repeated engine initialization.

Assisted-By: cagent