### PR TITLE
fix: improve panic recovery in checker execution

### DIFF
--- a/cmd/go-critic/check.go
+++ b/cmd/go-critic/check.go
@@ -135,6 +135,7 @@ func (p *program) checkPackage(pkg *packages.Package) {
 
 func (p *program) checkFile(f *ast.File) {
 	warnings := make([][]linter.Warning, len(p.checkers))
+	panics := make([]any, len(p.checkers))
 
 	sema := make(chan struct{}, p.concurrency)
 
@@ -150,27 +151,28 @@ func (p *program) checkFile(f *ast.File) {
 
 		go func() {
 			defer func() {
-				wg.Done()
+				if r := recover(); r != nil {
+					panics[i] = r
+				}
 				<-sema
-
-				// Checker signals unexpected error with panic(error).
-				r := recover()
-				if r == nil {
-					return // There were no panic
-				}
-				if err, ok := r.(error); ok {
-					log.Printf("%s: error: %v\n", c.Info.Name, err)
-					panic(err)
-				}
-				// Some other kind of run-time panic.
-				// Undo the recover and resume panic.
-				panic(r)
+				wg.Done()
 			}()
 
 			warnings[i] = append(warnings[i], c.Check(f)...)
 		}()
 	}
 	wg.Wait()
+
+	for i, c := range p.checkers {
+		if p := panics[i]; p != nil {
+			if err, ok := p.(error); ok {
+				log.Printf("%s: error: %v\n", c.Info.Name, err)
+			} else {
+				log.Printf("%s: recovered panic: %v\n", c.Info.Name, p)
+			}
+			panic(p)
+		}
+	}
 
 	for i, c := range p.checkers {
 		for _, warn := range warnings[i] {

--- a/cmd/go-critic/check_test.go
+++ b/cmd/go-critic/check_test.go
@@ -1,7 +1,15 @@
 package main
 
 import (
+	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"runtime"
 	"testing"
+
+	"github.com/go-critic/go-critic/linter"
 )
 
 func TestShortenLocation(t *testing.T) {
@@ -38,4 +46,79 @@ func TestShortenLocation(t *testing.T) {
 				test.input, have, want)
 		}
 	}
+}
+
+// panickingWalker is a FileWalker that panics when WalkFile is called.
+type panickingWalker struct {
+	err any
+}
+
+func (w *panickingWalker) WalkFile(_ *ast.File) {
+	panic(w.err)
+}
+
+func TestCheckFile_PanicRecovery(t *testing.T) {
+	// Register a checker that panics with an error.
+	collection := &linter.CheckerCollection{}
+	errToPanic := errors.New("test checker panic")
+
+	collection.AddChecker(&linter.CheckerInfo{
+		Name: "testPanicChecker",
+		Tags: []string{"diagnostic"},
+	}, func(ctx *linter.CheckerContext) (linter.FileWalker, error) {
+		return &panickingWalker{err: errToPanic}, nil
+	})
+
+	// Create a linter context and checker.
+	fset := token.NewFileSet()
+	sizes := types.SizesFor("gc", runtime.GOARCH)
+	ctx := linter.NewContext(fset, sizes)
+	info := linter.GetCheckersInfo()
+
+	var checkerInfo *linter.CheckerInfo
+	for _, i := range info {
+		if i.Name == "testPanicChecker" {
+			checkerInfo = i
+			break
+		}
+	}
+	if checkerInfo == nil {
+		t.Fatal("testPanicChecker not registered")
+	}
+
+	checker, err := linter.NewChecker(ctx, checkerInfo)
+	if err != nil {
+		t.Fatalf("NewChecker: %v", err)
+	}
+
+	// Parse a minimal Go file.
+	src := `package main
+func main() {}
+`
+	f, err := parser.ParseFile(fset, "test.go", src, 0)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+
+	// Create a program and verify that checkFile re-throws the panic.
+	p := &program{
+		ctx:        ctx,
+		checkers:   []*linter.Checker{checker},
+		concurrency: runtime.GOMAXPROCS(0),
+	}
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic from checkFile, but none occurred")
+		}
+		if r != errToPanic {
+			t.Errorf("recovered panic = %v (%T), want %v", r, r, errToPanic)
+		}
+	}()
+
+	p.checkFile(f)
+
+	// Should not reach here — panic should propagate.
+	t.Fatal("checkFile returned without re-throwing panic")
 }

--- a/cmd/gocritic/check.go
+++ b/cmd/gocritic/check.go
@@ -135,6 +135,7 @@ func (p *program) checkPackage(pkg *packages.Package) {
 
 func (p *program) checkFile(f *ast.File) {
 	warnings := make([][]linter.Warning, len(p.checkers))
+	panics := make([]any, len(p.checkers))
 
 	sema := make(chan struct{}, p.concurrency)
 
@@ -150,27 +151,28 @@ func (p *program) checkFile(f *ast.File) {
 
 		go func() {
 			defer func() {
-				wg.Done()
+				if r := recover(); r != nil {
+					panics[i] = r
+				}
 				<-sema
-
-				// Checker signals unexpected error with panic(error).
-				r := recover()
-				if r == nil {
-					return // There were no panic
-				}
-				if err, ok := r.(error); ok {
-					log.Printf("%s: error: %v\n", c.Info.Name, err)
-					panic(err)
-				}
-				// Some other kind of run-time panic.
-				// Undo the recover and resume panic.
-				panic(r)
+				wg.Done()
 			}()
 
 			warnings[i] = append(warnings[i], c.Check(f)...)
 		}()
 	}
 	wg.Wait()
+
+	for i, c := range p.checkers {
+		if p := panics[i]; p != nil {
+			if err, ok := p.(error); ok {
+				log.Printf("%s: error: %v\n", c.Info.Name, err)
+			} else {
+				log.Printf("%s: recovered panic: %v\n", c.Info.Name, p)
+			}
+			panic(p)
+		}
+	}
 
 	for i, c := range p.checkers {
 		for _, warn := range warnings[i] {

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -360,7 +360,7 @@ func (ctx *CheckerContext) safeSizesInfoSizeof(typ types.Type) (size int64, ok b
 	ok = true
 	defer func() {
 		if r := recover(); r != nil {
-			if strings.Contains(r.(string), "assertion failed") {
+			if msg, ok := r.(string); ok && strings.Contains(msg, "assertion failed") {
 				size, ok = 0, false
 			} else {
 				panic(r)


### PR DESCRIPTION
Closes #1533

## Changes

### `cmd/go-critic/check.go` + `cmd/gocritic/check.go`

Refactor panic recovery in `checkFile` to prevent the parent goroutine from masking incomplete lint results:

- **Before**: `wg.Done()` executes before `recover()`. If a checker panics, the parent goroutine can proceed through `wg.Wait()` → `p.exit()` → `os.Exit` before the child re-panics, producing incomplete results with no error.
- **After**: Panics are captured into a `[]any` slice by index. The child goroutine calls `recover()` first, then `<-sema` and `wg.Done()`. After `wg.Wait()`, the parent checks the slice and re-throws. This guarantees panic is never masked.

Defer order changed from `wg.Done() → <-sema → recover()` to `recover() → <-sema → wg.Done()`.

### `linter/linter.go`

Fix unsafe type assertion in `safeSizesInfoSizeof`:

```go
// Before (line 363):
if strings.Contains(r.(string), "assertion failed") {

// After:
if msg, ok := r.(string); ok && strings.Contains(msg, "assertion failed") {
```

Prevents secondary panic when the recovered value is not a string (e.g. `*runtime.TypeAssertionError`).

## Verification

- `go build ./...` — success
- `go test -race -count=1 ./...` — 341 passed, no race conditions detected