### PR TITLE
checkers/sloppyTypeAssert: do not warn when type info is missing

### DIFF
--- a/checkers/checkers_test.go
+++ b/checkers/checkers_test.go
@@ -38,6 +38,7 @@ func TestCheckers(t *testing.T) {
 	cfg := linttest.CheckersTest{
 		IgnoreErrors: []string{
 			"caseOrder",
+			"sloppyTypeAssert",
 		},
 	}
 

--- a/checkers/sloppyTypeAssert_checker.go
+++ b/checkers/sloppyTypeAssert_checker.go
@@ -45,6 +45,13 @@ func (c *sloppyTypeAssertChecker) VisitExpr(expr ast.Expr) {
 	toType := c.ctx.TypeOf(expr)
 	fromType := c.ctx.TypeOf(assert.X)
 
+	// TypeOf returns the UnknownType sentinel when the type info is missing.
+	// It is a singleton, so types.Identical reports two unknowns as identical
+	// and the check would warn about an assertion it knows nothing about.
+	if toType == linter.UnknownType || fromType == linter.UnknownType {
+		return
+	}
+
 	if types.Identical(toType, fromType) {
 		c.warnIdentical(expr)
 		return

--- a/checkers/testdata/sloppyTypeAssert/negative_tests.go
+++ b/checkers/testdata/sloppyTypeAssert/negative_tests.go
@@ -21,3 +21,12 @@ func noWarnings(eface interface{}, r io.Reader, rc io.ReadCloser) {
 
 	_ = r.(underlyingReader)
 }
+
+func issue1422() {
+	data := undefinedFunc()
+
+	exampleA, ok := data.([]string)
+	_, _ = exampleA, ok
+
+	_ = data.(int)
+}


### PR DESCRIPTION
Fixes #1422.

## The report

`sloppyTypeAssert` warns "type assertion from/to types are identical" for assertions whose
types are obviously different, and the report notes two odd details: it happens in VS Code but
not always from the CLI, and *"changing the statement does not change whether go-critic warns"*.

## Cause

`CheckerContext.TypeOf` never returns `nil`; when the type info is missing it returns the
`UnknownType` sentinel (`linter/linter.go`), and its own comment promises the sentinel
*"will fail most type assertions as well as kind checks"*.

That promise does not hold for `types.Identical`. `UnknownType` is
`types.Typ[types.Invalid]` — a package-level singleton — so both sides of the comparison are
the *same pointer* and `types.Identical(UnknownType, UnknownType)` is `true`.

When the operand of an assertion does not resolve, go/types marks the operand and the whole
expression invalid, so `toType` and `fromType` both become the sentinel and
`sloppyTypeAssert_checker.go` reports them as identical. This explains both details in the
report: an editor lints partially-typed packages, and the asserted type never enters the
decision at all.

## Fix

Return early when either side is the sentinel, before the `types.Identical` comparison.

## Tests

`checkers/testdata/sloppyTypeAssert/negative_tests.go` gets `issue1422`, which asserts on the
result of an undefined function in both the comma-ok and the single-value form. The checker
name is added to the existing `IgnoreErrors` list in `checkers/checkers_test.go` so the fixture
is allowed to have type errors — the same mechanism `caseOrder` already uses
(`checkers/internal/linttest/linttest.go`).

Before the fix:

```
--- FAIL: TestCheckers/sloppyTypeAssert
    linttest.go:171: testdata/sloppyTypeAssert/negative_tests.go:28: unexpected warn: type assertion from/to types are identical
    linttest.go:171: testdata/sloppyTypeAssert/negative_tests.go:31: unexpected warn: type assertion from/to types are identical
```

Both forms are covered on purpose: with an invalid operand go/types does not build the tuple,
so comma-ok does not protect against this.

Verified on `325d070` with Go 1.26:

- `go test -count=1 -run=/sloppyTypeAssert ./checkers` — red before, `ok` after;
- `go test -race -count=1 ./...` — all packages `ok`;
- `go generate ./...` leaves the tree clean;
- `go-critic check -enableAll ./...` on the patched tree — no findings;
- `gofmt` clean for the touched files.

## One note, not part of this PR

The root cause is shared: `UnknownType` being identical to itself affects any checker that
compares two types from `TypeOf`. This PR keeps to the one checker the issue is about; it may
be worth auditing the others separately.

---

Prepared with AI assistance. Every claim above was verified by running it.
