### PR TITLE
checkers: reduce commentedOutCode false negatives on short lines

### DIFF
--- a/checkers/commentedOutCode_checker.go
+++ b/checkers/commentedOutCode_checker.go
@@ -75,10 +75,15 @@ func (c *commentedOutCodeChecker) VisitLocalComment(cg *ast.CommentGroup) {
 		}
 	}
 
+	stmt := strparse.Stmt(s)
+
 	// Some very short comment that can be skipped.
 	// Usually triggering on these results in false positive.
-	// Unless there is a very popular call like print/println.
+	// Unless there is a very popular call like print/println,
+	// or the comment clearly parses as code (an assignment or a
+	// plain function call) that is unlikely to be prose.
 	cond := utf8.RuneCountInString(s) < c.minLength &&
+		!c.isObviousCode(stmt) &&
 		!strings.Contains(s, "print") &&
 		!strings.Contains(s, "fmt.") &&
 		!strings.Contains(s, "log.")
@@ -96,8 +101,6 @@ func (c *commentedOutCodeChecker) VisitLocalComment(cg *ast.CommentGroup) {
 	if c.isExampleOutputComment(s) {
 		return
 	}
-
-	stmt := strparse.Stmt(s)
 
 	if c.isPermittedStmt(stmt) {
 		return
@@ -134,6 +137,28 @@ func (c *commentedOutCodeChecker) VisitLocalComment(cg *ast.CommentGroup) {
 // See https://go.dev/blog/examples
 func (c *commentedOutCodeChecker) isExampleOutputComment(s string) bool {
 	return isExampleTestFunc(c.fn) && strings.Contains(s, "Output:")
+}
+
+// isObviousCode reports whether stmt is a construct that is almost never
+// found in prose comments, so it is worth reporting even for very short
+// comments that the minLength heuristic would otherwise skip. We keep this
+// intentionally narrow (assignments and plain function/method calls) to
+// avoid new false positives on things like "<-ch" or a lone identifier.
+func (c *commentedOutCodeChecker) isObviousCode(stmt ast.Stmt) bool {
+	switch stmt := stmt.(type) {
+	case *ast.AssignStmt:
+		return true
+	case *ast.ExprStmt:
+		call, ok := stmt.X.(*ast.CallExpr)
+		if !ok {
+			return false
+		}
+		switch call.Fun.(type) {
+		case *ast.Ident, *ast.SelectorExpr:
+			return true
+		}
+	}
+	return false
 }
 
 func (c *commentedOutCodeChecker) isPermittedStmt(stmt ast.Stmt) bool {

--- a/checkers/testdata/commentedOutCode/negative_tests.go
+++ b/checkers/testdata/commentedOutCode/negative_tests.go
@@ -82,5 +82,7 @@ func permittedComments() {
 
 	/* CINC/CINV/CNEG */
 
-	// v := 世界
+	// foo ()
+
+	// world
 }

--- a/checkers/testdata/commentedOutCode/positive_tests.go
+++ b/checkers/testdata/commentedOutCode/positive_tests.go
@@ -42,3 +42,17 @@ func multiLineCode() {
 	/*! may want to remove commented-out code */
 	// v := 781
 }
+
+func shortCode() {
+	/*! may want to remove commented-out code */
+	// Baz()
+
+	/*! may want to remove commented-out code */
+	// foo.Bar()
+
+	/*! may want to remove commented-out code */
+	// x := 1
+
+	/*! may want to remove commented-out code */
+	// v := 世界
+}


### PR DESCRIPTION
Fixes #1457.

The `commentedOutCode` check skips comments shorter than `minLength` to
keep the false-positive rate down, but that also lets real commented-out
code slip through. In the issue, only `// fmt.Println()` gets flagged
while `// Baz()` and `// x := 1` do not, purely because they are short.

This lets a short comment through the length filter when it clearly
parses as code that almost never shows up in prose: an assignment, or a
plain function/method call (`name()` / `pkg.Fn()`). Everything else that
the length check protects (a lone identifier, `<-ch`, a binary expr,
`foo (1, 2)` with the whitespace) is left untouched, so no new false
positives. I moved one testdata line (`// v := 世界`) from the negative
to the positive set since it is a commented-out assignment and should be
reported now.

I left the composite-literal fragment case (`// A: "abc",`) alone. It
parses as a bad statement and there is no reliable way to tell it apart
from prose, which matches what @quasilyte noted on the issue.
