### PR TITLE
checkers/internal/astwalk: keep the parenthesis of a receive-only channel type

### DIFF
--- a/checkers/internal/astwalk/type_expr_walker.go
+++ b/checkers/internal/astwalk/type_expr_walker.go
@@ -95,11 +95,22 @@ func (w *typeExprWalker) walk(x ast.Node) bool {
 	return true
 }
 
+// isRecvOnlyChanType reports whether x is a receive-only channel type, `<-chan T`.
+//
+// The Go spec requires a parenthesis around a conversion type that starts with
+// `*`, `<-`, or the `func` keyword: without it `(<-chan int)(nil)` parses as
+// `<-(chan int(nil))` and does not compile. A send-only `chan<- int(nil)` is
+// unambiguous, so only the receive direction is special here.
+func isRecvOnlyChanType(x ast.Expr) bool {
+	ch, ok := x.(*ast.ChanType)
+	return ok && ch.Dir == ast.RECV
+}
+
 func (w *typeExprWalker) inspectInner(x ast.Expr) bool {
 	parens, ok := x.(*ast.ParenExpr)
 	shouldInspect := ok &&
 		typep.IsTypeExpr(w.info, parens.X) &&
-		(astp.IsStarExpr(parens.X) || astp.IsFuncType(parens.X))
+		(astp.IsStarExpr(parens.X) || astp.IsFuncType(parens.X) || isRecvOnlyChanType(parens.X))
 	if shouldInspect {
 		ast.Inspect(parens.X, w.walk)
 		return false

--- a/checkers/testdata/typeUnparen/negative_tests.go
+++ b/checkers/testdata/typeUnparen/negative_tests.go
@@ -100,3 +100,7 @@ func channelIssue1035() {
 func funcIssue1245() {
 	_ = (func())(nil)
 }
+
+func convIssue1428() {
+	_ = (<-chan int)(nil)
+}

--- a/checkers/testdata/typeUnparen/positive_tests.go
+++ b/checkers/testdata/typeUnparen/positive_tests.go
@@ -204,3 +204,8 @@ func chanType() {
 	/*! could simplify chan<- (int) to chan<- int */
 	_ = make(chan<- (int))
 }
+
+func convIssue1428SendOnly() {
+	/*! could simplify (chan<- int) to chan<- int */
+	_ = (chan<- int)(nil)
+}


### PR DESCRIPTION
Fixes #1428.

## The report

`typeUnparen` suggests simplifying `(<-chan int)(nil)` to `<-chan int(nil)`. Applying that
suggestion does not compile.

Checked with the compiler rather than assumed:

| source | result |
|---|---|
| `a := (<-chan int)(nil)` | compiles |
| `a := <-chan int(nil)` (the suggested edit) | **fails**: `cannot use a (variable of type int) as <-chan int value in argument to recv` |
| `b := chan<- int(nil)` | compiles |

So the parenthesis is required for the receive direction and redundant for the send direction —
which matches the spec: *"If the type starts with the operator `*` or `<-`, or if the type
starts with the keyword `func` and has no result list, it must be parenthesized when necessary
to avoid ambiguity."*

## Cause

`typeExprWalker.inspectInner` is what skips the outermost parenthesis of a conversion, and its
comment already says so. Its whitelist implements only two of the three spec cases:

```go
	shouldInspect := ok &&
		typep.IsTypeExpr(w.info, parens.X) &&
		(astp.IsStarExpr(parens.X) || astp.IsFuncType(parens.X))
```

`*` (`(*int)(nil)`) and `func` (`(func())(nil)`, #1245) are handled; `<-` is missing. For
`(<-chan int)(nil)` the walker therefore descends normally, reaches the `*ast.ParenExpr` case,
and `typeUnparen` strips a parenthesis the code cannot compile without.

`inspectInner` is only reached from the `*ast.CallExpr` and `*ast.SelectorExpr` cases —
conversions and method expressions — so this does not affect places where the parenthesis
really is redundant, e.g. `var _ (<-chan int)`.

Note the `*ast.ChanType` branch inside `typeUnparen_checker.go` (the fix for #1035, nested
channels such as `chan (<-chan T)`) is a different code path and keeps working; its fixture
`channelIssue1035` stays green.

## Fix

Add the third spec case to the whitelist, restricted to `ast.RECV` because the compiler run
above shows `chan<-` needs no parenthesis.

## Tests

- `checkers/testdata/typeUnparen/negative_tests.go` — `convIssue1428`, the reported snippet.
  Before the fix: `testdata/typeUnparen/negative_tests.go:105: unexpected warn: could simplify
  (<-chan int) to <-chan int`.
- `checkers/testdata/typeUnparen/positive_tests.go` — `convIssue1428SendOnly`, asserting that
  `(chan<- int)(nil)` is **still** reported, so the fix cannot silently widen to both
  directions. (This one earned its place: an earlier draft with the expectation marker on the
  wrong line failed with `unexpected warn` at that exact spot, which is also the proof the
  warning is really emitted there.)

Verified on `325d070` with Go 1.26:

- `go test -count=1 -run=/typeUnparen ./checkers` — red before, `ok` after;
- `go test -race -count=1 ./...` — all packages `ok`, so `ptrCast`, `funcIssue1245`,
  `channelIssue1035` and the rest of the golden fixtures are unaffected;
- `go generate ./...` leaves the tree clean;
- `go-critic check -enableAll ./...` on the patched tree — no findings;
- `gofmt` clean for the touched files.

---

Prepared with AI assistance. Every claim above was verified by running it.
