### PR TITLE
chore: Bump golang.org/x/tools v0.38.0 -> v0.49.0 for Go 1.27 compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-critic/go-critic
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cristalhq/acmd v0.12.0
@@ -16,13 +16,13 @@ require (
 	github.com/quasilyte/go-ruleguard v0.4.5
 	github.com/quasilyte/go-ruleguard/dsl v0.3.23
 	github.com/quasilyte/regex/syntax v0.0.0-20210819130434-b3f0c404a727
-	golang.org/x/tools v0.38.0
+	golang.org/x/tools v0.49.0
 )
 
 require (
 	github.com/quasilyte/gogrep v0.5.0 // indirect
 	github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20251023183803-a4bb9ffd2546 // indirect
-	golang.org/x/mod v0.29.0 // indirect
-	golang.org/x/sync v0.17.0 // indirect
+	golang.org/x/mod v0.39.0 // indirect
+	golang.org/x/sync v0.22.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -36,9 +36,9 @@ golang.org/x/exp/typeparams v0.0.0-20220428152302-39d4317da171/go.mod h1:AbB0pIl
 golang.org/x/exp/typeparams v0.0.0-20230203172020-98cc5a0785f9/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/exp/typeparams v0.0.0-20251023183803-a4bb9ffd2546 h1:HDjDiATsGqvuqvkDvgJjD1IgPrVekcSXVVE21JwvzGE=
 golang.org/x/exp/typeparams v0.0.0-20251023183803-a4bb9ffd2546/go.mod h1:4Mzdyp/6jzw9auFDJ3OMF5qksa7UvPnzKqTVGcb04ms=
-golang.org/x/mod v0.29.0 h1:HV8lRxZC4l2cr3Zq1LvtOsi/ThTgWnUk/y64QSs8GwA=
-golang.org/x/mod v0.29.0/go.mod h1:NyhrlYXJ2H4eJiRy/WDBO6HMqZQ6q9nk4JzS3NuCK+w=
-golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
-golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
-golang.org/x/tools v0.38.0 h1:Hx2Xv8hISq8Lm16jvBZ2VQf+RLmbd7wVUsALibYI/IQ=
-golang.org/x/tools v0.38.0/go.mod h1:yEsQ/d/YK8cjh0L6rZlY8tgtlKiBNTL14pGDJPJpYQs=
+golang.org/x/mod v0.39.0 h1:UF5zwQdCRRUpHfyPwr7d4UrGiVeldIsogtzWVnczL74=
+golang.org/x/mod v0.39.0/go.mod h1:bvIbwjQ0HUFFf5AKukeeYQG4ZBUG9yxQbR9aEweIwYY=
+golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/tools v0.49.0 h1:3NI7VXzL9+1WZD52Dx2ttoPwD5DWrFGpl9mFZDlmisI=
+golang.org/x/tools v0.49.0/go.mod h1:SJNXV9DBKT0UbdttsQjbfJlAE/q+y36++zo3uL3N0Oo=


### PR DESCRIPTION
With `go version go1.27.1 darwin/arm64` tests failed with `internal error: package "bytes" without types was imported from "github.com/go-critic/go-critic/checkers/testdata/argOrder"`

## Tests before FAIL:
```
$ make test
go test -v -count=1 ./...
?       github.com/go-critic/go-critic  [no test files]
=== RUN   TestCheckers
=== RUN   TestCheckers/appendAssign/debug
=== RUN   TestCheckers/appendCombine/debug
=== RUN   TestCheckers/argOrder/debug
=== RUN   TestCheckers/assignOp/debug
=== RUN   TestCheckers/badCall/debug
=== RUN   TestCheckers/badCond/debug
=== RUN   TestCheckers/badLock/debug
=== RUN   TestCheckers/badRegexp/debug
=== RUN   TestCheckers/badSorting/debug
=== RUN   TestCheckers/badSyncOnceFunc/debug
=== RUN   TestCheckers/boolExprSimplify/debug
=== RUN   TestCheckers/builtinShadow/debug
=== RUN   TestCheckers/builtinShadowDecl/debug
=== RUN   TestCheckers/captLocal/debug
=== RUN   TestCheckers/caseOrder/debug
=== RUN   TestCheckers/codegenComment/debug
=== RUN   TestCheckers/commentFormatting/debug
=== RUN   TestCheckers/commentedOutCode/debug
=== RUN   TestCheckers/commentedOutImport/debug
=== RUN   TestCheckers/defaultCaseOrder/debug
=== RUN   TestCheckers/deferInLoop/debug
=== RUN   TestCheckers/deferUnlambda/debug
=== RUN   TestCheckers/deprecatedComment/debug
=== RUN   TestCheckers/docStub/debug
=== RUN   TestCheckers/dupArg/debug
=== RUN   TestCheckers/dupBranchBody/debug
=== RUN   TestCheckers/dupCase/debug
=== RUN   TestCheckers/dupImport/debug
=== RUN   TestCheckers/dupOption/debug
=== RUN   TestCheckers/dupSubExpr/debug
=== RUN   TestCheckers/dynamicFmtString/debug
=== RUN   TestCheckers/elseif/debug
=== RUN   TestCheckers/emptyDecl/debug
=== RUN   TestCheckers/emptyFallthrough/debug
=== RUN   TestCheckers/emptyStringTest/debug
=== RUN   TestCheckers/equalFold/debug
=== RUN   TestCheckers/evalOrder/debug
=== RUN   TestCheckers/exitAfterDefer/debug
=== RUN   TestCheckers/exposedSyncMutex/debug
=== RUN   TestCheckers/externalErrorReassign/debug
=== RUN   TestCheckers/filepathJoin/debug
=== RUN   TestCheckers/flagDeref/debug
=== RUN   TestCheckers/flagName/debug
=== RUN   TestCheckers/hexLiteral/debug
=== RUN   TestCheckers/httpNoBody/debug
=== RUN   TestCheckers/hugeParam/debug
=== RUN   TestCheckers/ifElseChain/debug
=== RUN   TestCheckers/importShadow/debug
=== RUN   TestCheckers/indexAlloc/debug
=== RUN   TestCheckers/initClause/debug
=== RUN   TestCheckers/mapKey/debug
=== RUN   TestCheckers/methodExprCall/debug
=== RUN   TestCheckers/nestingReduce/debug
=== RUN   TestCheckers/newDeref/debug
=== RUN   TestCheckers/nilValReturn/debug
=== RUN   TestCheckers/octalLiteral/debug
=== RUN   TestCheckers/offBy1/debug
=== RUN   TestCheckers/paramTypeCombine/debug
=== RUN   TestCheckers/preferDecodeRune/debug
=== RUN   TestCheckers/preferFilepathJoin/debug
=== RUN   TestCheckers/preferFprint/debug
=== RUN   TestCheckers/preferStringWriter/debug
=== RUN   TestCheckers/preferWriteByte/debug
=== RUN   TestCheckers/ptrToRefParam/debug
=== RUN   TestCheckers/rangeAppendAll/debug
=== RUN   TestCheckers/rangeExprCopy/debug
=== RUN   TestCheckers/rangeValCopy/debug
=== RUN   TestCheckers/redundantSprint/debug
=== RUN   TestCheckers/regexpMust/debug
=== RUN   TestCheckers/regexpPattern/debug
=== RUN   TestCheckers/regexpSimplify/debug
=== RUN   TestCheckers/returnAfterHttpError/debug
=== RUN   TestCheckers/ruleguard/debug
=== RUN   TestCheckers/singleCaseSwitch/debug
=== RUN   TestCheckers/sliceClear/debug
=== RUN   TestCheckers/sloppyLen/debug
=== RUN   TestCheckers/sloppyReassign/debug
=== RUN   TestCheckers/sloppyTypeAssert/debug
=== RUN   TestCheckers/sortSlice/debug
=== RUN   TestCheckers/sprintfQuotedString/debug
=== RUN   TestCheckers/sqlQuery/debug
=== RUN   TestCheckers/stringConcatSimplify/debug
=== RUN   TestCheckers/stringXbytes/debug
=== RUN   TestCheckers/stringsCompare/debug
=== RUN   TestCheckers/switchTrue/debug
=== RUN   TestCheckers/syncMapLoadAndDelete/debug
=== RUN   TestCheckers/timeExprSimplify/debug
=== RUN   TestCheckers/todoCommentWithoutDetail/debug
=== RUN   TestCheckers/tooManyResultsChecker/debug
=== RUN   TestCheckers/truncateCmp/debug
=== RUN   TestCheckers/typeAssertChain/debug
=== RUN   TestCheckers/typeDefFirst/debug
=== RUN   TestCheckers/typeSwitchVar/debug
=== RUN   TestCheckers/typeUnparen/debug
=== RUN   TestCheckers/uncheckedInlineErr/debug
=== RUN   TestCheckers/underef/debug
=== RUN   TestCheckers/unlabelStmt/debug
=== RUN   TestCheckers/unlambda/debug
=== RUN   TestCheckers/unnamedResult/debug
=== RUN   TestCheckers/unnecessaryBlock/debug
=== RUN   TestCheckers/unnecessaryDefer/debug
=== RUN   TestCheckers/unslice/debug
=== RUN   TestCheckers/valSwap/debug
=== RUN   TestCheckers/weakCond/debug
=== RUN   TestCheckers/whyNoLint/debug
=== RUN   TestCheckers/wrapperFunc/debug
=== RUN   TestCheckers/yodaStyleExpr/debug
=== RUN   TestCheckers/zeroByteRepeat/debug
=== RUN   TestCheckers/appendAssign/sanity
=== RUN   TestCheckers/appendCombine/sanity
=== RUN   TestCheckers/argOrder/sanity
=== RUN   TestCheckers/assignOp/sanity
=== RUN   TestCheckers/badCall/sanity
=== RUN   TestCheckers/badCond/sanity
=== RUN   TestCheckers/badLock/sanity
=== RUN   TestCheckers/badRegexp/sanity
=== RUN   TestCheckers/badSorting/sanity
=== RUN   TestCheckers/badSyncOnceFunc/sanity
=== RUN   TestCheckers/boolExprSimplify/sanity
=== RUN   TestCheckers/builtinShadow/sanity
=== RUN   TestCheckers/builtinShadowDecl/sanity
=== RUN   TestCheckers/captLocal/sanity
=== RUN   TestCheckers/caseOrder/sanity
=== RUN   TestCheckers/codegenComment/sanity
=== RUN   TestCheckers/commentFormatting/sanity
=== RUN   TestCheckers/commentedOutCode/sanity
=== RUN   TestCheckers/commentedOutImport/sanity
=== RUN   TestCheckers/defaultCaseOrder/sanity
=== RUN   TestCheckers/deferInLoop/sanity
=== RUN   TestCheckers/deferUnlambda/sanity
=== RUN   TestCheckers/deprecatedComment/sanity
=== RUN   TestCheckers/docStub/sanity
=== RUN   TestCheckers/dupArg/sanity
=== RUN   TestCheckers/dupBranchBody/sanity
=== RUN   TestCheckers/dupCase/sanity
=== RUN   TestCheckers/dupImport/sanity
=== RUN   TestCheckers/dupOption/sanity
=== RUN   TestCheckers/dupSubExpr/sanity
=== RUN   TestCheckers/dynamicFmtString/sanity
=== RUN   TestCheckers/elseif/sanity
=== RUN   TestCheckers/emptyDecl/sanity
=== RUN   TestCheckers/emptyFallthrough/sanity
=== RUN   TestCheckers/emptyStringTest/sanity
=== RUN   TestCheckers/equalFold/sanity
=== RUN   TestCheckers/evalOrder/sanity
=== RUN   TestCheckers/exitAfterDefer/sanity
=== RUN   TestCheckers/exposedSyncMutex/sanity
=== RUN   TestCheckers/externalErrorReassign/sanity
=== RUN   TestCheckers/filepathJoin/sanity
=== RUN   TestCheckers/flagDeref/sanity
=== RUN   TestCheckers/flagName/sanity
=== RUN   TestCheckers/hexLiteral/sanity
=== RUN   TestCheckers/httpNoBody/sanity
=== RUN   TestCheckers/hugeParam/sanity
=== RUN   TestCheckers/ifElseChain/sanity
=== RUN   TestCheckers/importShadow/sanity
=== RUN   TestCheckers/indexAlloc/sanity
=== RUN   TestCheckers/initClause/sanity
=== RUN   TestCheckers/mapKey/sanity
=== RUN   TestCheckers/methodExprCall/sanity
=== RUN   TestCheckers/nestingReduce/sanity
=== RUN   TestCheckers/newDeref/sanity
=== RUN   TestCheckers/nilValReturn/sanity
=== RUN   TestCheckers/octalLiteral/sanity
=== RUN   TestCheckers/offBy1/sanity
=== RUN   TestCheckers/paramTypeCombine/sanity
=== RUN   TestCheckers/preferDecodeRune/sanity
=== RUN   TestCheckers/preferFilepathJoin/sanity
=== RUN   TestCheckers/preferFprint/sanity
=== RUN   TestCheckers/preferStringWriter/sanity
=== RUN   TestCheckers/preferWriteByte/sanity
=== RUN   TestCheckers/ptrToRefParam/sanity
=== RUN   TestCheckers/rangeAppendAll/sanity
=== RUN   TestCheckers/rangeExprCopy/sanity
=== RUN   TestCheckers/rangeValCopy/sanity
=== RUN   TestCheckers/redundantSprint/sanity
=== RUN   TestCheckers/regexpMust/sanity
=== RUN   TestCheckers/regexpPattern/sanity
=== RUN   TestCheckers/regexpSimplify/sanity
=== RUN   TestCheckers/returnAfterHttpError/sanity
=== RUN   TestCheckers/ruleguard/sanity
=== RUN   TestCheckers/singleCaseSwitch/sanity
=== RUN   TestCheckers/sliceClear/sanity
=== RUN   TestCheckers/sloppyLen/sanity
=== RUN   TestCheckers/sloppyReassign/sanity
=== RUN   TestCheckers/sloppyTypeAssert/sanity
=== RUN   TestCheckers/sortSlice/sanity
=== RUN   TestCheckers/sprintfQuotedString/sanity
=== RUN   TestCheckers/sqlQuery/sanity
=== RUN   TestCheckers/stringConcatSimplify/sanity
=== RUN   TestCheckers/stringXbytes/sanity
=== RUN   TestCheckers/stringsCompare/sanity
=== RUN   TestCheckers/switchTrue/sanity
=== RUN   TestCheckers/syncMapLoadAndDelete/sanity
=== RUN   TestCheckers/timeExprSimplify/sanity
=== RUN   TestCheckers/todoCommentWithoutDetail/sanity
=== RUN   TestCheckers/tooManyResultsChecker/sanity
=== RUN   TestCheckers/truncateCmp/sanity
=== RUN   TestCheckers/typeAssertChain/sanity
=== RUN   TestCheckers/typeDefFirst/sanity
=== RUN   TestCheckers/typeSwitchVar/sanity
=== RUN   TestCheckers/typeUnparen/sanity
=== RUN   TestCheckers/uncheckedInlineErr/sanity
=== RUN   TestCheckers/underef/sanity
=== RUN   TestCheckers/unlabelStmt/sanity
=== RUN   TestCheckers/unlambda/sanity
=== RUN   TestCheckers/unnamedResult/sanity
=== RUN   TestCheckers/unnecessaryBlock/sanity
=== RUN   TestCheckers/unnecessaryDefer/sanity
=== RUN   TestCheckers/unslice/sanity
=== RUN   TestCheckers/valSwap/sanity
=== RUN   TestCheckers/weakCond/sanity
=== RUN   TestCheckers/whyNoLint/sanity
=== RUN   TestCheckers/wrapperFunc/sanity
=== RUN   TestCheckers/yodaStyleExpr/sanity
=== RUN   TestCheckers/zeroByteRepeat/sanity
=== RUN   TestCheckers/appendAssign
=== RUN   TestCheckers/appendCombine
=== RUN   TestCheckers/argOrder
2026/09/03 05:25:20 internal error: package "bytes" without types was imported from "github.com/go-critic/go-critic/checkers/testdata/argOrder"
FAIL    github.com/go-critic/go-critic/checkers 5.866s
?       github.com/go-critic/go-critic/checkers/analyzer        [no test files]
?       github.com/go-critic/go-critic/checkers/internal/astwalk        [no test files]
?       github.com/go-critic/go-critic/checkers/internal/linttest       [no test files]
?       github.com/go-critic/go-critic/checkers/internal/lintutil       [no test files]
?       github.com/go-critic/go-critic/checkers/rules   [no test files]
?       github.com/go-critic/go-critic/checkers/rulesdata       [no test files]
=== RUN   TestShortenLocation
--- PASS: TestShortenLocation (0.00s)
PASS
ok      github.com/go-critic/go-critic/cmd/go-critic    0.437s
?       github.com/go-critic/go-critic/cmd/go-critic-analysis   [no test files]
=== RUN   TestShortenLocation
--- PASS: TestShortenLocation (0.00s)
PASS
ok      github.com/go-critic/go-critic/cmd/gocritic     1.393s
?       github.com/go-critic/go-critic/cmd/gocritic-analysis    [no test files]
?       github.com/go-critic/go-critic/cmd/makedocs     [no test files]
=== RUN   TestGoVersionParse
--- PASS: TestGoVersionParse (0.00s)
=== RUN   TestGoVersionCompare
--- PASS: TestGoVersionCompare (0.00s)
PASS
ok      github.com/go-critic/go-critic/linter   1.056s
=== RUN   TestRules
--- PASS: TestRules (0.57s)
PASS
ok      github.com/go-critic/go-critic/rulestest        2.324s
FAIL
make: *** [test] Error 1
```

## Bump done via:
```
$ go get -u golang.org/x/tools@latest && go mod tidy 
go: upgraded go 1.24.0 => 1.25.0
go: upgraded golang.org/x/mod v0.29.0 => v0.39.0
go: upgraded golang.org/x/sync v0.17.0 => v0.22.0
go: upgraded golang.org/x/tools v0.38.0 => v0.49.0
```

## Tests after PASS:
```
$ make test
go test -v -count=1 ./...
?       github.com/go-critic/go-critic  [no test files]
=== RUN   TestCheckers
=== RUN   TestCheckers/appendAssign/debug
=== RUN   TestCheckers/appendCombine/debug
=== RUN   TestCheckers/argOrder/debug
=== RUN   TestCheckers/assignOp/debug
=== RUN   TestCheckers/badCall/debug
=== RUN   TestCheckers/badCond/debug
=== RUN   TestCheckers/badLock/debug
=== RUN   TestCheckers/badRegexp/debug
=== RUN   TestCheckers/badSorting/debug
=== RUN   TestCheckers/badSyncOnceFunc/debug
=== RUN   TestCheckers/boolExprSimplify/debug
=== RUN   TestCheckers/builtinShadow/debug
=== RUN   TestCheckers/builtinShadowDecl/debug
=== RUN   TestCheckers/captLocal/debug
=== RUN   TestCheckers/caseOrder/debug
=== RUN   TestCheckers/codegenComment/debug
=== RUN   TestCheckers/commentFormatting/debug
=== RUN   TestCheckers/commentedOutCode/debug
=== RUN   TestCheckers/commentedOutImport/debug
=== RUN   TestCheckers/defaultCaseOrder/debug
=== RUN   TestCheckers/deferInLoop/debug
=== RUN   TestCheckers/deferUnlambda/debug
=== RUN   TestCheckers/deprecatedComment/debug
=== RUN   TestCheckers/docStub/debug
=== RUN   TestCheckers/dupArg/debug
=== RUN   TestCheckers/dupBranchBody/debug
=== RUN   TestCheckers/dupCase/debug
=== RUN   TestCheckers/dupImport/debug
=== RUN   TestCheckers/dupOption/debug
=== RUN   TestCheckers/dupSubExpr/debug
=== RUN   TestCheckers/dynamicFmtString/debug
=== RUN   TestCheckers/elseif/debug
=== RUN   TestCheckers/emptyDecl/debug
=== RUN   TestCheckers/emptyFallthrough/debug
=== RUN   TestCheckers/emptyStringTest/debug
=== RUN   TestCheckers/equalFold/debug
=== RUN   TestCheckers/evalOrder/debug
=== RUN   TestCheckers/exitAfterDefer/debug
=== RUN   TestCheckers/exposedSyncMutex/debug
=== RUN   TestCheckers/externalErrorReassign/debug
=== RUN   TestCheckers/filepathJoin/debug
=== RUN   TestCheckers/flagDeref/debug
=== RUN   TestCheckers/flagName/debug
=== RUN   TestCheckers/hexLiteral/debug
=== RUN   TestCheckers/httpNoBody/debug
=== RUN   TestCheckers/hugeParam/debug
=== RUN   TestCheckers/ifElseChain/debug
=== RUN   TestCheckers/importShadow/debug
=== RUN   TestCheckers/indexAlloc/debug
=== RUN   TestCheckers/initClause/debug
=== RUN   TestCheckers/mapKey/debug
=== RUN   TestCheckers/methodExprCall/debug
=== RUN   TestCheckers/nestingReduce/debug
=== RUN   TestCheckers/newDeref/debug
=== RUN   TestCheckers/nilValReturn/debug
=== RUN   TestCheckers/octalLiteral/debug
=== RUN   TestCheckers/offBy1/debug
=== RUN   TestCheckers/paramTypeCombine/debug
=== RUN   TestCheckers/preferDecodeRune/debug
=== RUN   TestCheckers/preferFilepathJoin/debug
=== RUN   TestCheckers/preferFprint/debug
=== RUN   TestCheckers/preferStringWriter/debug
=== RUN   TestCheckers/preferWriteByte/debug
=== RUN   TestCheckers/ptrToRefParam/debug
=== RUN   TestCheckers/rangeAppendAll/debug
=== RUN   TestCheckers/rangeExprCopy/debug
=== RUN   TestCheckers/rangeValCopy/debug
=== RUN   TestCheckers/redundantSprint/debug
=== RUN   TestCheckers/regexpMust/debug
=== RUN   TestCheckers/regexpPattern/debug
=== RUN   TestCheckers/regexpSimplify/debug
=== RUN   TestCheckers/returnAfterHttpError/debug
=== RUN   TestCheckers/ruleguard/debug
=== RUN   TestCheckers/singleCaseSwitch/debug
=== RUN   TestCheckers/sliceClear/debug
=== RUN   TestCheckers/sloppyLen/debug
=== RUN   TestCheckers/sloppyReassign/debug
=== RUN   TestCheckers/sloppyTypeAssert/debug
=== RUN   TestCheckers/sortSlice/debug
=== RUN   TestCheckers/sprintfQuotedString/debug
=== RUN   TestCheckers/sqlQuery/debug
=== RUN   TestCheckers/stringConcatSimplify/debug
=== RUN   TestCheckers/stringXbytes/debug
=== RUN   TestCheckers/stringsCompare/debug
=== RUN   TestCheckers/switchTrue/debug
=== RUN   TestCheckers/syncMapLoadAndDelete/debug
=== RUN   TestCheckers/timeExprSimplify/debug
=== RUN   TestCheckers/todoCommentWithoutDetail/debug
=== RUN   TestCheckers/tooManyResultsChecker/debug
=== RUN   TestCheckers/truncateCmp/debug
=== RUN   TestCheckers/typeAssertChain/debug
=== RUN   TestCheckers/typeDefFirst/debug
=== RUN   TestCheckers/typeSwitchVar/debug
=== RUN   TestCheckers/typeUnparen/debug
=== RUN   TestCheckers/uncheckedInlineErr/debug
=== RUN   TestCheckers/underef/debug
=== RUN   TestCheckers/unlabelStmt/debug
=== RUN   TestCheckers/unlambda/debug
=== RUN   TestCheckers/unnamedResult/debug
=== RUN   TestCheckers/unnecessaryBlock/debug
=== RUN   TestCheckers/unnecessaryDefer/debug
=== RUN   TestCheckers/unslice/debug
=== RUN   TestCheckers/valSwap/debug
=== RUN   TestCheckers/weakCond/debug
=== RUN   TestCheckers/whyNoLint/debug
=== RUN   TestCheckers/wrapperFunc/debug
=== RUN   TestCheckers/yodaStyleExpr/debug
=== RUN   TestCheckers/zeroByteRepeat/debug
=== RUN   TestCheckers/appendAssign/sanity
=== RUN   TestCheckers/appendCombine/sanity
=== RUN   TestCheckers/argOrder/sanity
=== RUN   TestCheckers/assignOp/sanity
=== RUN   TestCheckers/badCall/sanity
=== RUN   TestCheckers/badCond/sanity
=== RUN   TestCheckers/badLock/sanity
=== RUN   TestCheckers/badRegexp/sanity
=== RUN   TestCheckers/badSorting/sanity
=== RUN   TestCheckers/badSyncOnceFunc/sanity
=== RUN   TestCheckers/boolExprSimplify/sanity
=== RUN   TestCheckers/builtinShadow/sanity
=== RUN   TestCheckers/builtinShadowDecl/sanity
=== RUN   TestCheckers/captLocal/sanity
=== RUN   TestCheckers/caseOrder/sanity
=== RUN   TestCheckers/codegenComment/sanity
=== RUN   TestCheckers/commentFormatting/sanity
=== RUN   TestCheckers/commentedOutCode/sanity
=== RUN   TestCheckers/commentedOutImport/sanity
=== RUN   TestCheckers/defaultCaseOrder/sanity
=== RUN   TestCheckers/deferInLoop/sanity
=== RUN   TestCheckers/deferUnlambda/sanity
=== RUN   TestCheckers/deprecatedComment/sanity
=== RUN   TestCheckers/docStub/sanity
=== RUN   TestCheckers/dupArg/sanity
=== RUN   TestCheckers/dupBranchBody/sanity
=== RUN   TestCheckers/dupCase/sanity
=== RUN   TestCheckers/dupImport/sanity
=== RUN   TestCheckers/dupOption/sanity
=== RUN   TestCheckers/dupSubExpr/sanity
=== RUN   TestCheckers/dynamicFmtString/sanity
=== RUN   TestCheckers/elseif/sanity
=== RUN   TestCheckers/emptyDecl/sanity
=== RUN   TestCheckers/emptyFallthrough/sanity
=== RUN   TestCheckers/emptyStringTest/sanity
=== RUN   TestCheckers/equalFold/sanity
=== RUN   TestCheckers/evalOrder/sanity
=== RUN   TestCheckers/exitAfterDefer/sanity
=== RUN   TestCheckers/exposedSyncMutex/sanity
=== RUN   TestCheckers/externalErrorReassign/sanity
=== RUN   TestCheckers/filepathJoin/sanity
=== RUN   TestCheckers/flagDeref/sanity
=== RUN   TestCheckers/flagName/sanity
=== RUN   TestCheckers/hexLiteral/sanity
=== RUN   TestCheckers/httpNoBody/sanity
=== RUN   TestCheckers/hugeParam/sanity
=== RUN   TestCheckers/ifElseChain/sanity
=== RUN   TestCheckers/importShadow/sanity
=== RUN   TestCheckers/indexAlloc/sanity
=== RUN   TestCheckers/initClause/sanity
=== RUN   TestCheckers/mapKey/sanity
=== RUN   TestCheckers/methodExprCall/sanity
=== RUN   TestCheckers/nestingReduce/sanity
=== RUN   TestCheckers/newDeref/sanity
=== RUN   TestCheckers/nilValReturn/sanity
=== RUN   TestCheckers/octalLiteral/sanity
=== RUN   TestCheckers/offBy1/sanity
=== RUN   TestCheckers/paramTypeCombine/sanity
=== RUN   TestCheckers/preferDecodeRune/sanity
=== RUN   TestCheckers/preferFilepathJoin/sanity
=== RUN   TestCheckers/preferFprint/sanity
=== RUN   TestCheckers/preferStringWriter/sanity
=== RUN   TestCheckers/preferWriteByte/sanity
=== RUN   TestCheckers/ptrToRefParam/sanity
=== RUN   TestCheckers/rangeAppendAll/sanity
=== RUN   TestCheckers/rangeExprCopy/sanity
=== RUN   TestCheckers/rangeValCopy/sanity
=== RUN   TestCheckers/redundantSprint/sanity
=== RUN   TestCheckers/regexpMust/sanity
=== RUN   TestCheckers/regexpPattern/sanity
=== RUN   TestCheckers/regexpSimplify/sanity
=== RUN   TestCheckers/returnAfterHttpError/sanity
=== RUN   TestCheckers/ruleguard/sanity
=== RUN   TestCheckers/singleCaseSwitch/sanity
=== RUN   TestCheckers/sliceClear/sanity
=== RUN   TestCheckers/sloppyLen/sanity
=== RUN   TestCheckers/sloppyReassign/sanity
=== RUN   TestCheckers/sloppyTypeAssert/sanity
=== RUN   TestCheckers/sortSlice/sanity
=== RUN   TestCheckers/sprintfQuotedString/sanity
=== RUN   TestCheckers/sqlQuery/sanity
=== RUN   TestCheckers/stringConcatSimplify/sanity
=== RUN   TestCheckers/stringXbytes/sanity
=== RUN   TestCheckers/stringsCompare/sanity
=== RUN   TestCheckers/switchTrue/sanity
=== RUN   TestCheckers/syncMapLoadAndDelete/sanity
=== RUN   TestCheckers/timeExprSimplify/sanity
=== RUN   TestCheckers/todoCommentWithoutDetail/sanity
=== RUN   TestCheckers/tooManyResultsChecker/sanity
=== RUN   TestCheckers/truncateCmp/sanity
=== RUN   TestCheckers/typeAssertChain/sanity
=== RUN   TestCheckers/typeDefFirst/sanity
=== RUN   TestCheckers/typeSwitchVar/sanity
=== RUN   TestCheckers/typeUnparen/sanity
=== RUN   TestCheckers/uncheckedInlineErr/sanity
=== RUN   TestCheckers/underef/sanity
=== RUN   TestCheckers/unlabelStmt/sanity
=== RUN   TestCheckers/unlambda/sanity
=== RUN   TestCheckers/unnamedResult/sanity
=== RUN   TestCheckers/unnecessaryBlock/sanity
=== RUN   TestCheckers/unnecessaryDefer/sanity
=== RUN   TestCheckers/unslice/sanity
=== RUN   TestCheckers/valSwap/sanity
=== RUN   TestCheckers/weakCond/sanity
=== RUN   TestCheckers/whyNoLint/sanity
=== RUN   TestCheckers/wrapperFunc/sanity
=== RUN   TestCheckers/yodaStyleExpr/sanity
=== RUN   TestCheckers/zeroByteRepeat/sanity
=== RUN   TestCheckers/appendAssign
=== RUN   TestCheckers/appendCombine
=== RUN   TestCheckers/argOrder
=== RUN   TestCheckers/assignOp
=== RUN   TestCheckers/badCall
=== RUN   TestCheckers/badCond
=== RUN   TestCheckers/badLock
=== RUN   TestCheckers/badRegexp
=== RUN   TestCheckers/badSorting
=== RUN   TestCheckers/badSyncOnceFunc
=== RUN   TestCheckers/boolExprSimplify
=== RUN   TestCheckers/builtinShadow
=== RUN   TestCheckers/builtinShadowDecl
=== RUN   TestCheckers/captLocal
=== RUN   TestCheckers/caseOrder
=== RUN   TestCheckers/codegenComment
=== RUN   TestCheckers/commentFormatting
=== RUN   TestCheckers/commentedOutCode
=== RUN   TestCheckers/commentedOutImport
=== RUN   TestCheckers/defaultCaseOrder
=== RUN   TestCheckers/deferInLoop
=== RUN   TestCheckers/deferUnlambda
=== RUN   TestCheckers/deprecatedComment
=== RUN   TestCheckers/docStub
=== RUN   TestCheckers/dupArg
=== RUN   TestCheckers/dupBranchBody
=== RUN   TestCheckers/dupCase
=== RUN   TestCheckers/dupImport
=== RUN   TestCheckers/dupOption
=== RUN   TestCheckers/dupSubExpr
=== RUN   TestCheckers/dynamicFmtString
=== RUN   TestCheckers/elseif
=== RUN   TestCheckers/emptyDecl
=== RUN   TestCheckers/emptyFallthrough
=== RUN   TestCheckers/emptyStringTest
=== RUN   TestCheckers/equalFold
=== RUN   TestCheckers/evalOrder
=== RUN   TestCheckers/exitAfterDefer
=== RUN   TestCheckers/exposedSyncMutex
=== RUN   TestCheckers/externalErrorReassign
=== RUN   TestCheckers/filepathJoin
=== RUN   TestCheckers/flagDeref
=== RUN   TestCheckers/flagName
=== RUN   TestCheckers/hexLiteral
=== RUN   TestCheckers/httpNoBody
=== RUN   TestCheckers/hugeParam
=== RUN   TestCheckers/ifElseChain
=== RUN   TestCheckers/importShadow
=== RUN   TestCheckers/indexAlloc
=== RUN   TestCheckers/initClause
=== RUN   TestCheckers/mapKey
=== RUN   TestCheckers/methodExprCall
=== RUN   TestCheckers/nestingReduce
=== RUN   TestCheckers/newDeref
=== RUN   TestCheckers/nilValReturn
=== RUN   TestCheckers/octalLiteral
=== RUN   TestCheckers/offBy1
=== RUN   TestCheckers/paramTypeCombine
=== RUN   TestCheckers/preferDecodeRune
=== RUN   TestCheckers/preferFilepathJoin
=== RUN   TestCheckers/preferFprint
=== RUN   TestCheckers/preferStringWriter
=== RUN   TestCheckers/preferWriteByte
=== RUN   TestCheckers/ptrToRefParam
=== RUN   TestCheckers/rangeAppendAll
=== RUN   TestCheckers/rangeExprCopy
=== RUN   TestCheckers/rangeValCopy
=== RUN   TestCheckers/redundantSprint
=== RUN   TestCheckers/regexpMust
=== RUN   TestCheckers/regexpPattern
=== RUN   TestCheckers/regexpSimplify
=== RUN   TestCheckers/returnAfterHttpError
=== RUN   TestCheckers/ruleguard
=== RUN   TestCheckers/singleCaseSwitch
=== RUN   TestCheckers/sliceClear
=== RUN   TestCheckers/sloppyLen
=== RUN   TestCheckers/sloppyReassign
=== RUN   TestCheckers/sloppyTypeAssert
=== RUN   TestCheckers/sortSlice
=== RUN   TestCheckers/sprintfQuotedString
=== RUN   TestCheckers/sqlQuery
=== RUN   TestCheckers/stringConcatSimplify
=== RUN   TestCheckers/stringXbytes
=== RUN   TestCheckers/stringsCompare
=== RUN   TestCheckers/switchTrue
=== RUN   TestCheckers/syncMapLoadAndDelete
=== RUN   TestCheckers/timeExprSimplify
=== RUN   TestCheckers/todoCommentWithoutDetail
=== RUN   TestCheckers/tooManyResultsChecker
=== RUN   TestCheckers/truncateCmp
=== RUN   TestCheckers/typeAssertChain
=== RUN   TestCheckers/typeDefFirst
=== RUN   TestCheckers/typeSwitchVar
=== RUN   TestCheckers/typeUnparen
=== RUN   TestCheckers/uncheckedInlineErr
=== RUN   TestCheckers/underef
=== RUN   TestCheckers/unlabelStmt
=== RUN   TestCheckers/unlambda
=== RUN   TestCheckers/unnamedResult
=== RUN   TestCheckers/unnecessaryBlock
=== RUN   TestCheckers/unnecessaryDefer
=== RUN   TestCheckers/unslice
=== RUN   TestCheckers/valSwap
=== RUN   TestCheckers/weakCond
=== RUN   TestCheckers/whyNoLint
=== RUN   TestCheckers/wrapperFunc
=== RUN   TestCheckers/yodaStyleExpr
=== RUN   TestCheckers/zeroByteRepeat
--- PASS: TestCheckers (10.74s)
    --- PASS: TestCheckers/appendAssign/debug (0.03s)
    --- PASS: TestCheckers/appendCombine/debug (0.02s)
    --- PASS: TestCheckers/argOrder/debug (0.02s)
    --- PASS: TestCheckers/assignOp/debug (0.02s)
    --- PASS: TestCheckers/badCall/debug (0.02s)
    --- PASS: TestCheckers/badCond/debug (0.02s)
    --- PASS: TestCheckers/badLock/debug (0.02s)
    --- PASS: TestCheckers/badRegexp/debug (0.02s)
    --- PASS: TestCheckers/badSorting/debug (0.02s)
    --- PASS: TestCheckers/badSyncOnceFunc/debug (0.02s)
    --- PASS: TestCheckers/boolExprSimplify/debug (0.02s)
    --- PASS: TestCheckers/builtinShadow/debug (0.02s)
    --- PASS: TestCheckers/builtinShadowDecl/debug (0.02s)
    --- PASS: TestCheckers/captLocal/debug (0.02s)
    --- PASS: TestCheckers/caseOrder/debug (0.02s)
    --- PASS: TestCheckers/codegenComment/debug (0.02s)
    --- PASS: TestCheckers/commentFormatting/debug (0.02s)
    --- PASS: TestCheckers/commentedOutCode/debug (0.02s)
    --- PASS: TestCheckers/commentedOutImport/debug (0.02s)
    --- PASS: TestCheckers/defaultCaseOrder/debug (0.02s)
    --- PASS: TestCheckers/deferInLoop/debug (0.02s)
    --- PASS: TestCheckers/deferUnlambda/debug (0.02s)
    --- PASS: TestCheckers/deprecatedComment/debug (0.02s)
    --- PASS: TestCheckers/docStub/debug (0.02s)
    --- PASS: TestCheckers/dupArg/debug (0.02s)
    --- PASS: TestCheckers/dupBranchBody/debug (0.02s)
    --- PASS: TestCheckers/dupCase/debug (0.02s)
    --- PASS: TestCheckers/dupImport/debug (0.02s)
    --- PASS: TestCheckers/dupOption/debug (0.02s)
    --- PASS: TestCheckers/dupSubExpr/debug (0.02s)
    --- PASS: TestCheckers/dynamicFmtString/debug (0.02s)
    --- PASS: TestCheckers/elseif/debug (0.02s)
    --- PASS: TestCheckers/emptyDecl/debug (0.02s)
    --- PASS: TestCheckers/emptyFallthrough/debug (0.02s)
    --- PASS: TestCheckers/emptyStringTest/debug (0.02s)
    --- PASS: TestCheckers/equalFold/debug (0.02s)
    --- PASS: TestCheckers/evalOrder/debug (0.02s)
    --- PASS: TestCheckers/exitAfterDefer/debug (0.02s)
    --- PASS: TestCheckers/exposedSyncMutex/debug (0.02s)
    --- PASS: TestCheckers/externalErrorReassign/debug (0.02s)
    --- PASS: TestCheckers/filepathJoin/debug (0.02s)
    --- PASS: TestCheckers/flagDeref/debug (0.04s)
    --- PASS: TestCheckers/flagName/debug (0.03s)
    --- PASS: TestCheckers/hexLiteral/debug (0.02s)
    --- PASS: TestCheckers/httpNoBody/debug (0.04s)
    --- PASS: TestCheckers/hugeParam/debug (0.02s)
    --- PASS: TestCheckers/ifElseChain/debug (0.03s)
    --- PASS: TestCheckers/importShadow/debug (0.03s)
    --- PASS: TestCheckers/indexAlloc/debug (0.03s)
    --- PASS: TestCheckers/initClause/debug (0.04s)
    --- PASS: TestCheckers/mapKey/debug (0.03s)
    --- PASS: TestCheckers/methodExprCall/debug (0.03s)
    --- PASS: TestCheckers/nestingReduce/debug (0.03s)
    --- PASS: TestCheckers/newDeref/debug (0.03s)
    --- PASS: TestCheckers/nilValReturn/debug (0.02s)
    --- PASS: TestCheckers/octalLiteral/debug (0.02s)
    --- PASS: TestCheckers/offBy1/debug (0.02s)
    --- PASS: TestCheckers/paramTypeCombine/debug (0.02s)
    --- PASS: TestCheckers/preferDecodeRune/debug (0.02s)
    --- PASS: TestCheckers/preferFilepathJoin/debug (0.02s)
    --- PASS: TestCheckers/preferFprint/debug (0.02s)
    --- PASS: TestCheckers/preferStringWriter/debug (0.02s)
    --- PASS: TestCheckers/preferWriteByte/debug (0.02s)
    --- PASS: TestCheckers/ptrToRefParam/debug (0.02s)
    --- PASS: TestCheckers/rangeAppendAll/debug (0.02s)
    --- PASS: TestCheckers/rangeExprCopy/debug (0.02s)
    --- PASS: TestCheckers/rangeValCopy/debug (0.02s)
    --- PASS: TestCheckers/redundantSprint/debug (0.02s)
    --- PASS: TestCheckers/regexpMust/debug (0.02s)
    --- PASS: TestCheckers/regexpPattern/debug (0.02s)
    --- PASS: TestCheckers/regexpSimplify/debug (0.02s)
    --- PASS: TestCheckers/returnAfterHttpError/debug (0.02s)
    --- PASS: TestCheckers/ruleguard/debug (0.02s)
    --- PASS: TestCheckers/singleCaseSwitch/debug (0.02s)
    --- PASS: TestCheckers/sliceClear/debug (0.02s)
    --- PASS: TestCheckers/sloppyLen/debug (0.02s)
    --- PASS: TestCheckers/sloppyReassign/debug (0.02s)
    --- PASS: TestCheckers/sloppyTypeAssert/debug (0.02s)
    --- PASS: TestCheckers/sortSlice/debug (0.02s)
    --- PASS: TestCheckers/sprintfQuotedString/debug (0.02s)
    --- PASS: TestCheckers/sqlQuery/debug (0.02s)
    --- PASS: TestCheckers/stringConcatSimplify/debug (0.02s)
    --- PASS: TestCheckers/stringXbytes/debug (0.02s)
    --- PASS: TestCheckers/stringsCompare/debug (0.02s)
    --- PASS: TestCheckers/switchTrue/debug (0.02s)
    --- PASS: TestCheckers/syncMapLoadAndDelete/debug (0.02s)
    --- PASS: TestCheckers/timeExprSimplify/debug (0.02s)
    --- PASS: TestCheckers/todoCommentWithoutDetail/debug (0.02s)
    --- PASS: TestCheckers/tooManyResultsChecker/debug (0.02s)
    --- PASS: TestCheckers/truncateCmp/debug (0.02s)
    --- PASS: TestCheckers/typeAssertChain/debug (0.02s)
    --- PASS: TestCheckers/typeDefFirst/debug (0.02s)
    --- PASS: TestCheckers/typeSwitchVar/debug (0.02s)
    --- PASS: TestCheckers/typeUnparen/debug (0.02s)
    --- PASS: TestCheckers/uncheckedInlineErr/debug (0.02s)
    --- PASS: TestCheckers/underef/debug (0.03s)
    --- PASS: TestCheckers/unlabelStmt/debug (0.02s)
    --- PASS: TestCheckers/unlambda/debug (0.02s)
    --- PASS: TestCheckers/unnamedResult/debug (0.02s)
    --- PASS: TestCheckers/unnecessaryBlock/debug (0.02s)
    --- PASS: TestCheckers/unnecessaryDefer/debug (0.02s)
    --- PASS: TestCheckers/unslice/debug (0.02s)
    --- PASS: TestCheckers/valSwap/debug (0.02s)
    --- PASS: TestCheckers/weakCond/debug (0.02s)
    --- PASS: TestCheckers/whyNoLint/debug (0.02s)
    --- PASS: TestCheckers/wrapperFunc/debug (0.02s)
    --- PASS: TestCheckers/yodaStyleExpr/debug (0.02s)
    --- PASS: TestCheckers/zeroByteRepeat/debug (0.02s)
    --- PASS: TestCheckers/appendAssign/sanity (0.02s)
    --- PASS: TestCheckers/appendCombine/sanity (0.02s)
    --- PASS: TestCheckers/argOrder/sanity (0.02s)
    --- PASS: TestCheckers/assignOp/sanity (0.02s)
    --- PASS: TestCheckers/badCall/sanity (0.02s)
    --- PASS: TestCheckers/badCond/sanity (0.02s)
    --- PASS: TestCheckers/badLock/sanity (0.02s)
    --- PASS: TestCheckers/badRegexp/sanity (0.02s)
    --- PASS: TestCheckers/badSorting/sanity (0.02s)
    --- PASS: TestCheckers/badSyncOnceFunc/sanity (0.02s)
    --- PASS: TestCheckers/boolExprSimplify/sanity (0.02s)
    --- PASS: TestCheckers/builtinShadow/sanity (0.02s)
    --- PASS: TestCheckers/builtinShadowDecl/sanity (0.02s)
    --- PASS: TestCheckers/captLocal/sanity (0.02s)
    --- PASS: TestCheckers/caseOrder/sanity (0.02s)
    --- PASS: TestCheckers/codegenComment/sanity (0.02s)
    --- PASS: TestCheckers/commentFormatting/sanity (0.02s)
    --- PASS: TestCheckers/commentedOutCode/sanity (0.02s)
    --- PASS: TestCheckers/commentedOutImport/sanity (0.02s)
    --- PASS: TestCheckers/defaultCaseOrder/sanity (0.02s)
    --- PASS: TestCheckers/deferInLoop/sanity (0.02s)
    --- PASS: TestCheckers/deferUnlambda/sanity (0.02s)
    --- PASS: TestCheckers/deprecatedComment/sanity (0.02s)
    --- PASS: TestCheckers/docStub/sanity (0.02s)
    --- PASS: TestCheckers/dupArg/sanity (0.02s)
    --- PASS: TestCheckers/dupBranchBody/sanity (0.02s)
    --- PASS: TestCheckers/dupCase/sanity (0.02s)
    --- PASS: TestCheckers/dupImport/sanity (0.02s)
    --- PASS: TestCheckers/dupOption/sanity (0.02s)
    --- PASS: TestCheckers/dupSubExpr/sanity (0.02s)
    --- PASS: TestCheckers/dynamicFmtString/sanity (0.02s)
    --- PASS: TestCheckers/elseif/sanity (0.02s)
    --- PASS: TestCheckers/emptyDecl/sanity (0.02s)
    --- PASS: TestCheckers/emptyFallthrough/sanity (0.02s)
    --- PASS: TestCheckers/emptyStringTest/sanity (0.02s)
    --- PASS: TestCheckers/equalFold/sanity (0.02s)
    --- PASS: TestCheckers/evalOrder/sanity (0.02s)
    --- PASS: TestCheckers/exitAfterDefer/sanity (0.02s)
    --- PASS: TestCheckers/exposedSyncMutex/sanity (0.02s)
    --- PASS: TestCheckers/externalErrorReassign/sanity (0.02s)
    --- PASS: TestCheckers/filepathJoin/sanity (0.02s)
    --- PASS: TestCheckers/flagDeref/sanity (0.02s)
    --- PASS: TestCheckers/flagName/sanity (0.02s)
    --- PASS: TestCheckers/hexLiteral/sanity (0.02s)
    --- PASS: TestCheckers/httpNoBody/sanity (0.02s)
    --- PASS: TestCheckers/hugeParam/sanity (0.02s)
    --- PASS: TestCheckers/ifElseChain/sanity (0.02s)
    --- PASS: TestCheckers/importShadow/sanity (0.02s)
    --- PASS: TestCheckers/indexAlloc/sanity (0.02s)
    --- PASS: TestCheckers/initClause/sanity (0.02s)
    --- PASS: TestCheckers/mapKey/sanity (0.02s)
    --- PASS: TestCheckers/methodExprCall/sanity (0.02s)
    --- PASS: TestCheckers/nestingReduce/sanity (0.02s)
    --- PASS: TestCheckers/newDeref/sanity (0.02s)
    --- PASS: TestCheckers/nilValReturn/sanity (0.02s)
    --- PASS: TestCheckers/octalLiteral/sanity (0.02s)
    --- PASS: TestCheckers/offBy1/sanity (0.02s)
    --- PASS: TestCheckers/paramTypeCombine/sanity (0.02s)
    --- PASS: TestCheckers/preferDecodeRune/sanity (0.02s)
    --- PASS: TestCheckers/preferFilepathJoin/sanity (0.02s)
    --- PASS: TestCheckers/preferFprint/sanity (0.02s)
    --- PASS: TestCheckers/preferStringWriter/sanity (0.02s)
    --- PASS: TestCheckers/preferWriteByte/sanity (0.02s)
    --- PASS: TestCheckers/ptrToRefParam/sanity (0.02s)
    --- PASS: TestCheckers/rangeAppendAll/sanity (0.02s)
    --- PASS: TestCheckers/rangeExprCopy/sanity (0.02s)
    --- PASS: TestCheckers/rangeValCopy/sanity (0.02s)
    --- PASS: TestCheckers/redundantSprint/sanity (0.02s)
    --- PASS: TestCheckers/regexpMust/sanity (0.02s)
    --- PASS: TestCheckers/regexpPattern/sanity (0.02s)
    --- PASS: TestCheckers/regexpSimplify/sanity (0.02s)
    --- PASS: TestCheckers/returnAfterHttpError/sanity (0.02s)
    --- PASS: TestCheckers/ruleguard/sanity (0.02s)
    --- PASS: TestCheckers/singleCaseSwitch/sanity (0.02s)
    --- PASS: TestCheckers/sliceClear/sanity (0.02s)
    --- PASS: TestCheckers/sloppyLen/sanity (0.02s)
    --- PASS: TestCheckers/sloppyReassign/sanity (0.02s)
    --- PASS: TestCheckers/sloppyTypeAssert/sanity (0.02s)
    --- PASS: TestCheckers/sortSlice/sanity (0.02s)
    --- PASS: TestCheckers/sprintfQuotedString/sanity (0.02s)
    --- PASS: TestCheckers/sqlQuery/sanity (0.02s)
    --- PASS: TestCheckers/stringConcatSimplify/sanity (0.02s)
    --- PASS: TestCheckers/stringXbytes/sanity (0.02s)
    --- PASS: TestCheckers/stringsCompare/sanity (0.02s)
    --- PASS: TestCheckers/switchTrue/sanity (0.02s)
    --- PASS: TestCheckers/syncMapLoadAndDelete/sanity (0.02s)
    --- PASS: TestCheckers/timeExprSimplify/sanity (0.02s)
    --- PASS: TestCheckers/todoCommentWithoutDetail/sanity (0.02s)
    --- PASS: TestCheckers/tooManyResultsChecker/sanity (0.02s)
    --- PASS: TestCheckers/truncateCmp/sanity (0.02s)
    --- PASS: TestCheckers/typeAssertChain/sanity (0.02s)
    --- PASS: TestCheckers/typeDefFirst/sanity (0.02s)
    --- PASS: TestCheckers/typeSwitchVar/sanity (0.02s)
    --- PASS: TestCheckers/typeUnparen/sanity (0.02s)
    --- PASS: TestCheckers/uncheckedInlineErr/sanity (0.02s)
    --- PASS: TestCheckers/underef/sanity (0.02s)
    --- PASS: TestCheckers/unlabelStmt/sanity (0.02s)
    --- PASS: TestCheckers/unlambda/sanity (0.02s)
    --- PASS: TestCheckers/unnamedResult/sanity (0.02s)
    --- PASS: TestCheckers/unnecessaryBlock/sanity (0.02s)
    --- PASS: TestCheckers/unnecessaryDefer/sanity (0.02s)
    --- PASS: TestCheckers/unslice/sanity (0.02s)
    --- PASS: TestCheckers/valSwap/sanity (0.02s)
    --- PASS: TestCheckers/weakCond/sanity (0.02s)
    --- PASS: TestCheckers/whyNoLint/sanity (0.02s)
    --- PASS: TestCheckers/wrapperFunc/sanity (0.02s)
    --- PASS: TestCheckers/yodaStyleExpr/sanity (0.02s)
    --- PASS: TestCheckers/zeroByteRepeat/sanity (0.02s)
    --- PASS: TestCheckers/appendAssign (0.03s)
    --- PASS: TestCheckers/appendCombine (0.03s)
    --- PASS: TestCheckers/argOrder (0.10s)
    --- PASS: TestCheckers/assignOp (0.03s)
    --- PASS: TestCheckers/badCall (0.07s)
    --- PASS: TestCheckers/badCond (0.03s)
    --- PASS: TestCheckers/badLock (0.06s)
    --- PASS: TestCheckers/badRegexp (0.07s)
    --- PASS: TestCheckers/badSorting (0.07s)
    --- PASS: TestCheckers/badSyncOnceFunc (0.06s)
    --- PASS: TestCheckers/boolExprSimplify (0.03s)
    --- PASS: TestCheckers/builtinShadow (0.03s)
    --- PASS: TestCheckers/builtinShadowDecl (0.03s)
    --- PASS: TestCheckers/captLocal (0.03s)
    --- PASS: TestCheckers/caseOrder (0.08s)
    --- PASS: TestCheckers/codegenComment (0.03s)
    --- PASS: TestCheckers/commentFormatting (0.03s)
    --- PASS: TestCheckers/commentedOutCode (0.03s)
    --- PASS: TestCheckers/commentedOutImport (0.06s)
    --- PASS: TestCheckers/defaultCaseOrder (0.03s)
    --- PASS: TestCheckers/deferInLoop (0.07s)
    --- PASS: TestCheckers/deferUnlambda (0.08s)
    --- PASS: TestCheckers/deprecatedComment (0.03s)
    --- PASS: TestCheckers/docStub (0.03s)
    --- PASS: TestCheckers/dupArg (0.10s)
    --- PASS: TestCheckers/dupBranchBody (0.03s)
    --- PASS: TestCheckers/dupCase (0.03s)
    --- PASS: TestCheckers/dupImport (0.07s)
    --- PASS: TestCheckers/dupOption (0.07s)
    --- PASS: TestCheckers/dupSubExpr (0.03s)
    --- PASS: TestCheckers/dynamicFmtString (0.07s)
    --- PASS: TestCheckers/elseif (0.03s)
    --- PASS: TestCheckers/emptyDecl (0.03s)
    --- PASS: TestCheckers/emptyFallthrough (0.07s)
    --- PASS: TestCheckers/emptyStringTest (0.03s)
    --- PASS: TestCheckers/equalFold (0.07s)
    --- PASS: TestCheckers/evalOrder (0.03s)
    --- PASS: TestCheckers/exitAfterDefer (0.07s)
    --- PASS: TestCheckers/exposedSyncMutex (0.06s)
    --- PASS: TestCheckers/externalErrorReassign (0.07s)
    --- PASS: TestCheckers/filepathJoin (0.07s)
    --- PASS: TestCheckers/flagDeref (0.08s)
    --- PASS: TestCheckers/flagName (0.07s)
    --- PASS: TestCheckers/hexLiteral (0.03s)
    --- PASS: TestCheckers/httpNoBody (0.18s)
    --- PASS: TestCheckers/hugeParam (0.03s)
    --- PASS: TestCheckers/ifElseChain (0.03s)
    --- PASS: TestCheckers/importShadow (0.09s)
    --- PASS: TestCheckers/indexAlloc (0.07s)
    --- PASS: TestCheckers/initClause (0.03s)
    --- PASS: TestCheckers/mapKey (0.03s)
    --- PASS: TestCheckers/methodExprCall (0.03s)
    --- PASS: TestCheckers/nestingReduce (0.03s)
    --- PASS: TestCheckers/newDeref (0.06s)
    --- PASS: TestCheckers/nilValReturn (0.03s)
    --- PASS: TestCheckers/octalLiteral (0.08s)
    --- PASS: TestCheckers/offBy1 (0.07s)
    --- PASS: TestCheckers/paramTypeCombine (0.03s)
    --- PASS: TestCheckers/preferDecodeRune (0.06s)
    --- PASS: TestCheckers/preferFilepathJoin (0.07s)
    --- PASS: TestCheckers/preferFprint (0.17s)
    --- PASS: TestCheckers/preferStringWriter (0.15s)
    --- PASS: TestCheckers/preferWriteByte (0.18s)
    --- PASS: TestCheckers/ptrToRefParam (0.05s)
    --- PASS: TestCheckers/rangeAppendAll (0.04s)
    --- PASS: TestCheckers/rangeExprCopy (0.04s)
    --- PASS: TestCheckers/rangeValCopy (0.09s)
    --- PASS: TestCheckers/redundantSprint (0.34s)
    --- PASS: TestCheckers/regexpMust (0.07s)
    --- PASS: TestCheckers/regexpPattern (0.07s)
    --- PASS: TestCheckers/regexpSimplify (0.07s)
    --- PASS: TestCheckers/returnAfterHttpError (0.13s)
    --- PASS: TestCheckers/ruleguard (0.02s)
    --- PASS: TestCheckers/singleCaseSwitch (0.03s)
    --- PASS: TestCheckers/sliceClear (0.03s)
    --- PASS: TestCheckers/sloppyLen (0.03s)
    --- PASS: TestCheckers/sloppyReassign (0.03s)
    --- PASS: TestCheckers/sloppyTypeAssert (0.06s)
    --- PASS: TestCheckers/sortSlice (0.06s)
    --- PASS: TestCheckers/sprintfQuotedString (0.08s)
    --- PASS: TestCheckers/sqlQuery (0.10s)
    --- PASS: TestCheckers/stringConcatSimplify (0.07s)
    --- PASS: TestCheckers/stringXbytes (0.07s)
    --- PASS: TestCheckers/stringsCompare (0.06s)
    --- PASS: TestCheckers/switchTrue (0.03s)
    --- PASS: TestCheckers/syncMapLoadAndDelete (0.13s)
    --- PASS: TestCheckers/timeExprSimplify (0.07s)
    --- PASS: TestCheckers/todoCommentWithoutDetail (0.03s)
    --- PASS: TestCheckers/tooManyResultsChecker (0.02s)
    --- PASS: TestCheckers/truncateCmp (0.03s)
    --- PASS: TestCheckers/typeAssertChain (0.03s)
    --- PASS: TestCheckers/typeDefFirst (0.03s)
    --- PASS: TestCheckers/typeSwitchVar (0.03s)
    --- PASS: TestCheckers/typeUnparen (0.03s)
    --- PASS: TestCheckers/uncheckedInlineErr (0.02s)
    --- PASS: TestCheckers/underef (0.03s)
    --- PASS: TestCheckers/unlabelStmt (0.03s)
    --- PASS: TestCheckers/unlambda (0.07s)
    --- PASS: TestCheckers/unnamedResult (0.03s)
    --- PASS: TestCheckers/unnecessaryBlock (0.03s)
    --- PASS: TestCheckers/unnecessaryDefer (0.03s)
    --- PASS: TestCheckers/unslice (0.03s)
    --- PASS: TestCheckers/valSwap (0.03s)
    --- PASS: TestCheckers/weakCond (0.03s)
    --- PASS: TestCheckers/whyNoLint (0.03s)
    --- PASS: TestCheckers/wrapperFunc (0.13s)
    --- PASS: TestCheckers/yodaStyleExpr (0.03s)
    --- PASS: TestCheckers/zeroByteRepeat (0.06s)
=== RUN   TestIntegration
=== RUN   TestIntegration/cgo
=== RUN   TestIntegration/check_comments
=== RUN   TestIntegration/check_main_only
=== RUN   TestIntegration/check_packages
=== RUN   TestIntegration/ruleguard
=== RUN   TestIntegration/ruleguard-glob
=== RUN   TestIntegration/ruleguard-multi
--- PASS: TestIntegration (46.47s)
    --- PASS: TestIntegration/cgo (3.82s)
    --- PASS: TestIntegration/check_comments (2.19s)
    --- PASS: TestIntegration/check_main_only (11.85s)
    --- PASS: TestIntegration/check_packages (12.22s)
    --- PASS: TestIntegration/ruleguard (9.95s)
    --- PASS: TestIntegration/ruleguard-glob (2.53s)
    --- PASS: TestIntegration/ruleguard-multi (2.69s)
=== RUN   TestTags
--- PASS: TestTags (0.00s)
=== RUN   TestDocs
--- PASS: TestDocs (0.00s)
=== RUN   TestStableList
--- PASS: TestStableList (0.00s)
=== RUN   TestExternal
    checkers_test.go:165: temporary disabled during bump to Go 1.20
--- SKIP: TestExternal (0.00s)
PASS
ok      github.com/go-critic/go-critic/checkers 58.109s
?       github.com/go-critic/go-critic/checkers/analyzer        [no test files]
?       github.com/go-critic/go-critic/checkers/internal/astwalk        [no test files]
?       github.com/go-critic/go-critic/checkers/internal/linttest       [no test files]
?       github.com/go-critic/go-critic/checkers/internal/lintutil       [no test files]
?       github.com/go-critic/go-critic/checkers/rules   [no test files]
?       github.com/go-critic/go-critic/checkers/rulesdata       [no test files]
=== RUN   TestShortenLocation
--- PASS: TestShortenLocation (0.00s)
PASS
ok      github.com/go-critic/go-critic/cmd/go-critic    0.822s
?       github.com/go-critic/go-critic/cmd/go-critic-analysis   [no test files]
=== RUN   TestShortenLocation
--- PASS: TestShortenLocation (0.00s)
PASS
ok      github.com/go-critic/go-critic/cmd/gocritic     1.159s
?       github.com/go-critic/go-critic/cmd/gocritic-analysis    [no test files]
?       github.com/go-critic/go-critic/cmd/makedocs     [no test files]
=== RUN   TestGoVersionParse
--- PASS: TestGoVersionParse (0.00s)
=== RUN   TestGoVersionCompare
--- PASS: TestGoVersionCompare (0.00s)
PASS
ok      github.com/go-critic/go-critic/linter   1.800s
=== RUN   TestRules
--- PASS: TestRules (0.65s)
PASS
ok      github.com/go-critic/go-critic/rulestest        2.150s
```



Downstream ref:
* detected in https://github.com/Homebrew/homebrew-core/pull/288803
* temporary workaround https://github.com/Homebrew/homebrew-core/pull/301865
* using patch from this PR in https://github.com/Homebrew/homebrew-core/pull/302095

Closes #1523 

Please note, that 
* a new release is needed to support Go 1.27. Just https://github.com/go-critic/go-critic/pull/1530 released while `stable` Go was 1.26 and used for build and test was not enough.
* ci will fail at linter step until #1539 (or similar) is merged