### PR TITLE
ci: bump golangci-lint from v1.64.5 -> v2.13.2, fixed linter warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,62 +1,58 @@
-{
-  "run": {
-    # timeout for analysis, e.g. 30s, 5m, default is 1m
-    "timeout": "3m",
-  },
-  "linters": {
-    "fast": false,
-    "enable": [
-      "copyloopvar",
-      "errcheck",
-      "gosec",
-      "gocritic",
-      "gofmt",
-      "goimports",
-      "goprintffuncname",
-      "gosimple",
-      "govet",
-      "ineffassign",
-      "misspell",
-      "nakedret",
-      "revive",
-      "staticcheck",
-      "unconvert",
-      "unparam",
-      "unused",
-      "usetesting",
-    ],
-    "disable": [
-      "depguard",
-      "dupl",
-      "gocyclo",
-      "lll",
-      "prealloc",
-    ],
-  },
-  "linters-settings": {
-    "gocritic": {
-      "enabled-checks": [
-        "ruleguard",
-      ],
-      "settings": {
-        "ruleguard": {
-          "rules": "rules.go",
-        },
-      },
-    },
-    "gosec": {
-      "excludes": ["G115"]
-    },
-    "usetesting": {
-      "os-temp-dir": true,
-    },
-  },
-  "issues": {
-    "exclude-case-sensitive": true,
-    "exclude-dirs": ["checkers/rules"],
-    "exclude-rules": [
-      # Backward compatibility for CheckerContext.Warn, WarnWithPos, WarnFixable, and WarnFixableWithPos
-      {"linters":["goprintffuncname"], "text":"Warn(WithPos|Fixable)?"},
-    ]
-  }
-}
+version: "2"
+linters:
+  enable:
+    - copyloopvar
+    - gocritic
+    - goprintffuncname
+    - gosec
+    - misspell
+    - nakedret
+    - revive
+    - unconvert
+    - unparam
+    - usetesting
+  disable:
+    - depguard
+    - dupl
+    - gocyclo
+    - lll
+    - prealloc
+  settings:
+    gocritic:
+      enabled-checks:
+        - ruleguard
+      settings:
+        ruleguard:
+          rules: rules.go
+    gosec:
+      excludes:
+        - G115
+    usetesting:
+      os-temp-dir: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - goprintffuncname
+        text: (?i)Warn(WithPos|Fixable)?
+    paths:
+      - checkers/rules
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - checkers/rules
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ ci-generate:
 	@git diff --exit-code --quiet || (echo "Please run 'go generate ./...' to update precompiled rules."; false)
 
 ci-linter:
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH_DIR)/bin v1.64.5
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH_DIR)/bin v2.13.2
 	@$(GOPATH_DIR)/bin/golangci-lint run
 	# cd tools && go install github.com/quasilyte/go-consistent
 	# @$(GOPATH_DIR)/bin/go-consistent ./...

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ ci-generate:
 	@git diff --exit-code --quiet || (echo "Please run 'go generate ./...' to update precompiled rules."; false)
 
 ci-linter:
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH_DIR)/bin v2.13.2
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/main/install.sh | sh -s -- -b $(GOPATH_DIR)/bin v2.13.2
 	@$(GOPATH_DIR)/bin/golangci-lint run
 	# cd tools && go install github.com/quasilyte/go-consistent
 	# @$(GOPATH_DIR)/bin/go-consistent ./...

--- a/checkers/internal/linttest/integration.go
+++ b/checkers/internal/linttest/integration.go
@@ -68,7 +68,7 @@ func (cfg *IntegrationTest) runTest(t *testing.T, gocritic, gopath string) {
 		if data, ok := goldenDataCache[goldenFile]; ok {
 			want = data
 		} else {
-			data, err := os.ReadFile(goldenFile)
+			data, err := os.ReadFile(goldenFile) //nolint:gosec // path comes from the test's own testdata/.../linttest.params file
 			if err != nil {
 				t.Errorf("read golden file: %v", err)
 			}

--- a/checkers/rangeExprCopy_checker.go
+++ b/checkers/rangeExprCopy_checker.go
@@ -54,7 +54,7 @@ type rangeExprCopyChecker struct {
 
 func (c *rangeExprCopyChecker) EnterFunc(fn *ast.FuncDecl) bool {
 	return fn.Body != nil &&
-		!(c.skipTestFuncs && isUnitTestFunc(c.ctx, fn))
+		(!c.skipTestFuncs || !isUnitTestFunc(c.ctx, fn))
 }
 
 func (c *rangeExprCopyChecker) VisitStmt(stmt ast.Stmt) {

--- a/checkers/rangeValCopy_checker.go
+++ b/checkers/rangeValCopy_checker.go
@@ -53,7 +53,7 @@ type rangeValCopyChecker struct {
 
 func (c *rangeValCopyChecker) EnterFunc(fn *ast.FuncDecl) bool {
 	return fn.Body != nil &&
-		!(c.skipTestFuncs && isUnitTestFunc(c.ctx, fn))
+		(!c.skipTestFuncs || !isUnitTestFunc(c.ctx, fn))
 }
 
 func (c *rangeValCopyChecker) VisitStmt(stmt ast.Stmt) {

--- a/linter/go_version.go
+++ b/linter/go_version.go
@@ -18,10 +18,10 @@ type GoVersion struct {
 //
 // As a special case, Major=0 covers all versions.
 func (v GoVersion) GreaterOrEqual(other GoVersion) bool {
-	switch {
-	case v.Major == 0:
+	switch v.Major {
+	case 0:
 		return true
-	case v.Major == other.Major:
+	case other.Major:
 		return v.Minor >= other.Minor
 	default:
 		return v.Major >= other.Major


### PR DESCRIPTION
1) upgrade `golanci-lint` in CI to current https://github.com/golangci/golangci-lint/releases/tag/v2.13.2

2) migrate golangcilint config:
  ```
  $ golangci-lint migrate
  WARN The configuration comments are not migrated.
  WARN Details about the migration: https://golangci-lint.run/docs/product/migration-guide/ WARN The configuration `run.timeout` is ignored. By default, in v2, the timeout is disabled.
  ```
3) Verified using
```
$ golangci-lint config verify
$ golangci-lint run
checkers/internal/linttest/integration.go:71:28: G703: Path traversal via taint analysis (gosec)
                        data, err := os.ReadFile(goldenFile)
                                                ^
checkers/rangeExprCopy_checker.go:57:3: QF1001: could apply De Morgan's law (staticcheck)
                !(c.skipTestFuncs && isUnitTestFunc(c.ctx, fn))
                ^
checkers/rangeValCopy_checker.go:56:3: QF1001: could apply De Morgan's law (staticcheck)
                !(c.skipTestFuncs && isUnitTestFunc(c.ctx, fn))
                ^
linter/go_version.go:21:2: QF1002: could use tagged switch on v.Major (staticcheck)
        switch {
        ^
4 issues:
* gosec: 1
* staticcheck: 3
```

4) Fixed ALL linter warnings.