### PR TITLE
checkers/regexpPattern: fix misspelled regexp.MustCompilePOSIX

### DIFF
--- a/checkers/regexpPattern_checker.go
+++ b/checkers/regexpPattern_checker.go
@@ -51,7 +51,7 @@ func (c *regexpPatternChecker) VisitExpr(x ast.Expr) {
 	}
 
 	switch qualifiedName(call.Fun) {
-	case "regexp.Compile", "regexp.CompilePOSIX", "regexp.MustCompile", "regexp.MustCompilePosix":
+	case "regexp.Compile", "regexp.CompilePOSIX", "regexp.MustCompile", "regexp.MustCompilePOSIX":
 		cv := c.ctx.TypesInfo.Types[call.Args[0]].Value
 		if cv == nil || cv.Kind() != constant.String {
 			return

--- a/checkers/testdata/regexpPattern/negative_tests.go
+++ b/checkers/testdata/regexpPattern/negative_tests.go
@@ -8,4 +8,6 @@ func domainDotsEscaped() {
 	regexp.MustCompile(`google\.com`)
 
 	regexp.CompilePOSIX(`yandex\.ru|radio.yandex\.ru`)
+
+	regexp.MustCompilePOSIX(`golang\.org`)
 }

--- a/checkers/testdata/regexpPattern/positive_tests.go
+++ b/checkers/testdata/regexpPattern/positive_tests.go
@@ -10,4 +10,7 @@ func domainDots() {
 
 	/*! '.ru' should probably be '\.ru' */
 	regexp.CompilePOSIX(`yandex.ru|radio.yandex.ru`)
+
+	/*! '.org' should probably be '\.org' */
+	regexp.MustCompilePOSIX(`golang.org`)
 }


### PR DESCRIPTION
`regexpPattern` never inspects a pattern passed to `regexp.MustCompilePOSIX`. The switch in `VisitExpr` (checkers/regexpPattern_checker.go:54) lists `"regexp.MustCompilePosix"`, but the standard library spells it `regexp.MustCompilePOSIX`, so `qualifiedName` never returns that string and the case is dead. The unescaped domain dot diagnostic is reported for `regexp.Compile`, `regexp.CompilePOSIX` and `regexp.MustCompile`, and silently skipped for `regexp.MustCompilePOSIX`.

The fix is the name itself. I also added `regexp.MustCompilePOSIX` cases to `positive_tests.go` and `negative_tests.go`, so the case cannot go dead again without a test failing.

Verification, Go 1.26.4 on darwin/arm64. With the new testdata but without the one word fix:

```
$ go test -count=1 -run 'TestCheckers/regexpPattern' ./checkers
--- FAIL: TestCheckers (0.19s)
    --- FAIL: TestCheckers/regexpPattern (0.15s)
        linttest.go:201: testdata/regexpPattern/positive_tests.go:15: unmatched `'.org' should probably be '\.org'`
FAIL
```

With the fix:

```
$ go test -count=1 -run 'TestCheckers/regexpPattern' ./checkers
ok  	github.com/go-critic/go-critic/checkers	0.853s
```

Whole tree: `go test -race -count=1 ./...` passes, `go generate ./...` leaves the tree clean, `gofmt -l` on the changed files is empty, and `go build -o go-critic ./cmd/go-critic && ./go-critic check -enableAll ./...` exits 0.

Note that `badRegexp` and `regexpSimplify` also only match `regexp.Compile` and `regexp.MustCompile`. That looks deliberate rather than a typo, since POSIX mode restricts the accepted syntax, so I left them alone.
